### PR TITLE
Fix for 170 and 166

### DIFF
--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -22,11 +22,14 @@ enum Type {
 var is_blocked := false
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
-#region Godot
+#region Godot ######################################################################################
 func _ready():
 	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
+	
+	# Connect to autoload signals
 	E.ready.connect(show_cursor)
+	G.blocked.connect(_on_gui_blocked)
+	G.unblocked.connect(_on_gui_unblocked)
 
 
 func _process(delta):
@@ -57,7 +60,8 @@ func _process(delta):
 
 
 #endregion
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+
+#region Public #####################################################################################
 func show_cursor(anim_name := "normal", ignore_block := false) -> void:
 	if not ignore_block and is_blocked: return
 	
@@ -134,3 +138,19 @@ func show_secondary_cursor() -> void:
 
 func get_type_name(idx: int) -> String:
 	return Type.keys()[idx].to_snake_case()
+
+
+#endregion
+
+#region Private ####################################################################################
+func _on_gui_blocked() -> void:
+	show_cursor("wait")
+	is_blocked = true
+
+
+func _on_gui_unblocked() -> void:
+	is_blocked = false
+	show_cursor()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -497,7 +497,13 @@ func queue_walk_to_clicked(offset := Vector2.ZERO) -> Callable:
 ## Makes the character walk to the last clicked [PopochiuClickable], which is stored in
 ## [member Popochiu.clicked]. You can set an [param offset] relative to the target position.
 func walk_to_clicked(offset := Vector2.ZERO) -> void:
+	var clicked_id: String = E.clicked.script_name
+	
 	await _walk_to_node(E.clicked, offset)
+	
+	# A double check in case two PopochiuClickable share the same `walk_to_point` coordinates
+	if clicked_id != E.clicked.script_name:
+		await E.await_stopped
 
 
 func walk_to_clicked_blocking(offset := Vector2.ZERO) -> void:

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -501,15 +501,15 @@ func walk_to_clicked(offset := Vector2.ZERO) -> void:
 	
 	await _walk_to_node(E.clicked, offset)
 	
-	# A double check in case two PopochiuClickable share the same `walk_to_point` coordinates
-	if clicked_id != E.clicked.script_name:
+	# Check if the action was cancelled
+	if not E.clicked or clicked_id != E.clicked.script_name:
 		await E.await_stopped
 
 
 func walk_to_clicked_blocking(offset := Vector2.ZERO) -> void:
 	G.block()
 	
-	await _walk_to_node(E.clicked, offset, true)
+	await _walk_to_node(E.clicked, offset)
 	
 	G.unblock()
 
@@ -816,20 +816,14 @@ func _get_valid_oriented_animation(animation_label):
 	return null
 
 
-func _walk_to_node(node: Node2D, offset: Vector2, is_blocking := false) -> void:
+func _walk_to_node(node: Node2D, offset: Vector2) -> void:
 	if not is_instance_valid(node):
 		await get_tree().process_frame
 		return
 	
-	var target_pos := (
+	await walk(
 		node.to_global(node.walk_to_point if node is PopochiuClickable else Vector2.ZERO) + offset
 	)
-	var target_move_pos: Vector2 = R.current.get_move_target_position(position, target_pos)
-	
-	await walk(target_pos)
-	
-	if not is_blocking and position != target_move_pos:
-		await E.await_stopped
 
 
 func _update_position():

--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -95,8 +95,8 @@ func _ready():
 		
 		# Connect to singleton signals
 		E.language_changed.connect(_translate)
-		G.blocked.connect(_on_graphic_interface_blocked)
-		G.unblocked.connect(_on_graphic_interface_unblocked)
+		#G.blocked.connect(_on_graphic_interface_blocked)
+		#G.unblocked.connect(_on_graphic_interface_unblocked)
 	
 	set_process_unhandled_input(false)
 	_translate()
@@ -327,6 +327,8 @@ func set_room(value: Node2D) -> void:
 
 #region Private ####################################################################################
 func _on_mouse_entered() -> void:
+	if G.is_blocked: return
+	
 	set_process_unhandled_input(true)
 	
 	if E.hovered and is_instance_valid(E.hovered) and (

--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -95,8 +95,6 @@ func _ready():
 		
 		# Connect to singleton signals
 		E.language_changed.connect(_translate)
-		#G.blocked.connect(_on_graphic_interface_blocked)
-		#G.unblocked.connect(_on_graphic_interface_unblocked)
 	
 	set_process_unhandled_input(false)
 	_translate()
@@ -364,16 +362,6 @@ func _translate() -> void:
 	description = E.get_text(
 		'%s-%s' % [get_tree().current_scene.name, _description_code]
 	)
-
-
-func _on_graphic_interface_blocked() -> void:
-	input_pickable = false
-	set_process_unhandled_input(false)
-
-
-func _on_graphic_interface_unblocked() -> void:
-	input_pickable = true
-	set_process_unhandled_input(true)
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
@@ -60,7 +60,7 @@ func _on_mouse_entered_clickable(clickable: PopochiuClickable) -> void:
 ## Called when the mouse exits [param clickable]. Clears the text in the [HoverText] component and
 ## shows the default cursor texture if there is no [PopochiuInventoryItem] active.
 func _on_mouse_exited_clickable(clickable: PopochiuClickable) -> void:
-	if G.is_blocked: return
+	#if G.is_blocked: return
 	
 	G.show_hover_text()
 	

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -126,6 +126,10 @@ func _unhandled_input(event):
 		return
 	
 	if is_instance_valid(C.player) and C.player.can_move:
+		# Set this property to null in order to cancel any running interaction with a
+		# PopochiuClickable (check PopochiuCharacter.walk_to_clicked(...))
+		E.clicked = null
+		
 		C.player.walk(get_local_mouse_position())
 
 
@@ -403,12 +407,6 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 		_nav_path = active_walkable_area
 	else:
 		PopochiuUtils.print_error("Can't set %s as active walkable area" % walkable_area_name)
-
-
-func get_move_target_position(start_position: Vector2, end_position: Vector2) -> Vector2:
-	return NavigationServer2D.map_get_path(
-		_nav_path.map_rid, start_position, end_position, true
-	)[-1]
 
 
 #endregion

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -405,6 +405,12 @@ func set_active_walkable_area(walkable_area_name: String) -> void:
 		PopochiuUtils.print_error("Can't set %s as active walkable area" % walkable_area_name)
 
 
+func get_move_target_position(start_position: Vector2, end_position: Vector2) -> Vector2:
+	return NavigationServer2D.map_get_path(
+		_nav_path.map_rid, start_position, end_position, true
+	)[-1]
+
+
 #endregion
 
 #region SetGet #####################################################################################
@@ -465,10 +471,7 @@ func _update_navigation_path(
 		return
 	
 	_moving_characters[character.get_instance_id()] = {}
-
-	var moving_character_data: Dictionary =\
-	_moving_characters[character.get_instance_id()]
-
+	var moving_character_data: Dictionary = _moving_characters[character.get_instance_id()]
 	moving_character_data.character = character
 	
 	# TODO: Use a Dictionary so more than one character can move around at the

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -36,6 +36,7 @@ signal game_loaded(data: Dictionary)
 signal command_selected
 ## Emitted when the dialog style changes in [PopochiuSettings].
 signal dialog_style_changed
+signal await_stopped
 
 ## Path to the script with the class used to save and load game data.
 const SAVELOAD_PATH := 'res://addons/popochiu/engine/others/popochiu_save_load.gd'
@@ -1023,7 +1024,8 @@ func _on_character_spoke(chr: PopochiuCharacter, msg := '') -> void:
 
 
 func _on_graphic_interface_unblocked() -> void:
-	clicked = null
+	pass
+	#clicked = null
 	#current_command = 0
 
 


### PR DESCRIPTION
For #170 : **PopochiuClickable** no longer stops listening mouse entering/exiting while the GUI is blocked. And the HoverText and the cursor are restored to default when moving to another room.

For #166 : After the movement ends, the character's position is checked. If the position doesn't match the expected one, execution is indefinitely paused (`await E.await_stopped`). Conversely, if the position matches, the `script_name` of the object that triggered the movement is compared to `E.clicked.script_name` to verify if the currently clicked object is the same as the one that triggered the action.