### PR TITLE
Refs 114: Scaling polygon naming fix

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.tscn
+++ b/addons/popochiu/engine/objects/character/popochiu_character.tscn
@@ -5,11 +5,12 @@
 [node name="Character" type="Area2D"]
 script = ExtResource("1_2xmr4")
 popochiu_placeholder = null
+interaction_polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="."]
 polygon = PackedVector2Array(-10, -10, 10, -10, 10, 10, -10, 10)
 
-[node name="ScalingPolygon2D" type="CollisionPolygon2D" parent="."]
+[node name="ScalingPolygon" type="CollisionPolygon2D" parent="."]
 polygon = PackedVector2Array(0, 0, 0, 0, 0, 0, 0, 0)
 
 [node name="BaselineHelper" type="Line2D" parent="."]


### PR DESCRIPTION
character's ScalingPolygon's name in character template had "2D" by mistake that made proper reference from _regions' check_scaling impossible.