### PR TITLE
refs 101: anti-glide animation added

### DIFF
--- a/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
+++ b/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
@@ -22,6 +22,9 @@ export var ignore_walkable_areas := false
 # will not work if call method track in animation player is not calling update_position every frame
 export var anti_glide_animation: bool = false
 
+#stores character position between frames if anti-glide animation is on
+var position_stored = null
+
 var last_room := ''
 var anim_suffix := ''
 var is_moving := false

--- a/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
+++ b/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
@@ -43,6 +43,10 @@ func _ready():
 	else:
 		hide_helpers()
 		set_process(true)
+	for child in get_children():
+		if not child is Sprite:
+			continue
+		child.connect("frame_changed", self, "update_position")
 
 
 func _get_property_list():
@@ -411,6 +415,8 @@ func play_walk(target_pos: Vector2) -> void:
 
 func play_talk() -> void:
 	play_animation('talk')
+
+
 
 
 func play_grab() -> void:

--- a/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
+++ b/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
@@ -18,8 +18,7 @@ export var follow_player := false
 export var walk_speed := 200.0
 export var can_move := true
 export var ignore_walkable_areas := false
-# turns anti-glide animation on.
-# will not work if call method track in animation player is not calling update_position every frame
+# turns anti-glide animation on
 export var anti_glide_animation: bool = false
 
 #stores character position between frames if anti-glide animation is on
@@ -37,6 +36,7 @@ onready var dialog_pos: Position2D = $DialogPos
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready():
+	print('call_ready')
 	if not Engine.editor_hint:
 #		idle(false)
 		set_process(follow_player)
@@ -47,7 +47,7 @@ func _ready():
 		if not child is Sprite:
 			continue
 		child.connect("frame_changed", self, "update_position")
-
+		print(self.name, child)
 
 func _get_property_list():
 	var properties = []

--- a/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
+++ b/addons/Popochiu/Engine/Objects/Character/PopochiuCharacter.gd
@@ -18,6 +18,9 @@ export var follow_player := false
 export var walk_speed := 200.0
 export var can_move := true
 export var ignore_walkable_areas := false
+# turns anti-glide animation on.
+# will not work if call method track in animation player is not calling update_position every frame
+export var anti_glide_animation: bool = false
 
 var last_room := ''
 var anim_suffix := ''
@@ -257,6 +260,12 @@ func walk_to_room_point(id: String) -> void:
 	)
 	
 	yield(C, 'character_move_ended')
+
+# Updates character position in the current room if anti-glide animation is on
+# should be called every frame in call method track in animation player
+func update_position():
+	E.current_room.update_characters_position(self)
+	
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ SET & GET ░░░░

--- a/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
+++ b/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
@@ -293,16 +293,15 @@ func _move_along_path(distance):
 			#track in animation player and call update_position every frame
 			#additional condition to avoid crash if update_position method
 			#would be deleted
+			var next_position = last_point.linear_interpolate(
+					_path[0], distance / distance_between_points
+				)
 			if (_moving_character.anti_glide_animation == true 
 			and _moving_character.has_method("update_position")
 			):
-				moving_character_position_stored = last_point.linear_interpolate(
-					_path[0], distance / distance_between_points
-				)
+				moving_character_position_stored = next_position
 			else:
-				_moving_character.position = last_point.linear_interpolate(
-					_path[0], distance / distance_between_points
-				)
+				_moving_character.position = next_position
 			return
 
 		distance -= distance_between_points

--- a/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
+++ b/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
@@ -282,10 +282,7 @@ func _move_along_path(distance):
 			# Play the animation on the character
 			_moving_character.play_walk(_path[0])
 			# Move the character on the destination
-			#in order to run anti-glide animation you need to add call method 
-			#track in animation player and call update_position every frame
-			#additional condition to avoid crash if update_position method
-			#would be deleted
+			
 			var next_position = last_point.linear_interpolate(
 					_path[0], distance / distance_between_points
 				)

--- a/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
+++ b/addons/Popochiu/Engine/Objects/Room/PopochiuRoom.gd
@@ -21,14 +21,6 @@ var _path := []
 var _moving_character: PopochiuCharacter = null
 var _nav_path: PopochiuWalkableArea = null
 
-#stores character position between frames if anti-glide animation is on
-var moving_character_position_stored = (
-	_moving_character.position 
-	if _moving_character 
-	else null
-	)
-
-
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _enter_tree() -> void:
 	if Engine.editor_hint:
@@ -257,7 +249,7 @@ func get_characters() -> Array:
 	for c in $Characters.get_children():
 		if c is PopochiuCharacter:
 			characters.append(c)
-	
+			
 	return characters
 
 
