### PR TITLE
Fix #183 by changing how input is handled

### DIFF
--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -150,7 +150,7 @@ func _on_gui_blocked() -> void:
 
 func _on_gui_unblocked() -> void:
 	is_blocked = false
-	show_cursor()
+	show_cursor(G.get_cursor_name())
 
 
 #endregion

--- a/addons/popochiu/engine/interfaces/i_graphic_interface.gd
+++ b/addons/popochiu/engine/interfaces/i_graphic_interface.gd
@@ -180,4 +180,11 @@ func show_sound_settings() -> void:
 	sound_settings_requested.emit()
 
 
+## Returns the name of the cursor texture to show.
+func get_cursor_name() -> String:
+	if not is_instance_valid(gui): return ""
+	
+	return gui.get_cursor_name()
+
+
 #endregion

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -172,6 +172,7 @@ func set_active(value: PopochiuInventoryItem) -> void:
 		active.unselected.emit()
 	
 	active = value
+	
 	item_selected.emit(active)
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
@@ -122,6 +122,11 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	pass
 
 
+## Called by [b]cursor.gd[/b] to get the name of the cursor texture to show.
+func _get_cursor_name() -> String:
+	return ""
+
+
 #endregion
 
 #region Public #####################################################################################
@@ -135,6 +140,11 @@ func get_component(component_name: String) -> Control:
 		PopochiuUtils.print_warning("No GUI component with name %s" % component_name)
 	
 	return null
+
+
+## Returns the name of the cursor texture to show. [code]"normal"[/code] is returned by default.
+func get_cursor_name() -> String:
+	return "normal" if _get_cursor_name().is_empty() else _get_cursor_name()
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_popup.gd
@@ -15,6 +15,7 @@ func _open() -> void:
 func _close() -> void:
 	if I.active:
 		Cursor.set_secondary_cursor_texture(I.active.texture)
+		Cursor.hide_main_cursor()
 	else:
 		if E.current_command == -1:
 			E.current_command = _command_when_opened

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_commands.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_commands.gd
@@ -43,7 +43,8 @@ func fallback() -> void:
 ## By default makes the character walk to the clicked [PopochiuClickable].
 func walk() -> void:
 #	E.get_node("/root/C").walk_to_clicked()
-	C.walk_to_clicked()
+	if E.clicked:
+		C.walk_to_clicked()
 
 
 ## Called when [code]E.current_command == Commands.LOOK[/code] and [code]E.command_fallback()[/code]

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
@@ -103,11 +103,16 @@ func _on_dialog_finished(_dialog: PopochiuDialog) -> void:
 ## default cursor.
 func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	if is_instance_valid(item):
-		Cursor.set_secondary_cursor_texture(item.texture)
 		Cursor.hide_main_cursor()
+		Cursor.set_secondary_cursor_texture(item.texture, true)
 	else:
 		Cursor.remove_secondary_cursor_texture()
 		Cursor.show_cursor()
+
+
+## Called by [b]cursor.gd[/b] to get the name of the cursor texture to show.
+func _get_cursor_name() -> String:
+	return E.get_current_command_name().to_snake_case()
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_commands.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_commands.gd
@@ -12,14 +12,19 @@ extends PopochiuCommands
 func fallback() -> void:
 	if is_instance_valid(E.clicked):
 		if E.clicked.last_click_button == MOUSE_BUTTON_LEFT:
-			click_clickable()
+			await click_clickable()
+		elif E.clicked.last_click_button == MOUSE_BUTTON_RIGHT:
+			await right_click_clickable()
 		else:
-			right_click_clickable()
-	elif is_instance_valid(I.clicked):
+			await RenderingServer.frame_post_draw
+	
+	if is_instance_valid(I.clicked):
 		if I.clicked.last_click_button == MOUSE_BUTTON_LEFT:
-			click_inventory_item()
+			await click_inventory_item()
+		elif E.clicked.last_click_button == MOUSE_BUTTON_RIGHT:
+			await right_click_inventory_item()
 		else:
