### PR TITLE
refs #26: Move popochiu settings to Project Settings

### DIFF
--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -24,6 +24,7 @@ const _DEFAULT_MAX_DIALOG_OPTIONS = 'popochiu/text/max_dialog_options'
 
 # Inventory
 const _DEFAULT_INVENTORY_LIMIT = 'popochiu/inventory/inventory_limit'
+const _DEFAULT_INVENTORY_ITEMS_ON_START = 'popochiu/inventory/items_on_start'
 
 # Import
 const _DEFAULT_IMPORT_ENABLED = 'popochiu/import/aseprite/import_animation_by_default'
@@ -59,6 +60,9 @@ func initialize_project_settings():
 	_initialize_project_cfg(_DEFAULT_MAX_DIALOG_OPTIONS, 3, TYPE_INT)
 
 	_initialize_project_cfg(_DEFAULT_INVENTORY_LIMIT, 0, TYPE_INT)
+	_initialize_project_cfg(_DEFAULT_INVENTORY_ITEMS_ON_START, [], TYPE_ARRAY,
+		PROPERTY_HINT_TYPE_STRING, "%d/%d:%s" % [TYPE_STRING, PROPERTY_HINT_FILE, "*tscn"]
+	)
 
 	_initialize_project_cfg(_DEFAULT_IMPORT_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_LOOP_ENABLED, true, TYPE_BOOL)
@@ -127,6 +131,10 @@ func get_default_max_dialog_options() -> int:
 
 func get_default_inventory_limit() -> int:
 	return _get_project_setting(_DEFAULT_INVENTORY_LIMIT, 0)
+
+
+func get_default_inventory_items_on_start() -> Array[int]:
+	return _get_project_setting(_DEFAULT_INVENTORY_ITEMS_ON_START, [])
 
 
 func is_default_animation_import_enabled() -> bool:

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -8,6 +8,8 @@ const _REMOVE_SOURCE_FILES_KEY = 'popochiu/import/aseprite/remove_json_file'
 # PROJECT SETTINGS
 
 # Interface
+const _DEFAULT_GRAPHIC_INTERFACE = 'popochiu/interface/graphic_interface'
+const _DEFAULT_TRANSITION_LAYER = 'popochiu/interface/transition_layer'
 const _DEFAULT_SCALE_GUI = 'popochiu/interface/scale_gui'
 const _DEFAULT_INVENTORY_ALWAYS_VISIBLE = 'popochiu/interface/inventory_always_visible'
 const _DEFAULT_TOOLBAR_ALWAYS_VISIBLE = 'popochiu/interface/toolbar_always_visible'
@@ -42,6 +44,8 @@ func initialize_editor_settings():
 
 
 func initialize_project_settings():
+	_initialize_project_cfg(_DEFAULT_GRAPHIC_INTERFACE, "", TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
+	_initialize_project_cfg(_DEFAULT_TRANSITION_LAYER, "", TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
 	_initialize_project_cfg(_DEFAULT_SCALE_GUI, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
@@ -73,6 +77,14 @@ func should_remove_source_files() -> bool:
 
 func get_icon(icon_name: String) -> Texture2D:
 	return _plugin_icons[icon_name]
+
+
+func get_default_graphic_interface() -> PackedScene:
+	return _get_project_setting(_DEFAULT_GRAPHIC_INTERFACE, "")
+
+
+func get_default_transition_layer() -> PackedScene:
+	return _get_project_setting(_DEFAULT_TRANSITION_LAYER, "")
 
 
 func is_default_scale_gui() -> bool:
@@ -135,7 +147,7 @@ func _set_icons() -> void:
 	}
 
 
-func _initialize_editor_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE):
+func _initialize_editor_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE, hint_string: String = ""):
 	if not editor_settings.has_setting(key):
 		editor_settings.set_setting(key, default_value)
 		editor_settings.set_initial_value(key, default_value, false)
@@ -143,9 +155,10 @@ func _initialize_editor_cfg(key: String, default_value, type: int, hint: int = P
 			"name": key,
 			"type": type,
 			"hint": hint,
+			"hint_string": hint_string,
 		})
 
-func _initialize_project_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE):
+func _initialize_project_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE, hint_string: String = ""):
 	if not ProjectSettings.has_setting(key):
 		ProjectSettings.set_setting(key, default_value)
 		ProjectSettings.set_initial_value(key, default_value)
