### PR TITLE
Refs 145: walking on broken line fix

### DIFF
--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -350,6 +350,8 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		)
 		
 		if distance <= distance_between_points:
+			moving_character_data.character.face_direction(moving_character_data.path[0])
+			moving_character_data.character._play_walk(moving_character_data.path[0])
 			var next_position = last_point.lerp(
 					moving_character_data.path[0], distance / distance_between_points
 				)


### PR DESCRIPTION
Following solution fixes problem of character playing once oriented animation from  the very beginning up to the end of animation, ignoring geometry of broken line path.

In order to fix that ```_play_walk``` had to be called in order to have ```_get_valid_oriented_animation called```.

Reservations:
```_play_walk``` is private function. In order to make this solution clean, it should be made public or should be wrapped into some public function eg.:

```
func take_turn(target_pos: Vector2) -> void:
    _play_walk(target_pos)
```