-			right_click_inventory_item()
+			await RenderingServer.frame_post_draw
 
 
 ## Called when players click (LMB) a [PopochiuClickable].

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -340,20 +340,23 @@ func _toggle_description(is_hover: bool) -> void:
 
 
 func _on_gui_input(event: InputEvent) -> void: 
-	var mouse_event := event as InputEventMouseButton 
-	if mouse_event and mouse_event.pressed:
-		I.clicked = self
-		last_click_button = mouse_event.button_index
-		
-		match mouse_event.button_index:
-			MOUSE_BUTTON_LEFT:
-				if I.active:
-					on_item_used(I.active)
-				else:
-					handle_command(mouse_event.button_index)
-			MOUSE_BUTTON_RIGHT, MOUSE_BUTTON_MIDDLE:
-				if not I.active:
-					handle_command(mouse_event.button_index)
+	if not PopochiuUtils.is_mouse_button_pressed(event): return
+	
+	I.clicked = self
+	last_click_button = event.button_index
+	
+	match event.button_index:
+		MOUSE_BUTTON_LEFT:
+			if I.active:
+				on_item_used(I.active)
+			else:
+				if DisplayServer.is_touchscreen_available():
+					G.mouse_entered_inventory_item.emit(self)
+				
+				handle_command(event.button_index)
+		MOUSE_BUTTON_RIGHT, MOUSE_BUTTON_MIDDLE:
+			if not I.active:
+				handle_command(event.button_index)
 
 
 #endregion

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -113,16 +113,21 @@ func _physics_process(delta):
 		_move_along_path(walk_distance, moving_character_data)
 
 
-func _unhandled_input(event):
+func _unhandled_input(event: InputEvent):
 	if not has_player: return
 	
 	if I.active:
 		if event.is_action_released("popochiu-look")\
 		or event.is_action_pressed("popochiu-interact"):
+			# Wait so PopochiuClickable can handle the interaction
+			await get_tree().create_timer(0.1).timeout
+			
 			I.set_active_item()
 		return
 	
-	if not event.is_action_pressed("popochiu-interact"):
+	if not (
+		PopochiuUtils.is_mouse_button_pressed(event) and event.button_index == MOUSE_BUTTON_LEFT
+	):
 		return
 	
 	if is_instance_valid(C.player) and C.player.can_move:

--- a/addons/popochiu/engine/others/popochiu_utils.gd
+++ b/addons/popochiu/engine/others/popochiu_utils.gd
@@ -52,3 +52,8 @@ static func print_warning(msg: String) -> void:
 
 static func print_normal(msg: String) -> void:
 	print_rich("[bgcolor=75cec8][color=000000][b][Popochiu][/b] %s[/color][/bgcolor]" % msg)
+
+
+static func is_mouse_button_pressed(event: InputEvent) -> bool:
+	# Fix #183 by including `event is InputEventScreenTouch` validation
+	return (event is InputEventMouseButton or event is InputEventScreenTouch) and event.pressed

--- a/addons/popochiu/engine/templates/graphic_interface/graphic_interface_template.gd
+++ b/addons/popochiu/engine/templates/graphic_interface/graphic_interface_template.gd
@@ -81,4 +81,9 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	super(item)
 
 
+# Called by [b]cursor.gd[/b] to get the name of the cursor texture to show.
+func _get_cursor_name() -> String:
+	return super()
+
+
 #endregion

--- a/project.godot
+++ b/project.godot
@@ -73,6 +73,7 @@ import/aseprite/command_path="D:\\visual\\Aseprite\\Aseprite.exe"
 
 [rendering]
 
+textures/vram_compression/import_etc2_astc=true
 quality/driver/driver_name="GLES2"
 vram_compression/import_etc=true
 vram_compression/import_etc2=false


### PR DESCRIPTION
The validation of the pressed button now takes into account InputEventScreenTouch events.

[fea] When the game detects a touchscreen inventory items auto-hover when clicked.
[fea] Improve how Cursor sets its texture when unblocked. Now it asks to the G singleton for the texture name.
[upd] Now PopochiuClickable handle inputs with its input_event signal. [fix] Sierra GUI wasn't hiding the main cursor after closing the inventory with an item selected.