@@ -153,6 +166,7 @@ func _initialize_project_cfg(key: String, default_value, type: int, hint: int = 
 			"name": key,
 			"type": type,
 			"hint": hint,
+			"hint_string": hint_string,
 		})
 
 

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -6,9 +6,20 @@ const _ASEPRITE_COMMAND_KEY = 'popochiu/import/aseprite/command_path'
 const _REMOVE_SOURCE_FILES_KEY = 'popochiu/import/aseprite/remove_json_file'
 
 # PROJECT SETTINGS
+
+# Interface
+const _DEFAULT_INVENTORY_ALWAYS_VISIBLE = 'popochiu/interface/inventory_always_visible'
+const _DEFAULT_SCALE_GUI = 'popochiu/interface/scale_gui'
+const _DEFAULT_TOOLBAR_ALWAYS_VISIBLE = 'popochiu/interface/toolbar_always_visible'
+
+# Import
 const _DEFAULT_IMPORT_ENABLED = 'popochiu/import/aseprite/import_animation_by_default'
 const _DEFAULT_LOOP_ENABLED = 'popochiu/import/aseprite/loop_animation_by_default'
 const _DEFAULT_WIPE_OLD_ANIMS_ENABLED = 'popochiu/import/aseprite/wipe_old_animations'
+
+# Text
+const _DEFAULT_AUTO_CONTINUE_TEXT = 'popochiu/text/auto_continue_text'
+const _DEFAULT_USE_TRANSLATIONS = 'popochiu/text/use_translations'
 
 
 var ei: EditorInterface
@@ -25,9 +36,16 @@ func initialize_editor_settings():
 
 
 func initialize_project_settings():
+	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_SCALE_GUI, true, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
+
 	_initialize_project_cfg(_DEFAULT_IMPORT_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_LOOP_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_WIPE_OLD_ANIMS_ENABLED, true, TYPE_BOOL)
+
+	_initialize_project_cfg(_DEFAULT_AUTO_CONTINUE_TEXT, false, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_USE_TRANSLATIONS, false, TYPE_BOOL)
 
 	_set_icons()
 	ProjectSettings.save()
@@ -58,7 +76,6 @@ func is_default_wipe_old_anims_enabled() -> bool:
 	return _get_project_setting(_DEFAULT_WIPE_OLD_ANIMS_ENABLED, true)
 
 
-	
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _default_command() -> String:
 	return 'aseprite'

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -36,8 +36,8 @@ func initialize_editor_settings():
 
 
 func initialize_project_settings():
-	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_SCALE_GUI, true, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
 
 	_initialize_project_cfg(_DEFAULT_IMPORT_ENABLED, true, TYPE_BOOL)
@@ -64,6 +64,18 @@ func get_icon(icon_name: String) -> Texture2D:
 	return _plugin_icons[icon_name]
 
 
+func is_default_scale_gui() -> bool:
+	return _get_project_setting(_DEFAULT_SCALE_GUI, true)
+
+
+func is_default_inventory_always_visible() -> bool:
+	return _get_project_setting(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false)
+
+
+func is_default_toolbar_always_visible() -> bool:
+	return _get_project_setting(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false)
+
+
 func is_default_animation_import_enabled() -> bool:
 	return _get_project_setting(_DEFAULT_IMPORT_ENABLED, true)
 
@@ -74,6 +86,14 @@ func is_default_animation_loop_enabled() -> bool:
 
 func is_default_wipe_old_anims_enabled() -> bool:
 	return _get_project_setting(_DEFAULT_WIPE_OLD_ANIMS_ENABLED, true)
+
+
+func is_default_auto_continue_text() -> bool:
+	return _get_project_setting(_DEFAULT_AUTO_CONTINUE_TEXT, false)
+
+
+func is_default_use_translations() -> bool:
+	return _get_project_setting(_DEFAULT_USE_TRANSLATIONS, false)
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -17,6 +17,7 @@ const _DEFAULT_FADE_COLOR = 'popochiu/interface/fade_color'
 const _DEFAULT_SKIP_CUTSCENE_TIME = 'popochiu/interface/skip_cutscene_time'
 
 # Text
+const _DEFAULT_TEXT_SPEED = 'popochiu/text/text_speed'
 const _DEFAULT_AUTO_CONTINUE_TEXT = 'popochiu/text/auto_continue_text'
 const _DEFAULT_USE_TRANSLATIONS = 'popochiu/text/use_translations'
 const _DEFAULT_MAX_DIALOG_OPTIONS = 'popochiu/text/max_dialog_options'
@@ -52,6 +53,7 @@ func initialize_project_settings():
 	_initialize_project_cfg(_DEFAULT_FADE_COLOR, Color(0, 0, 0, 1), TYPE_COLOR)
 	_initialize_project_cfg(_DEFAULT_SKIP_CUTSCENE_TIME, 0.2, TYPE_FLOAT)
 