@@ -268,16 +260,17 @@ func clean_characters() -> void:
 
 func update_characters_position(character):
 	character.position = (
-		moving_character_position_stored 
-		if moving_character_position_stored 
+		character.position_stored 
+		if character.position_stored 
 		else character.position
 		)
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _move_along_path(distance):
+	
 	var last_point = (
-		moving_character_position_stored 
-		if moving_character_position_stored 
+		_moving_character.position_stored 
+		if _moving_character.position_stored 
 		else _moving_character.position
 		)
 	
@@ -299,7 +292,7 @@ func _move_along_path(distance):
 			if (_moving_character.anti_glide_animation == true 
 			and _moving_character.has_method("update_position")
 			):
-				moving_character_position_stored = next_position
+				_moving_character.position_stored = next_position
 			else:
 				_moving_character.position = next_position
 			return
@@ -344,7 +337,7 @@ func _clear_navigation_path() -> void:
 	# an empty Array.
 	if not _path.empty():
 		_path.clear()
-	
+	_moving_character.position_stored = null
 	_moving_character.idle(false)
 	C.emit_signal('character_move_ended', _moving_character)
 	_moving_character = null

--- a/addons/Popochiu/Engine/Templates/CharacterTemplate.gd
+++ b/addons/Popochiu/Engine/Templates/CharacterTemplate.gd
@@ -5,6 +5,9 @@ const Data := preload('CharacterStateTemplate.gd')
 
 var state: Data = null
 
+# turns anti-glide animation on.
+# will not work if call method track in animation player is not calling update_position every frame
+export var anti_glide_animation: bool = false
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the PopochiuRoom where this node was already loaded
@@ -52,3 +55,9 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	.play_grab()
+
+# Updates character position in the current room if anti-glide animation is on
+# should be called every frame in call method track in animation player
+func update_position():
+	E.current_room.update_characters_position(C.PLAYER_2)
+	

--- a/addons/Popochiu/Engine/Templates/CharacterTemplate.gd
+++ b/addons/Popochiu/Engine/Templates/CharacterTemplate.gd
@@ -5,10 +5,6 @@ const Data := preload('CharacterStateTemplate.gd')
 
 var state: Data = null
 
-# turns anti-glide animation on.
-# will not work if call method track in animation player is not calling update_position every frame
-export var anti_glide_animation: bool = false
-
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the PopochiuRoom where this node was already loaded
 func on_room_set() -> void:
@@ -55,9 +51,3 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	.play_grab()
-
-# Updates character position in the current room if anti-glide animation is on
-# should be called every frame in call method track in animation player
-func update_position():
-	E.current_room.update_characters_position(C.PLAYER_2)
-	

--- a/popochiu/Characters/Goddiu/CharacterGoddiu.gd
+++ b/popochiu/Characters/Goddiu/CharacterGoddiu.gd
@@ -8,10 +8,6 @@ const Data := preload('CharacterGoddiuState.gd')
 
 var state: Data = preload('CharacterGoddiu.tres')
 
-# turns anti-glide animation on.
-# will not work if call method track in animation player is not calling update_position every frame
-export var anti_glide_animation: bool = false
-
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the node is clicked
 func on_interact() -> void:
@@ -51,9 +47,3 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	.play_grab()
-
-# Updates character position in the current room if anti-glide animation is on
-# should be called every frame in call method track in animation player
-func update_position():
-	E.current_room.update_characters_position(self)
-	

--- a/popochiu/Characters/Goddiu/CharacterGoddiu.gd
+++ b/popochiu/Characters/Goddiu/CharacterGoddiu.gd
@@ -8,6 +8,9 @@ const Data := preload('CharacterGoddiuState.gd')
 
 var state: Data = preload('CharacterGoddiu.tres')
 
+# turns anti-glide animation on.
+# will not work if call method track in animation player is not calling update_position every frame
+export var anti_glide_animation: bool = false
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the node is clicked
@@ -48,3 +51,9 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	.play_grab()
+
+# Updates character position in the current room if anti-glide animation is on
+# should be called every frame in call method track in animation player
+func update_position():
+	E.current_room.update_characters_position(self)
+	

--- a/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
+++ b/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
@@ -258,6 +258,23 @@ tracks/4/keys = {
 "update": 1,
 "values": [ 4.0, 5.0 ]
 }
