### PR TITLE
Fix #168

### DIFF
--- a/addons/popochiu/engine/interfaces/i_graphic_interface.gd
+++ b/addons/popochiu/engine/interfaces/i_graphic_interface.gd
@@ -135,6 +135,7 @@ func unblock(wait := false) -> void:
 	
 	unblocked.emit()
 
+
 ## Makes the in-game graphic interface (GUI) to hide.
 func hide_interface() -> void:
 	hidden.emit()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
@@ -81,7 +81,7 @@ func _on_system_text_shown(_msg: String) -> void:
 
 ## Called when [method G.show_system_text] is executed. Shows the [code]"normal"[/code] cursor.
 func _on_system_text_hidden() -> void:
-	Cursor.show_cursor("normal")
+	Cursor.show_cursor()
 
 
 ## Called when the mouse enters (hovers) [param clickable]. It displays a text with the
@@ -92,8 +92,6 @@ func _on_mouse_entered_clickable(clickable: PopochiuClickable) -> void:
 	
 	if clickable.get("suggested_command"):
 		$"9VerbPanel".highlight_command(clickable.suggested_command)
-	
-	Cursor.show_cursor("active")
 	
 	if I.active:
 		G.show_hover_text(
@@ -115,7 +113,7 @@ func _on_mouse_exited_clickable(clickable: PopochiuClickable) -> void:
 	
 	if clickable.get("suggested_command"):
 		$"9VerbPanel".highlight_command(clickable.suggested_command, false)
-	Cursor.show_cursor("normal")
+	Cursor.show_cursor()
 	
 	if I.active:
 		_show_use_on(I.active)
@@ -134,7 +132,7 @@ func _on_mouse_entered_inventory_item(inventory_item: PopochiuInventoryItem) -> 
 		E.current_command = NineVerbCommands.Commands.USE
 	
 	$"9VerbPanel".highlight_command(NineVerbCommands.Commands.LOOK_AT)
-	Cursor.show_cursor("normal")
+	Cursor.show_cursor()
 	
 	if I.active:
 		if E.current_command == NineVerbCommands.Commands.USE and I.active != inventory_item:
@@ -158,7 +156,7 @@ func _on_mouse_exited_inventory_item(inventory_item: PopochiuInventoryItem) -> v
 		_return_to_walk_to = false
 	
 	$"9VerbPanel".highlight_command(NineVerbCommands.Commands.LOOK_AT, false)
-	Cursor.show_cursor("normal")
+	Cursor.show_cursor()
 	
 	if I.active:
 		G.show_hover_text("Use %s in" % I.active.description)
@@ -185,7 +183,7 @@ func _on_dialog_started(_dialog: PopochiuDialog) -> void:
 
 ## Called when a [PopochiuDialog] finishes. It shows the [code]"normal"[/code] cursor.
 func _on_dialog_finished(_dialog: PopochiuDialog) -> void:
-	Cursor.show_cursor("normal")
+	Cursor.show_cursor()
 
 
 ## Called when [param item] is selected in the inventory (i.e. by clicking it). For this GUI, this

--- a/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
+++ b/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
@@ -3,9 +3,7 @@ extends Node2D
 ## Used to play different transition animations when moving between rooms, skipping a cutscene,
 ## and so on.
 
-# warning-ignore-all:return_value_discarded
-
-signal transition_finished(transition_name)
+signal transition_finished(transition_name: String)
 
 enum {
 	FADE_IN_OUT,
@@ -17,10 +15,10 @@ enum {
 }
 
 @onready var n := {
-	fade = find_child('Fade')
+	fade = find_child("Fade")
 }
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	$AnimationPlayer.animation_finished.connect(_transition_finished)
 	
@@ -28,8 +26,15 @@ func _ready() -> void:
 		$Transitions.scale = E.scale
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#endregion
+
+#region Public #####################################################################################
 func play_transition(type := FADE_IN, duration := 1.0) -> void:
+	# ---- Play RESET in order to fix #168 ---------------------------------------------------------
+	$AnimationPlayer.play("RESET")
+	await get_tree().process_frame
+	# --------------------------------------------------------- Play RESET in order to fix #168 ----
+	
 	for c in $Transitions.get_children():
 		(c as Sprite2D).modulate = E.settings.fade_color
 	
@@ -37,23 +42,33 @@ func play_transition(type := FADE_IN, duration := 1.0) -> void:
 	
 	match type:
 		FADE_IN_OUT:
-			$AnimationPlayer.play('fade_in')
+			$AnimationPlayer.play("fade_in")
 			await $AnimationPlayer.animation_finished
-			$AnimationPlayer.play('fade_out')
+			
+			$AnimationPlayer.play("fade_out")
 		FADE_IN:
-			$AnimationPlayer.play('fade_in')
+			$AnimationPlayer.play("fade_in")
 		FADE_OUT:
-			$AnimationPlayer.play('fade_out')
+			$AnimationPlayer.play("fade_out")
 		PASS_DOWN_IN_OUT:
-			$AnimationPlayer.play('pass_down_in')
+			$AnimationPlayer.play("pass_down_in")
 			await $AnimationPlayer.animation_finished
-			$AnimationPlayer.play('pass_down_out')
+			
+			$AnimationPlayer.play("pass_down_out")
 		PASS_DOWN_IN:
-			$AnimationPlayer.play('pass_down_in')
+			$AnimationPlayer.play("pass_down_in")
 		PASS_DOWN_OUT:
-			$AnimationPlayer.play('pass_down_out')
+			$AnimationPlayer.play("pass_down_out")
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
-func _transition_finished(anim_name := '') -> void:
+#endregion
+
+#region Private ####################################################################################
+func _transition_finished(anim_name := "") -> void:
+	if anim_name == "RESET":
+		return
+	
 	transition_finished.emit(anim_name)
+
+
+#endregion

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -259,11 +259,7 @@ func _process(delta: float) -> void:
 func _input(event: InputEvent) -> void:
 	if event.is_action_released('popochiu-skip'):
 		cutscene_skipped = true
-		tl.play_transition(
-			PopochiuTransitionLayer.PASS_DOWN_IN,
-			settings.skip_cutscene_time
-		)
-		
+		tl.play_transition(PopochiuTransitionLayer.PASS_DOWN_IN, settings.skip_cutscene_time)
 		await tl.transition_finished
 
 
@@ -337,13 +333,11 @@ func queue(instructions: Array, show_gi := true) -> void:
 func cutscene(instructions: Array) -> void:
 	set_process_input(true)
 	await queue(instructions)
+	
 	set_process_input(false)
 	
 	if cutscene_skipped:
-		tl.play_transition(
-			tl.PASS_DOWN_OUT,
-			settings.skip_cutscene_time
-		)
+		tl.play_transition(tl.PASS_DOWN_OUT, settings.skip_cutscene_time)
 		await tl.transition_finished
 	
 	cutscene_skipped = false
@@ -370,6 +364,10 @@ func goto_room(
 	if use_transition:
 		tl.play_transition(tl.FADE_IN)
 		await tl.transition_finished
+	
+	# Prevent the GUI to show info from the previous room
+	G.show_hover_text()
+	Cursor.show_cursor()
 	
 	if is_instance_valid(C.player) and Engine.get_process_frames() > 0:
 		C.player.last_room = current_room.script_name
@@ -494,6 +492,7 @@ func room_readied(room: PopochiuRoom) -> void:
 	if _use_transition_on_room_change:
 		tl.play_transition(tl.FADE_OUT)
 		await tl.transition_finished
+		
 		await wait(0.3)
 	else:
 		await get_tree().process_frame

--- a/addons/popochiu/engine/templates/character_template.gd
+++ b/addons/popochiu/engine/templates/character_template.gd
@@ -19,12 +19,20 @@ func _on_room_set() -> void:
 func _on_click() -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
+	# For example, you can make the player character walk to this character, gaze at it, and then
+	# say something:
+#	await C.player.walk_to_clicked()
+#	await C.player.face_clicked()
+#	await C.player.say("Hi!")
 
 
 # When the node is right clicked
 func _on_right_click() -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
+	# For example, you can make the player character gaze at this character and then say something:
+#	await C.player.face_clicked()
+#	await C.player.say("Is someone...")
 
 
 # When the node is middle clicked
@@ -34,9 +42,13 @@ func _on_middle_click() -> void:
 
 
 # When the node is clicked and there is an inventory item selected
-func _on_item_used(item: PopochiuInventoryItem) -> void:
+func _on_item_used(_item: PopochiuInventoryItem) -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
+	# For example, you can make the player character say something when the Key item is used in this
+	# character. Note that you have to change the name of the `_item` parameter to `item`.
+#	if item == I.Key:
+#		await C.player.say("I don't want to give up my key")
 
 
 # Use it to play the idle animation for the character

--- a/addons/popochiu/engine/templates/hotspot_template.gd
+++ b/addons/popochiu/engine/templates/hotspot_template.gd
@@ -10,21 +10,20 @@ extends PopochiuHotspot
 func _on_click() -> void:
 	# Replace the call to E.command_fallback() with your code.
 	E.command_fallback()
-	# E.g. Make the player-controlled character walk to the Hotspot and then say
+	# For example, you can make the player character walk to this hotspot, gaze at it, and then say
 	# something:
 #	await C.player.walk_to_clicked()
 #	await C.player.face_clicked()
-#	await C.player.say("Can't open it")
+#	await C.player.say("What a nice view")
 
 
 # When the node is right clicked
 func _on_right_click() -> void:
 	# Replace the call to E.command_fallback() with your code.
 	E.command_fallback()
-	# E.g. Make the player-controlled character walk to the Hotspot and then say
-	# something:
+	# For example, you can make the player character gaze at this hotspot and then say something:
 #	await C.player.face_clicked()
-#	await C.player.say("A closed door")
+#	await C.player.say("A window")
 
 
 # When the node is middle clicked
@@ -34,12 +33,12 @@ func _on_middle_click() -> void:
 
 
 # When the node is clicked and there is an inventory item selected
-func _on_item_used(item: PopochiuInventoryItem) -> void:
+func _on_item_used(_item: PopochiuInventoryItem) -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
-	# E.g. Make the player-controlled character to react when using a specific
-	# item on this Hotspot:
-#	if item.script_name == 'Key':
+	# For example, you can make the player character say something when the Key item is used in this
+	# hotspot. Note that you have to change the name of the `_item` parameter to `item`.
+#	if item == I.Key:
 #		await C.player.say("No can do")
 
 

--- a/addons/popochiu/engine/templates/inventory_item_template.gd
+++ b/addons/popochiu/engine/templates/inventory_item_template.gd
@@ -25,9 +25,13 @@ func _on_middle_click() -> void:
 
 
 # When the item is clicked and there is another inventory item selected
-func _on_item_used(item: PopochiuInventoryItem) -> void:
+func _on_item_used(_item: PopochiuInventoryItem) -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
+	# For example, you can make the player character say something when the Key item is used in this
+	# item. Note that you have to change the name of the `_item` parameter to `item`.
+#	if item == I.Key:
+#		await C.player.say("I cannot combine them")
 
 
 # Actions to excecute after the item is added to the Inventory

--- a/addons/popochiu/engine/templates/prop_template.gd
+++ b/addons/popochiu/engine/templates/prop_template.gd
@@ -10,7 +10,7 @@ extends PopochiuProp
 func _on_click() -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
-	# E.g. you can make the character walk to the Prop and then say
+	# For example, you can make the player character walk to this prop, gaze at it, and then say
 	# something:
 #	await C.player.walk_to_clicked()
 #	await C.player.face_clicked()
@@ -21,8 +21,7 @@ func _on_click() -> void:
 func _on_right_click() -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
-	# E.g. you can make the character walk to the Prop and then say
-	# something:
+	# For example, you can make the player character gaze at this prop and then say something:
 #	await C.player.face_clicked()
 #	await C.player.say("A deck of cards")
 
@@ -34,11 +33,12 @@ func _on_middle_click() -> void:
 
 
 # When the node is clicked and there is an inventory item selected
-func _on_item_used(item: PopochiuInventoryItem) -> void:
+func _on_item_used(_item: PopochiuInventoryItem) -> void:
 	# Replace the call to E.command_fallback() to implement your code.
 	E.command_fallback()
-	# E.g. you can make the PC react checked using some items in this Prop
-#	if item.script_name == 'Key':
+	# For example, you can make the player character say something when the Key item is used in this
+	# prop. Note that you have to change the name of the `_item` parameter to `item`.
+#	if item == I.Key:
 #		await C.player.say("I can't do that")
 
 


### PR DESCRIPTION
The RESET animation is played at the beginning of each transition.

[upd] Improve the example comments of some script templates.
[upd] Change name of `item` parameter to `_item` in some script templates in order to avoid warnings.
[upd] 9 Verb GUI doesn't use the "active" cursor animation.
[fea] Popochiu clears the Hover text and changes the Cursor to its "normal" shape when changing room.