+	_initialize_project_cfg(_DEFAULT_TEXT_SPEED, 0.1, TYPE_FLOAT, PROPERTY_HINT_RANGE, "0.0,0.1")
 	_initialize_project_cfg(_DEFAULT_AUTO_CONTINUE_TEXT, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_USE_TRANSLATIONS, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_MAX_DIALOG_OPTIONS, 3, TYPE_INT)
@@ -105,6 +107,10 @@ func get_default_fade_color() -> Color:
 
 func get_default_skip_cutscene_time() -> float:
 	return _get_project_setting(_DEFAULT_SKIP_CUTSCENE_TIME, 0.2)
+
+
+func get_default_text_speed() -> float:
+	return _get_project_setting(_DEFAULT_TEXT_SPEED, 0.1)
 
 
 func is_default_auto_continue_text() -> bool:

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -8,9 +8,10 @@ const _REMOVE_SOURCE_FILES_KEY = 'popochiu/import/aseprite/remove_json_file'
 # PROJECT SETTINGS
 
 # Interface
-const _DEFAULT_INVENTORY_ALWAYS_VISIBLE = 'popochiu/interface/inventory_always_visible'
 const _DEFAULT_SCALE_GUI = 'popochiu/interface/scale_gui'
+const _DEFAULT_INVENTORY_ALWAYS_VISIBLE = 'popochiu/interface/inventory_always_visible'
 const _DEFAULT_TOOLBAR_ALWAYS_VISIBLE = 'popochiu/interface/toolbar_always_visible'
+const _DEFAULT_FADE_COLOR = 'popochiu/interface/fade_color'
 
 # Import
 const _DEFAULT_IMPORT_ENABLED = 'popochiu/import/aseprite/import_animation_by_default'
@@ -39,6 +40,7 @@ func initialize_project_settings():
 	_initialize_project_cfg(_DEFAULT_SCALE_GUI, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_FADE_COLOR, Color(0, 0, 0, 1), TYPE_COLOR)
 
 	_initialize_project_cfg(_DEFAULT_IMPORT_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_LOOP_ENABLED, true, TYPE_BOOL)
@@ -74,6 +76,10 @@ func is_default_inventory_always_visible() -> bool:
 
 func is_default_toolbar_always_visible() -> bool:
 	return _get_project_setting(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false)
+
+
+func get_default_fade_color() -> Color:
+	return _get_project_setting(_DEFAULT_FADE_COLOR, Color(0, 0, 0, 1))
 
 
 func is_default_animation_import_enabled() -> bool:

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -46,8 +46,8 @@ func initialize_editor_settings():
 
 
 func initialize_project_settings():
