### PR TITLE
Refs 145: walking on broken line encapsulated

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -150,6 +150,9 @@ func walk(target_pos: Vector2) -> void:
 	await move_ended
 	is_moving = false
 
+func take_turn(target_pos: Vector2):
+	face_direction(target_pos)
+	_play_walk(target_pos)
 
 func queue_stop_walking() -> Callable:
 	return func (): await stop_walking()

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -350,8 +350,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		)
 		
 		if distance <= distance_between_points:
-			moving_character_data.character.face_direction(moving_character_data.path[0])
-			moving_character_data.character._play_walk(moving_character_data.path[0])
+			moving_character_data.character.take_turn(moving_character_data.path[0])
 			var next_position = last_point.lerp(
 					moving_character_data.path[0], distance / distance_between_points
 				)


### PR DESCRIPTION
Following change updates https://github.com/carenalgas/popochiu/pull/146 in order to follow encapsulation rules.

```_play_walk``` and ```face_direction``` had been wrapped into ```take_turn``` public function which can be freely called buy the room script.