+tracks/5/type = "method"
+tracks/5/path = NodePath(".")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/keys = {
+"times": PoolRealArray( 0, 0.1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"values": [ {
+"args": [  ],
+"method": "update_position"
+}, {
+"args": [  ],
+"method": "update_position"
+} ]
+}
 
 [node name="CharacterGoddiu" type="Area2D"]
 script = ExtResource( 1 )
@@ -295,6 +312,7 @@ description = "Goddiu"
 clickable = false
 cursor = 8
 flips_when = 2
+anti_glide_animation = true
 popochiu_placeholder = null
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
@@ -321,6 +339,7 @@ position = Vector2( 0, -27 )
 texture = ExtResource( 2 )
 hframes = 3
 vframes = 2
+frame = 4
 
 [node name="DialogPos" type="Position2D" parent="."]
 position = Vector2( 0, -51 )

--- a/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
+++ b/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
@@ -258,23 +258,6 @@ tracks/4/keys = {
 "update": 1,
 "values": [ 4.0, 5.0 ]
 }
-tracks/5/type = "method"
-tracks/5/path = NodePath(".")
-tracks/5/interp = 1
-tracks/5/loop_wrap = true
-tracks/5/imported = false
-tracks/5/enabled = true
-tracks/5/keys = {
-"times": PoolRealArray( 0, 0.1 ),
-"transitions": PoolRealArray( 1, 1 ),
-"values": [ {
-"args": [  ],
-"method": "update_position"
-}, {
-"args": [  ],
-"method": "update_position"
-} ]
-}
 
 [node name="CharacterGoddiu" type="Area2D"]
 script = ExtResource( 1 )

--- a/popochiu/Characters/Popsy/CharacterPopsy.gd
+++ b/popochiu/Characters/Popsy/CharacterPopsy.gd
@@ -8,10 +8,6 @@ const Data := preload('CharacterPopsyState.gd')
 
 var state: Data = preload('CharacterPopsy.tres')
 
-# turns anti-glide animation on.
-# will not work if call method track in animation player is not calling update_position every frame
-export var anti_glide_animation: bool = false
-
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the node is clicked
 func on_interact() -> void:
@@ -69,8 +65,3 @@ func play_talk() -> void:
 func play_grab() -> void:
 	pass
 
-# Updates character position in the current room if anti-glide animation is on
-# should be called every frame in call method track in animation player
-func update_position():
-	E.current_room.update_characters_position(C.PLAYER_2)
-	

--- a/popochiu/Characters/Popsy/CharacterPopsy.gd
+++ b/popochiu/Characters/Popsy/CharacterPopsy.gd
@@ -8,6 +8,9 @@ const Data := preload('CharacterPopsyState.gd')
 
 var state: Data = preload('CharacterPopsy.tres')
 
+# turns anti-glide animation on.
+# will not work if call method track in animation player is not calling update_position every frame
+export var anti_glide_animation: bool = false
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the node is clicked
@@ -65,3 +68,9 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	pass
+
+# Updates character position in the current room if anti-glide animation is on
+# should be called every frame in call method track in animation player
+func update_position():
+	E.current_room.update_characters_position(C.PLAYER_2)
+	

--- a/popochiu/Characters/Trapusinsiu/CharacterTrapusinsiu.gd
+++ b/popochiu/Characters/Trapusinsiu/CharacterTrapusinsiu.gd
@@ -5,6 +5,9 @@ const Data := preload('CharacterTrapusinsiuState.gd')
 
 var state: Data = preload('CharacterTrapusinsiu.tres')
 
+# turns anti-glide animation on.
+# will not work if call method track in animation player is not calling update_position every frame
+export var anti_glide_animation: bool = false
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the PopochiuRoom where this node was already loaded
@@ -52,3 +55,9 @@ func play_talk() -> void:
 # Use it to play the grab animation for the character
 func play_grab() -> void:
 	pass
+
+# Updates character position in the current room if anti-glide animation is on
+# should be called every frame in call method track in animation player
+func update_position():
+	E.current_room.update_characters_position(C.PLAYER_2)
+	

--- a/popochiu/Characters/Trapusinsiu/CharacterTrapusinsiu.gd
+++ b/popochiu/Characters/Trapusinsiu/CharacterTrapusinsiu.gd
@@ -5,10 +5,6 @@ const Data := preload('CharacterTrapusinsiuState.gd')
 
 var state: Data = preload('CharacterTrapusinsiu.tres')
 
-# turns anti-glide animation on.
-# will not work if call method track in animation player is not calling update_position every frame
-export var anti_glide_animation: bool = false
-
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the PopochiuRoom where this node was already loaded
 func on_room_set() -> void:
@@ -56,8 +52,3 @@ func play_talk() -> void:
 func play_grab() -> void:
 	pass
 
-# Updates character position in the current room if anti-glide animation is on
-# should be called every frame in call method track in animation player
-func update_position():
-	E.current_room.update_characters_position(C.PLAYER_2)
-	


### PR DESCRIPTION
Following changes adds option for anti-glide movement.

In order to make it working, for every character:
- add call method track in walking cycle animations (for every direction) that will call ```position_update()``` every frame 
![image](https://github.com/mapedorr/popochiu/assets/34949896/7d299aeb-1b4f-495b-ad5b-fd7bde1611e4)
- chenge anti-glide animation field to "on":
![image](https://github.com/mapedorr/popochiu/assets/34949896/dc48be8b-b7df-4fc3-b78f-fb5e53ded6e3)

for further description check #101