-	_initialize_project_cfg(_DEFAULT_GRAPHIC_INTERFACE, "", TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
-	_initialize_project_cfg(_DEFAULT_TRANSITION_LAYER, "", TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
+	_initialize_project_cfg(_DEFAULT_GRAPHIC_INTERFACE, PopochiuResources.GRAPHIC_INTERFACE_ADDON, TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
+	_initialize_project_cfg(_DEFAULT_TRANSITION_LAYER, PopochiuResources.TRANSITION_LAYER_ADDON, TYPE_STRING, PROPERTY_HINT_FILE, "*tscn")
 	_initialize_project_cfg(_DEFAULT_SCALE_GUI, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
@@ -85,12 +85,12 @@ func get_icon(icon_name: String) -> Texture2D:
 	return _plugin_icons[icon_name]
 
 
-func get_default_graphic_interface() -> PackedScene:
-	return _get_project_setting(_DEFAULT_GRAPHIC_INTERFACE, "")
+func get_graphic_interface() -> CanvasLayer:
+	return load(_get_project_setting(_DEFAULT_GRAPHIC_INTERFACE, PopochiuResources.GRAPHIC_INTERFACE_ADDON)).instantiate()
 
 
-func get_default_transition_layer() -> PackedScene:
-	return _get_project_setting(_DEFAULT_TRANSITION_LAYER, "")
+func get_transition_layer() -> CanvasLayer:
+	return load(_get_project_setting(_DEFAULT_TRANSITION_LAYER, PopochiuResources.TRANSITION_LAYER_ADDON)).instantiate()
 
 
 func is_default_scale_gui() -> bool:

--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -12,15 +12,20 @@ const _DEFAULT_SCALE_GUI = 'popochiu/interface/scale_gui'
 const _DEFAULT_INVENTORY_ALWAYS_VISIBLE = 'popochiu/interface/inventory_always_visible'
 const _DEFAULT_TOOLBAR_ALWAYS_VISIBLE = 'popochiu/interface/toolbar_always_visible'
 const _DEFAULT_FADE_COLOR = 'popochiu/interface/fade_color'
+const _DEFAULT_SKIP_CUTSCENE_TIME = 'popochiu/interface/skip_cutscene_time'
+
+# Text
+const _DEFAULT_AUTO_CONTINUE_TEXT = 'popochiu/text/auto_continue_text'
+const _DEFAULT_USE_TRANSLATIONS = 'popochiu/text/use_translations'
+const _DEFAULT_MAX_DIALOG_OPTIONS = 'popochiu/text/max_dialog_options'
+
+# Inventory
+const _DEFAULT_INVENTORY_LIMIT = 'popochiu/inventory/inventory_limit'
 
 # Import
 const _DEFAULT_IMPORT_ENABLED = 'popochiu/import/aseprite/import_animation_by_default'
 const _DEFAULT_LOOP_ENABLED = 'popochiu/import/aseprite/loop_animation_by_default'
 const _DEFAULT_WIPE_OLD_ANIMS_ENABLED = 'popochiu/import/aseprite/wipe_old_animations'
-
-# Text
-const _DEFAULT_AUTO_CONTINUE_TEXT = 'popochiu/text/auto_continue_text'
-const _DEFAULT_USE_TRANSLATIONS = 'popochiu/text/use_translations'
 
 
 var ei: EditorInterface
@@ -41,13 +46,17 @@ func initialize_project_settings():
 	_initialize_project_cfg(_DEFAULT_INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_FADE_COLOR, Color(0, 0, 0, 1), TYPE_COLOR)
+	_initialize_project_cfg(_DEFAULT_SKIP_CUTSCENE_TIME, 0.2, TYPE_FLOAT)
+
+	_initialize_project_cfg(_DEFAULT_AUTO_CONTINUE_TEXT, false, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_USE_TRANSLATIONS, false, TYPE_BOOL)
+	_initialize_project_cfg(_DEFAULT_MAX_DIALOG_OPTIONS, 3, TYPE_INT)
+
+	_initialize_project_cfg(_DEFAULT_INVENTORY_LIMIT, 0, TYPE_INT)
 
 	_initialize_project_cfg(_DEFAULT_IMPORT_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_LOOP_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_DEFAULT_WIPE_OLD_ANIMS_ENABLED, true, TYPE_BOOL)
-
-	_initialize_project_cfg(_DEFAULT_AUTO_CONTINUE_TEXT, false, TYPE_BOOL)
-	_initialize_project_cfg(_DEFAULT_USE_TRANSLATIONS, false, TYPE_BOOL)
 
 	_set_icons()
 	ProjectSettings.save()
@@ -82,6 +91,26 @@ func get_default_fade_color() -> Color:
 	return _get_project_setting(_DEFAULT_FADE_COLOR, Color(0, 0, 0, 1))
 
 
+func get_default_skip_cutscene_time() -> float:
+	return _get_project_setting(_DEFAULT_SKIP_CUTSCENE_TIME, 0.2)
+
+
+func is_default_auto_continue_text() -> bool:
+	return _get_project_setting(_DEFAULT_AUTO_CONTINUE_TEXT, false)
+
+
+func is_default_use_translations() -> bool:
+	return _get_project_setting(_DEFAULT_USE_TRANSLATIONS, false)
+
+
+func get_default_max_dialog_options() -> int:
+	return _get_project_setting(_DEFAULT_MAX_DIALOG_OPTIONS, 3)
+
+
+func get_default_inventory_limit() -> int:
+	return _get_project_setting(_DEFAULT_INVENTORY_LIMIT, 0)
+
+
 func is_default_animation_import_enabled() -> bool:
 	return _get_project_setting(_DEFAULT_IMPORT_ENABLED, true)
 
@@ -92,14 +121,6 @@ func is_default_animation_loop_enabled() -> bool:
 
 func is_default_wipe_old_anims_enabled() -> bool:
 	return _get_project_setting(_DEFAULT_WIPE_OLD_ANIMS_ENABLED, true)
-
-
-func is_default_auto_continue_text() -> bool:
-	return _get_project_setting(_DEFAULT_AUTO_CONTINUE_TEXT, false)
-
-
-func is_default_use_translations() -> bool:
-	return _get_project_setting(_DEFAULT_USE_TRANSLATIONS, false)
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -27,12 +27,15 @@ var height := 0.0 : get = get_height
 var half_width := 0.0 : get = get_half_width
 var half_height := 0.0 : get = get_half_height
 var settings := PopochiuResources.get_settings()
+var projectSettings: RefCounted = null
 var current_text_speed_idx := settings.default_text_speed
 var current_text_speed: float = settings.text_speeds[current_text_speed_idx]
 var current_language := 0
 var auto_continue_after := -1.0
 var scale := Vector2.ONE
 var am: PopochiuAudioManager = null
+var gi: CanvasLayer = null
+var tl: CanvasLayer = null
 # TODO: This might not just be a boolean, but there could be an array that puts
 # the calls to queue in an Array and executes them in order. Or perhaps it could
 # be something that allows for more dynamism, such as putting one queue to execute
@@ -64,47 +67,36 @@ var _saveload: Resource = null
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready() -> void:
 	am = load(PopochiuResources.AUDIO_MANAGER).instantiate()
-	
+	projectSettings = load("res://addons/popochiu/editor/config/config.gd").new()
+
 	_saveload = load(SAVELOAD_PATH).new()
 	_config = PopochiuResources.get_data_cfg()
-	
-	var gi: CanvasLayer = null
-	var tl: CanvasLayer = null
-	
-	if settings.graphic_interface:
-		gi = settings.graphic_interface.instantiate()
-		gi.name = 'GraphicInterface'
-	else:
-		gi = load(PopochiuResources.GRAPHIC_INTERFACE_ADDON).instantiate()
-	
-	if settings.transition_layer:
-		tl = settings.transition_layer.instantiate()
-		tl.name = 'TransitionLayer'
-	else:
-		tl = load(PopochiuResources.TRANSITION_LAYER_ADDON).instantiate()
-	
+
+	gi = projectSettings.get_graphic_interface()
+	tl = projectSettings.get_transition_layer()
+
 	# Scale GI and TL
 	scale = Vector2(self.width, self.height) / Vector2(320.0, 180.0)
-	
+
+	add_child(am)
 	add_child(gi)
 	add_child(tl)
-	add_child(am)
-	
+
 	if PopochiuResources.has_data_value('setup', 'pc'):
 		var pc_data_path: String = PopochiuResources.get_data_value(
 			'characters',
 			PopochiuResources.get_data_value('setup', 'pc', ''),
 			''
 		)
-		
+
 		if pc_data_path:
 			var pc_data: PopochiuCharacterData = load(pc_data_path)
 			var pc: PopochiuCharacter = load(pc_data.scene).instantiate()
-			
+
 			C.player = pc
 			C.characters.append(pc)
 			C.set(pc.script_name, pc)
-	
+
 	if not C.player:
 		# Set the first character on the list to be the default player character
 		var characters := PopochiuResources.get_section('characters')
@@ -117,25 +109,25 @@ func _ready() -> void:
 			C.player = pc
 			C.characters.append(pc)
 			C.set(pc.script_name, pc)
-	
+
 	# Add inventory items checked start (ignore animations (3rd parameter))
 	for key in settings.items_on_start:
 		I.add_item(key, false)
-	
+
 	set_process_input(false)
-	
+
 	if settings.scale_gui:
 		Cursor.scale_cursor(scale)
-	
+
 	# Save the default state for the objects in the game
 	for room_tres in PopochiuResources.get_section('rooms'):
 		var res: PopochiuRoomData = load(room_tres)
 		E.rooms_states[res.script_name] = res
-		
+
 		res.save_childs_states()
-	
+
 	C.character_spoke.connect(_on_character_spoke)
-	
+
 	redied.emit()
 
 
@@ -146,7 +138,7 @@ func _process(delta: float) -> void:
 			randf_range(-1.0, 1.0) * _camera_shake_amount,
 			randf_range(-1.0, 1.0) * _camera_shake_amount
 		)
-		
+
 		if _shake_timer <= 0.0:
 			stop_camera_shake()
 	elif not Engine.is_editor_hint()\
@@ -162,9 +154,9 @@ func _input(event: InputEvent) -> void:
 			TransitionLayer.PASS_DOWN_IN,
 			settings.skip_cutscene_time
 		)
-		
+
 		await $TransitionLayer.transition_finished
-		
+
 		G.continue_clicked.emit()
 
 
@@ -183,7 +175,7 @@ func wait(time := 1.0) -> void:
 	if cutscene_skipped:
 		await get_tree().process_frame
 		return
-	
+
 	await get_tree().create_timer(time).timeout
 
 
@@ -198,33 +190,33 @@ func queue(instructions: Array, show_gi := true) -> void:
 	if instructions.is_empty():
 		await get_tree().process_frame
 		return
-	
+
 	if playing_queue:
 		await get_tree().process_frame
 		await queue(instructions, show_gi)
 		return
-	
+
 	playing_queue = true
-	
+
 	G.block()
-	
+
 	for idx in instructions.size():
 		var instruction = instructions[idx]
-		
+
 		if instruction is Callable:
 			await instruction.call()
 		elif instruction is String:
 			await _eval_string(instruction as String)
-	
+
 	if show_gi:
 		G.done()
-	
+
 	if _is_camera_shaking:
 		stop_camera_shake()
-	
+
 	if instructions.is_empty():
 		await get_tree().process_frame
-	
+
 	playing_queue = false
 
 
@@ -233,14 +225,14 @@ func cutscene(instructions: Array) -> void:
 	set_process_input(true)
 	await queue(instructions)
 	set_process_input(false)
-	
+
 	if cutscene_skipped:
 		$TransitionLayer.play_transition(
 			$TransitionLayer.PASS_DOWN_OUT,
 			settings.skip_cutscene_time
 		)
 		await $TransitionLayer.transition_finished
-	
+
 	cutscene_skipped = false
 
 
@@ -253,45 +245,45 @@ func goto_room(
 	ignore_change := false
 ) -> void:
 	if not in_room: return
-	
+
 	self.in_room = false
-	
+
 	G.block()
-	
+
 	_use_transition_on_room_change = use_transition
 	if use_transition:
 		$TransitionLayer.play_transition($TransitionLayer.FADE_IN)
 		await $TransitionLayer.transition_finished
-	
+
 	if is_instance_valid(C.player) and Engine.get_process_frames() > 0:
 		C.player.last_room = current_room.script_name
-	
+
 	# Store the room state
 	if store_state:
 		rooms_states[current_room.script_name] = current_room.state
 		current_room.state.save_childs_states()
-	
+
 	# Remove PopochiuCharacter nodes from the room so they are not deleted
 	if Engine.get_process_frames() > 0:
 		current_room.exit_room()
-	
+
 	# Reset camera config
 	# TODO: This could be in the Camera3D's own script... along with shaking
 	main_camera.limit_left = _defaults.camera_limits.left
 	main_camera.limit_right = _defaults.camera_limits.right
 	main_camera.limit_top = _defaults.camera_limits.top
 	main_camera.limit_bottom = _defaults.camera_limits.bottom
-	
+
 	if ignore_change: return
-	
+
 	var rp: String = PopochiuResources.get_data_value('rooms', script_name, null)
 	if rp.is_empty():
 		printerr('[Popochiu] No PopochiuRoom with name: %s' % script_name)
 		return
-	
+
 	if Engine.get_process_frames() == 0:
 		await get_tree().process_frame
-	
+
 	R.clear_instances()
 	clear_hovered()
 	get_tree().change_scene_to_file(load(rp).scene)
@@ -300,21 +292,21 @@ func goto_room(
 # Called once the loaded room is _ready
 func room_readied(room: PopochiuRoom) -> void:
 	current_room = room
-	
+
 	# When running from the Editor the first time, use goto_room
 	if Engine.get_process_frames() == 0:
 		await get_tree().process_frame
 
 		self.in_room = true
-		
+
 		# Calling this will make the camera be set to its default values and
 		# will store the state of the main room (the last parameter will prevent
 		# Popochiu from changing the scene to the same that is already loaded
 		goto_room(room.script_name, false, true, true)
-	
+
 	# Make the camera be ready for the room
 	current_room.setup_camera()
-	
+
 	# Update the core state
 	if _loaded_game:
 		C.player = C.get_character(_loaded_game.player.id)
@@ -323,7 +315,7 @@ func room_readied(room: PopochiuRoom) -> void:
 		current_room.state.visited_times += 1
 		current_room.state.visited_first_time =\
 		current_room.state.visited_times == 1
-	
+
 	# Add the PopochiuCharacter instances to the room
 	if (rooms_states[room.script_name]['characters'] as Dictionary).is_empty():
 		# Store the initial state of the characters in the room
@@ -331,28 +323,28 @@ func room_readied(room: PopochiuRoom) -> void:
 		current_room.clean_characters()
 	else:
 		current_room.clean_characters()
-	
+
 	# Load the state of characters in the room
 	for chr_id in rooms_states[room.script_name]['characters']:
 		var chr_dic: Dictionary =\
 		rooms_states[room.script_name]['characters'][chr_id]
 		var chr: PopochiuCharacter = C.get_character(chr_id)
-		
+
 		if not chr: continue
-		
+
 		chr.position = Vector2(chr_dic.x, chr_dic.y)
 		chr._looking_dir = chr_dic.facing
-		
+
 		current_room.add_character(chr)
-	
+
 	# If the room must have the player character but it is not part of its
 	# $Characters node, add it to the room
 	if current_room.has_player and is_instance_valid(C.player):
 		if not current_room.has_character(C.player.script_name):
 			current_room.add_character(C.player)
-			
+
 			await C.player.idle()
-	
+
 	# Load the state of Props, Hotspots, Regions and WalkableAreas
 	for type in PopochiuResources.ROOM_CHILDS:
 		for script_name in rooms_states[room.script_name][type]:
@@ -362,44 +354,44 @@ func room_readied(room: PopochiuRoom) -> void:
 			)
 			var node_dic: Dictionary =\
 			rooms_states[room.script_name][type][script_name]
-			
+
 			for property in node_dic:
 				if not PopochiuResources.has_property(node, property): continue
-				
+
 				node[property] = node_dic[property]
-	
+
 	for c in get_tree().get_nodes_in_group('PopochiuClickable'):
 		c.room = current_room
-	
+
 	current_room._on_room_entered()
-	
+
 	if _loaded_game:
 		C.player.global_position = Vector2(
 			_loaded_game.player.position.x,
 			_loaded_game.player.position.y
 		)
-	
+
 	if _use_transition_on_room_change:
 		$TransitionLayer.play_transition($TransitionLayer.FADE_OUT)
 		await $TransitionLayer.transition_finished
 		await wait(0.3)
 	else:
 		await get_tree().process_frame
-	
+
 	if not current_room.hide_gi:
 		G.done()
-	
+
 	self.in_room = true
-	
+
 	if _loaded_game:
 		game_loaded.emit(_loaded_game)
 		await G.display('Game loaded')
-		
+
 		_loaded_game = {}
-	
+
 	# This enables the room to listen input events
 	current_room.is_current = true
-	
+
 	current_room._on_room_transition_finished()
 
 
@@ -410,7 +402,7 @@ func queue_camera_offset(offset := Vector2.ZERO) -> Callable:
 # Changes the main camera's offset (useful when zooming the camera)
 func camera_offset(offset := Vector2.ZERO) -> void:
 	main_camera.offset = offset
-	
+
 	await get_tree().process_frame
 
 
@@ -423,7 +415,7 @@ func camera_shake(strength := 1.0, duration := 1.0) -> void:
 	_camera_shake_amount = strength
 	_shake_timer = duration
 	_is_camera_shaking = true
-	
+
 	await get_tree().create_timer(duration).timeout
 
 
@@ -437,7 +429,7 @@ func camera_shake_bg(strength := 1.0, duration := 1.0) -> void:
 	_camera_shake_amount = strength
 	_shake_timer = duration
 	_is_camera_shaking = true
-	
+
 	await get_tree().process_frame
 
 
@@ -451,11 +443,11 @@ func queue_camera_zoom(target := Vector2.ONE, duration := 1.0) -> Callable:
 func camera_zoom(target := Vector2.ONE, duration := 1.0) -> void:
 	if is_instance_valid(_tween) and _tween.isplaying_queue():
 		_tween.kill()
-	
+
 	_tween = create_tween()
 	_tween.tween_property(main_camera, 'zoom', target, duration)\
 	.from_current().set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
-	
+
 	await _tween.finished
 
 
@@ -470,7 +462,7 @@ func get_character_instance(script_name: String) -> PopochiuCharacter:
 		var popochiu_character: PopochiuCharacterData = load(rp)
 		if popochiu_character.script_name == script_name:
 			return load(popochiu_character.scene).instantiate()
-	
+
 	printerr("[Popochiu] Character %s doesn't exists" % script_name)
 	return null
 
@@ -481,7 +473,7 @@ func get_inventory_item_instance(script_name: String) -> PopochiuInventoryItem:
 		var popochiu_inventory_item: PopochiuInventoryItemData = load(rp)
 		if popochiu_inventory_item.script_name == script_name:
 			return load(popochiu_inventory_item.scene).instantiate()
-	
+
 	printerr("[Popochiu] Item %s doesn't exists" % script_name)
 	return null
 
@@ -532,7 +524,7 @@ func queue_play_transition(type: int, duration: float) -> Callable:
 # in seconds. Possible type values can be found in TransitionLayer
 func play_transition(type: int, duration: float) -> void:
 	$TransitionLayer.play_transition(type, duration)
-	
+
 	await $TransitionLayer.transition_finished
 
 
@@ -543,7 +535,7 @@ func change_text_speed() -> void:
 		settings.text_speeds.size()
 	)
 	current_text_speed = settings.text_speeds[current_text_speed_idx]
-	
+
 	text_speed_changed.emit()
 
 
@@ -562,17 +554,17 @@ func get_saves_descriptions() -> Dictionary:
 func save_game(slot := 1, description := '') -> void:
 	if _saveload.save_game(slot, description):
 		game_saved.emit()
-		
+
 		await G.display('Game saved')
 
 
 func load_game(slot := 1) -> void:
 	I.clean_inventory(true)
-	
+
 	_loaded_game = _saveload.load_game(slot)
-	
+
 	if _loaded_game.is_empty(): return
-	
+
 	goto_room(
 		_loaded_game.player.room,
 		true,
@@ -595,13 +587,13 @@ func add_hovered(node: PopochiuClickable, prepend := false) -> void:
 
 func remove_hovered(node: PopochiuClickable) -> bool:
 	_hovered_queue.erase(node)
-	
+
 	if not _hovered_queue.is_empty():
 		var pc: PopochiuClickable = _hovered_queue[-1]
 		G.show_info(pc.description)
 		Cursor.set_cursor(pc.cursor)
 		return false
-	
+
 	return true
 
 
@@ -629,7 +621,7 @@ func get_half_height() -> float:
 
 func set_hovered(value: PopochiuClickable) -> void:
 	hovered = value
-	
+
 	if not hovered:
 		G.show_info()
 
@@ -658,11 +650,11 @@ func _eval_string(text: String) -> void:
 			var colon_idx: int = text.find(':')
 			if colon_idx:
 				var colon_prefix: String = text.substr(0, colon_idx)
-				
+
 				var emotion_idx := colon_prefix.find('(')
 				var auto_idx := colon_prefix.find('[')
 				var name_idx := -1
-				
+
 				if emotion_idx > 0:
 					if auto_idx > 0 and auto_idx > emotion_idx:
 						name_idx = emotion_idx
@@ -670,45 +662,45 @@ func _eval_string(text: String) -> void:
 						name_idx = auto_idx
 				elif auto_idx > 0:
 					name_idx = auto_idx
-				
+
 				var character_name: String = colon_prefix.substr(
 					0, name_idx
 				)
-				
+
 				if not C.is_valid_character(character_name):
 					printerr('[Popochiu] No PopochiuCharacter with name: %s'\
 					% character_name)
 					await get_tree().process_frame
 					return
-				
+
 				var character := C.get_character(character_name)
-				
+
 				if not C.is_valid_character(character_name):
 					printerr('[Popochiu] No PopochiuCharacter with name: %s'\
 					% character_name)
-					
+
 					await get_tree().process_frame
 					return
-				
+
 				var emotion := ''
 				if emotion_idx > 0:
 					emotion = colon_prefix.substr(emotion_idx + 1).rstrip(')')
-				
+
 				var auto := -1.0
 				if auto_idx > 0:
 					auto_continue_after = float(
 						colon_prefix.substr(auto_idx + 1).rstrip(')')
 					)
-				
+
 				if not emotion.is_empty():
 					character.emotion = emotion
-				
+
 				var dialogue := text.substr(colon_idx + 1).trim_prefix(' ')
-				
+
 				await character.say(dialogue)
 			else:
 				await get_tree().process_frame
-	
+
 	auto_continue_after = -1.0
 
 
@@ -732,10 +724,10 @@ func _queueable(
 		# function has to change the state of the game?
 		await get_tree().process_frame
 		return
-	
+
 	var f := Callable(node, method)
 	var c = f.callv(params)
-	
+
 	if not signal_name.is_empty():
 		if signal_name == 'completed':
 			await c
@@ -748,7 +740,7 @@ func _queueable(
 
 func _on_character_spoke(chr: PopochiuCharacter, msg := '') -> void:
 	G.block()
-	
+
 	add_history({
 		character = chr.description,
 		text = msg


### PR DESCRIPTION
This MR moves settings currently defined in `popochiu_settings.tres` to the Popochiu tree under Godot's Project Settings.

Note that this is a draft, and should not be merged yet. This is my first contribution to the project, so wanted to open this early to get feedback as I go.

Closes https://github.com/mapedorr/popochiu/issues/26.