### PR TITLE
GUI Scaling (fix for #188)

### DIFF
--- a/addons/popochiu/editor/main_dock/popochiu_dock.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.gd
@@ -90,7 +90,7 @@ func _ready() -> void:
 	
 	tab_container.tab_changed.connect(_on_tab_changed)
 	btn_setup.pressed.connect(open_setup)
-	btn_docs.pressed.connect(OS.shell_open.bind(Constants.WIKI))
+	btn_docs.pressed.connect(OS.shell_open.bind(Constants.DOCUMENTATION))
 	get_tree().node_added.connect(_check_node)
 
 
@@ -203,9 +203,12 @@ func scene_changed(scene_root: Node) -> void:
 	if not is_instance_valid(tab_ui): return
 	tab_ui.on_scene_changed(scene_root)
 	
-	if not scene_root is PopochiuRoom and not scene_root is PopochiuGraphicInterface:
-		# Open the Popochiu Main tab if the opened scene in the Editor2D is not
-		# a PopochiuRoom nor a PopochiuGraphicInterface
+	if (
+		not scene_root is PopochiuRoom
+		and not scene_root.scene_file_path == PopochiuResources.GUI_GAME_SCENE
+	):
+		# Open the Popochiu Main tab if the opened scene in the Editor2D is not a PopochiuRoom nor
+		# the GUI scene
 		tab_container.current_tab = 0
 
 

--- a/addons/popochiu/editor/popups/setup/setup.gd
+++ b/addons/popochiu/editor/popups/setup/setup.gd
@@ -155,27 +155,15 @@ func _on_close() -> void:
 
 
 func _on_about_to_popup() -> void:
-	welcome.add_theme_font_override(
-		"bold_font", get_theme_font("bold", "EditorFonts")
-	)
-	scale_message.add_theme_font_override(
-		"normal_font", get_theme_font("main", "EditorFonts")
-	)
-	scale_message.add_theme_font_override(
-		"bold_font", get_theme_font("bold", "EditorFonts")
-	)
-	scale_message.add_theme_font_override(
-		"mono_font", get_theme_font("doc_source", "EditorFonts")
-	)
-	gui_templates_title.add_theme_font_override(
-		"font", get_theme_font("bold", "EditorFonts")
-	)
+	welcome.add_theme_font_override("bold_font", get_theme_font("bold", "EditorFonts"))
+	scale_message.add_theme_font_override("normal_font", get_theme_font("main", "EditorFonts"))
+	scale_message.add_theme_font_override("bold_font", get_theme_font("bold", "EditorFonts"))
+	scale_message.add_theme_font_override("mono_font", get_theme_font("doc_source", "EditorFonts"))
+	gui_templates_title.add_theme_font_override("font", get_theme_font("bold", "EditorFonts"))
 	gui_templates_description.add_theme_font_override(
 		"font", get_theme_font("doc_source", "EditorFonts")
 	)
-	template_description.add_theme_font_override(
-		"bold_font", get_theme_font("bold", "EditorFonts")
-	)
+	template_description.add_theme_font_override("bold_font", get_theme_font("bold", "EditorFonts"))
 
 
 func _update_scale(_value: float) -> void:

--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -86,8 +86,8 @@ func set_secondary_cursor_texture(texture: Texture2D, ignore_block := false) -> 
 	secondary_cursor.texture = texture
 	
 	if E.settings.scale_gui:
-		# Scale the cursor based on the size of the relation of the texture size against
-		# the main cursor size
+		# Scale the cursor based the relation of the texture size compared to the main cursor
+		# texture size
 		secondary_cursor.scale = Vector2.ONE * ceil(
 			float(texture.get_height()) / float(get_cursor_height())
 		)

--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -21,6 +21,9 @@ enum Type {
 
 var is_blocked := false
 
+@onready var main_cursor: AnimatedSprite2D = $MainCursor
+@onready var secondary_cursor: Sprite2D = $SecondaryCursor
+
 
 #region Godot ######################################################################################
 func _ready():
@@ -33,30 +36,30 @@ func _ready():
 
 
 func _process(delta):
-	var texture_size := ($MainCursor.sprite_frames.get_frame_texture(
-		$MainCursor.animation,
-		$MainCursor.frame
+	var texture_size := (main_cursor.sprite_frames.get_frame_texture(
+		main_cursor.animation,
+		main_cursor.frame
 	) as Texture2D).get_size()
 	
-	var mouse_position: Vector2 = $MainCursor.get_global_mouse_position()
+	var mouse_position: Vector2 = main_cursor.get_global_mouse_position()
 	
 	if is_pixel_perfect:
 		# Thanks to @whyshchuck
-		$MainCursor.position = Vector2i(mouse_position)
-		$SecondaryCursor.position = Vector2i(mouse_position)
+		main_cursor.position = Vector2i(mouse_position)
+		secondary_cursor.position = Vector2i(mouse_position)
 	else:
-		$MainCursor.position = mouse_position
-		$SecondaryCursor.position = mouse_position
+		main_cursor.position = mouse_position
+		secondary_cursor.position = mouse_position
 	
-	if $MainCursor.position.x < 1.0:
-		$MainCursor.position.x = 1.0
-	elif $MainCursor.position.x > E.width - 2.0:
-		$MainCursor.position.x = E.width - 2.0
+	if main_cursor.position.x < 1.0:
+		main_cursor.position.x = 1.0
+	elif main_cursor.position.x > E.width - 2.0:
+		main_cursor.position.x = E.width - 2.0
 	
-	if $MainCursor.position.y < 1.0:
-		$MainCursor.position.y = 1.0
-	elif $MainCursor.position.y > E.height - 2.0:
-		$MainCursor.position.y = E.height - 2.0
+	if main_cursor.position.y < 1.0:
+		main_cursor.position.y = 1.0
+	elif main_cursor.position.y > E.height - 2.0:
+		main_cursor.position.y = E.height - 2.0
 
 
 #endregion
@@ -67,35 +70,35 @@ func show_cursor(anim_name := "normal", ignore_block := false) -> void:
 	
 	if (
 		not anim_name.is_empty()
-		and not $MainCursor.sprite_frames.has_animation(anim_name)
+		and not main_cursor.sprite_frames.has_animation(anim_name)
 	):
-		prints("[Popochiu] Cursor has no animation: %s" % anim_name)
+		PopochiuUtils.print_error("Cursor has no animation: %s" % anim_name)
 		return
 	
-	$MainCursor.play(anim_name)
-	$MainCursor.show()
-	$SecondaryCursor.hide()
+	main_cursor.play(anim_name)
+	main_cursor.show()
+	secondary_cursor.hide()
 
 
 func set_secondary_cursor_texture(texture: Texture2D, ignore_block := false) -> void:
 	if not ignore_block and is_blocked: return
 	
-	$SecondaryCursor.texture = texture
+	secondary_cursor.texture = texture
 	
-	#$MainCursor.hide()
-	$SecondaryCursor.show()
+	#main_cursor.hide()
+	secondary_cursor.show()
 
 
 func remove_secondary_cursor_texture() -> void:
-	$SecondaryCursor.texture = null
+	secondary_cursor.texture = null
 	
-	#$MainCursor.show()
-	$SecondaryCursor.hide()
+	#main_cursor.show()
+	secondary_cursor.hide()
 
 
 func toggle_visibility(is_visible: bool) -> void:
-	$MainCursor.visible = is_visible
-	$SecondaryCursor.visible = is_visible
+	main_cursor.visible = is_visible
+	secondary_cursor.visible = is_visible
 
 
 func block() -> void:
@@ -107,37 +110,48 @@ func unblock() -> void:
 
 
 func scale_cursor(factor: Vector2) -> void:
-	$SecondaryCursor.scale = Vector2.ONE * factor
-	$MainCursor.scale = Vector2.ONE * factor
+	secondary_cursor.scale = Vector2.ONE * factor
+	main_cursor.scale = Vector2.ONE * factor
 
 
 func get_position() -> Vector2:
-	return $SecondaryCursor.position
+	return secondary_cursor.position
 
 
 func replace_frames(new_node: AnimatedSprite2D) -> void:
-	$MainCursor.sprite_frames = new_node.sprite_frames
-	$MainCursor.offset = new_node.offset
+	main_cursor.sprite_frames = new_node.sprite_frames
+	main_cursor.offset = new_node.offset
 
 
 func hide_main_cursor() -> void:
-	$MainCursor.hide()
+	main_cursor.hide()
 
 
 func show_main_cursor() -> void:
-	$MainCursor.show()
+	main_cursor.show()
 
 
 func hide_secondary_cursor() -> void:
-	$SecondaryCursor.hide()
+	secondary_cursor.hide()
 
 
 func show_secondary_cursor() -> void:
-	$SecondaryCursor.show()
+	secondary_cursor.show()
 
 
 func get_type_name(idx: int) -> String:
 	return Type.keys()[idx].to_snake_case()
+
+
+func get_cursor_height() -> int:
+	var height := 0
+	
+	if main_cursor.visible:
+		height = main_cursor.sprite_frames.get_frame_texture(main_cursor.animation, 0).get_height()
+	elif secondary_cursor.visible:
+		height = secondary_cursor.texture.get_height()
+	
+	return height
 
 
 #endregion

--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -85,14 +85,22 @@ func set_secondary_cursor_texture(texture: Texture2D, ignore_block := false) -> 
 	
 	secondary_cursor.texture = texture
 	
-	#main_cursor.hide()
+	if E.settings.scale_gui:
+		# Scale the cursor based on the size of the relation of the texture size against
+		# the main cursor size
+		secondary_cursor.scale = Vector2.ONE * ceil(
+			float(texture.get_height()) / float(get_cursor_height())
+		)
+	
 	secondary_cursor.show()
 
 
 func remove_secondary_cursor_texture() -> void:
 	secondary_cursor.texture = null
 	
-	#main_cursor.show()
+	if E.settings.scale_gui:
+		secondary_cursor.scale = E.scale
+	
 	secondary_cursor.hide()
 
 
@@ -110,8 +118,8 @@ func unblock() -> void:
 
 
 func scale_cursor(factor: Vector2) -> void:
-	secondary_cursor.scale = Vector2.ONE * factor
-	main_cursor.scale = Vector2.ONE * factor
+	secondary_cursor.scale = factor
+	main_cursor.scale = factor
 
 
 func get_position() -> Vector2:

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -892,7 +892,9 @@ func _teleport_to_node(node: Node2D, offset: Vector2) -> void:
 		await get_tree().process_frame
 		return
 	
-	position = node.to_global(node.walk_to_point if node is PopochiuClickable else Vector2.ZERO) + offset
+	position = node.to_global(
+		node.walk_to_point if node is PopochiuClickable else Vector2.ZERO
+	) + offset
 
 
 func _update_position():

--- a/addons/popochiu/engine/objects/graphic_interface/components/dialog_menu/dialog_menu.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/dialog_menu/dialog_menu.gd
@@ -5,8 +5,8 @@ extends Container
 signal shown
 
 @export var option_scene: PackedScene
-@export var default: Color = Color('5B6EE1')
-@export var used: Color = Color('3F3F74')
+@export var default: Color = Color("5B6EE1")
+@export var used: Color = Color("3F3F74")
 @export var hover: Color = Color.WHITE
 
 var current_options := []
@@ -17,7 +17,7 @@ var _visible_options := 0
 @onready var dialog_options_container: VBoxContainer = %DialogOptionsContainer
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	for child in dialog_options_container.get_children():
 		child.queue_free()
@@ -35,7 +35,9 @@ func _ready() -> void:
 	hide()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _clicked(event: InputEvent) -> void:
 	if PopochiuUtils.get_click_or_touch_index(event) == MOUSE_BUTTON_LEFT:
 		pass
@@ -71,11 +73,11 @@ func _create_options(options := [], autoshow := false) -> void:
 		var dialog_option: PopochiuDialogOption = opt
 
 		btn.text = dialog_option.text
-		btn.add_theme_color_override('font_color', default)
-		btn.add_theme_color_override('font_hover_color', hover)
+		btn.add_theme_color_override("font_color", default)
+		btn.add_theme_color_override("font_hover_color", hover)
 		
 		if dialog_option.used and not dialog_option.always_on:
-			btn.add_theme_color_override('font_color', used)
+			btn.add_theme_color_override("font_color", used)
 		
 		btn.pressed.connect(_on_option_clicked.bind(dialog_option))
 
@@ -127,3 +129,6 @@ func _on_option_clicked(opt: PopochiuDialogOption) -> void:
 	
 	hide()
 	D.option_selected.emit(opt)
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
@@ -9,7 +9,7 @@ signal animation_finished
 signal text_show_started
 signal text_show_finished
 
-const DFLT_SIZE := 'dflt_size'
+const DFLT_SIZE := "dflt_size"
 const DFLT_POSITION := "dflt_position"
 
 @export var wrap_width := 200.0
@@ -79,7 +79,7 @@ func play_text(props: Dictionary) -> void:
 	# the whole text is shown
 	var rt := RichTextLabel.new()
 	rt.add_theme_font_override(
-		'normal_font',
+		"normal_font",
 		get_theme_font("normal_font")
 	)
 	rt.bbcode_enabled = true
@@ -91,7 +91,7 @@ func play_text(props: Dictionary) -> void:
 	# Create a Label to check if the text exceeds the wrap_width
 	var lbl := Label.new()
 	lbl.add_theme_font_override(
-		'normal_font',
+		"normal_font",
 		get_theme_font("normal_font")
 	)
 	
@@ -164,15 +164,15 @@ func play_text(props: Dictionary) -> void:
 		0:
 			var center := floor(position.x + (size.x / 2))
 			if center == props.position.x:
-				append_text('[center]%s[/center]' % msg)
+				append_text("[center]%s[/center]" % msg)
 			elif center < props.position.x:
-				append_text('[right]%s[/right]' % msg)
+				append_text("[right]%s[/right]" % msg)
 			else:
 				append_text(msg)
 		1:
 			append_text(msg)
 		2:
-			text = '[center][color=%s]%s[/color][/center]' % [
+			text = "[center][color=%s]%s[/color][/center]" % [
 				props.color.to_html(), msg
 			]
 	
@@ -183,7 +183,7 @@ func play_text(props: Dictionary) -> void:
 		
 		_tween = create_tween()
 		_tween.tween_property(
-			self, 'visible_ratio',
+			self, "visible_ratio",
 			1,
 			_secs_per_character * get_total_character_count()
 		).from(0.0)
@@ -244,7 +244,7 @@ func change_speed() -> void:
 #endregion
 
 #region Private ####################################################################################
-func _show_dialogue(chr: PopochiuCharacter, msg := '') -> void:
+func _show_dialogue(chr: PopochiuCharacter, msg := "") -> void:
 	if not visible: return
 	
 	play_text({
@@ -306,7 +306,7 @@ func _show_icon() -> void:
 				from_pos = size.y - _continue_icon.size.y - 1.0
 		
 		_continue_icon_tween.tween_property(
-			_continue_icon, 'position:y', to_pos, 0.8
+			_continue_icon, "position:y", to_pos, 0.8
 		).from(from_pos).set_trans(Tween.TRANS_BOUNCE).set_ease(Tween.EASE_OUT)
 		_continue_icon_tween.set_loops()
 	else:
@@ -319,7 +319,7 @@ func _show_icon() -> void:
 				_continue_icon.position.y = size.y / 2.0
 		
 		_continue_icon_tween.tween_property(
-			_continue_icon, 'value',
+			_continue_icon, "value",
 			100.0, 3.0,
 		).from_current().set_ease(Tween.EASE_OUT)
 		_continue_icon_tween.finished.connect(_continue)

--- a/addons/popochiu/engine/objects/graphic_interface/components/hover_text/hover_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/hover_text/hover_text.gd
@@ -2,13 +2,18 @@ extends RichTextLabel
 class_name PopochiuHoverText
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	text = ""
 	
 	G.hover_text_shown.connect(_show_text)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
-func _show_text(txt := '') -> void:
-	text = '[center]%s[/center]' % txt
+#endregion
+
+#region Virtual ####################################################################################
+func _show_text(txt := "") -> void:
+	text = "[center]%s[/center]" % txt
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -11,7 +11,7 @@ var _is_hidden := true
 @onready var _box: Container = find_child('Box')
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready():
 	if not always_visible:
 		position.y = _hidden_y
@@ -36,14 +36,21 @@ func _ready():
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
-		if _is_hidden and get_rect().has_point(get_global_mouse_position()):
+		var rect := get_rect()
+		
+		if E.settings.scale_gui:
+			rect = Rect2(get_rect().position * E.scale, get_rect().size * E.scale)
+		
+		if _is_hidden and rect.has_point(get_global_mouse_position()):
 			_open()
 		elif not _is_hidden\
-		and not get_rect().has_point(get_global_mouse_position()):
+		and not rect.has_point(get_global_mouse_position()):
 			_close()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _open() -> void:
 	if always_visible: return
 	if not is_disabled and position.y != _hidden_y: return
@@ -157,3 +164,6 @@ func _show_and_hide(time := 1.0) -> void:
 	set_process_input(true)
 	
 	I.inventory_shown.emit()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -6,7 +6,7 @@ var is_disabled := false
 
 var _is_hidden := true
 
-@onready var box: Container = find_child('Box')
+@onready var box: Container = find_child("Box")
 @onready var _tween: Tween = null
 @onready var _hidden_y := position.y - (size.y - 4)
 
@@ -59,7 +59,7 @@ func _open() -> void:
 		_tween.kill()
 	
 	_tween = create_tween()
-	_tween.tween_property(self, 'position:y', 0.0, 0.5)\
+	_tween.tween_property(self, "position:y", 0.0, 0.5)\
 	.from(_hidden_y if not is_disabled else position.y)\
 	.set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
 	
@@ -76,7 +76,7 @@ func _close() -> void:
 	
 	_tween = create_tween()
 	_tween.tween_property(
-		self, 'position:y',
+		self, "position:y",
 		_hidden_y if not is_disabled else _hidden_y - 3.5,
 		0.2
 	).from(0.0).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -6,9 +6,9 @@ var is_disabled := false
 
 var _is_hidden := true
 
+@onready var box: Container = find_child('Box')
 @onready var _tween: Tween = null
 @onready var _hidden_y := position.y - (size.y - 4)
-@onready var _box: Container = find_child('Box')
 
 
 #region Godot ######################################################################################
@@ -26,7 +26,7 @@ func _ready():
 	I.inventory_hide_requested.connect(_close)
 	
 	# Check if there are already items in the inventory (set manually in the scene)
-	for ii in _box.get_children():
+	for ii in box.get_children():
 		if ii is PopochiuInventoryItem:
 			ii.in_inventory = true
 			ii.selected.connect(_change_cursor)
@@ -101,7 +101,11 @@ func _on_graphic_interface_unblocked() -> void:
 
 
 func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
-	_box.add_child(item)
+	box.add_child(item)
+	
+	if E.settings.scale_gui:
+		item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
+		item.custom_minimum_size.y = box.size.y
 	
 	item.selected.connect(_change_cursor)
 	
@@ -126,7 +130,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
 	item.selected.disconnect(_change_cursor)
 	
-	_box.remove_child(item)
+	box.remove_child(item)
 	
 	if not always_visible:
 		Cursor.show_cursor()

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/confirmation_popup/confirmation_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/confirmation_popup/confirmation_popup.gd
@@ -1,7 +1,7 @@
 extends "../popochiu_popup.gd"
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
+#region Virtual ####################################################################################
 ## Called when the popup is opened. At this point it is not visible yet.
 func _open() -> void:
 	pass
@@ -20,3 +20,6 @@ func _on_ok() -> void:
 ## Called when CANCEL or X (top-right corner) are pressed.
 func _on_cancel() -> void:
 	pass
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/history_popup/history_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/history_popup/history_popup.gd
@@ -1,17 +1,23 @@
 extends PopochiuPopup
 
-const DIALOG_LINE := preload('components/dialog_line.tscn')
-const INTERACTION_LINE := preload('components/interaction_line.tscn')
+const DIALOG_LINE := preload(
+	PopochiuResources.GUI_ADDON_FOLDER + 
+	"components/popups/history_popup/components/dialog_line.tscn"
+)
+const INTERACTION_LINE := preload(
+	PopochiuResources.GUI_ADDON_FOLDER + 
+	"components/popups/history_popup/components/interaction_line.tscn"
+)
 
 @export var dialog_line: PackedScene = null
 @export var interaction_line: PackedScene = null
 
-@onready var lines_list: VBoxContainer = find_child('LinesList')
+@onready var lines_list: VBoxContainer = find_child("LinesList")
 @onready var empty: Label = %Empty
 @onready var lines_scroll: ScrollContainer = %LinesScroll
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -22,7 +28,9 @@ func _ready() -> void:
 		(c as Control).queue_free()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUALS ░░░░
+#endregion
+
+#region Virtual ####################################################################################
 func _open() -> void:
 	if E.history.is_empty():
 		empty.show()
@@ -34,9 +42,9 @@ func _open() -> void:
 	for data in E.history:
 		var lbl: RichTextLabel
 		
-		if data.has('character'):
+		if data.has("character"):
 			lbl = (dialog_line if dialog_line else DIALOG_LINE).instantiate()
-			lbl.text = '[color=%s]%s:[/color] %s' \
+			lbl.text = "[color=%s]%s:[/color] %s" \
 			% [
 				(data.character as PopochiuCharacter).text_color.to_html(false),
 				(data.character as PopochiuCharacter).description,
@@ -44,7 +52,7 @@ func _open() -> void:
 			]
 		else:
 			lbl = (interaction_line if interaction_line else INTERACTION_LINE).instantiate()
-			lbl.text = '[color=edf171]%s[/color] [color=a9ff9f]%s[/color]'\
+			lbl.text = "[color=edf171]%s[/color] [color=a9ff9f]%s[/color]"\
 			% [data.action, data.target]
 	
 		lines_list.add_child(lbl)
@@ -53,3 +61,6 @@ func _open() -> void:
 func _close() -> void:
 	for c in lines_list.get_children():
 		(c as Control).queue_free()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/popochiu_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/popochiu_popup.gd
@@ -64,10 +64,6 @@ func _on_cancel() -> void:
 func open() -> void:
 	_open()
 	
-	# TODO: I'm not sure we should do this...
-	if E.settings.scale_gui:
-		scale = Vector2.ONE * E.scale
-	
 	G.block()
 	Cursor.show_cursor("gui", true)
 	

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/quit_popup/quit_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/quit_popup/quit_popup.gd
@@ -1,7 +1,7 @@
 extends "../popochiu_popup.gd"
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
+#region Virtual ####################################################################################
 ## Called when the popup is opened. At this point it is not visible yet.
 func _open() -> void:
 	pass
@@ -20,3 +20,6 @@ func _on_ok() -> void:
 ## Called when CANCEL or X (top-right corner) are pressed.
 func _on_cancel() -> void:
 	pass
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/save_and_load_popup/save_and_load_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/save_and_load_popup/save_and_load_popup.gd
@@ -1,17 +1,17 @@
 extends PopochiuPopup
 
-const SELECTION_COLOR := Color('edf171')
-const OVERWRITE_COLOR := Color('c46c71')
+const SELECTION_COLOR := Color("edf171")
+const OVERWRITE_COLOR := Color("c46c71")
 
 var _current_slot: Button = null
-var _slot_name := ''
-var _prev_text := ''
+var _slot_name := ""
+var _prev_text := ""
 var _slot := 0
 
 @onready var slots: VBoxContainer = %Slots
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -23,19 +23,21 @@ func _ready() -> void:
 	
 	var saves: Dictionary = E.get_saves_descriptions()
 	
-	for btn in slots.get_children():
-		(btn as Button).set_meta('has_save', false)
+	for btn: Button in slots.get_children():
+		btn.set_meta("has_save", false)
 		
 		if saves.has(btn.get_index() + 1):
 			btn.text = saves[btn.get_index() + 1]
-			(btn as Button).set_meta('has_save', true)
+			btn.set_meta("has_save", true)
 		else:
 			btn.disabled = true
 		
 		btn.pressed.connect(_select_slot.bind(btn))
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
+#endregion
+
+#region Virtual ####################################################################################
 func _open() -> void:
 	btn_ok.disabled = true
 	_slot = 0
@@ -45,7 +47,7 @@ func _open() -> void:
 		_current_slot.button_pressed = false
 		
 		_current_slot = null
-		_prev_text = ''
+		_prev_text = ""
 
 
 func _close() -> void:
@@ -62,12 +64,14 @@ func _on_ok() -> void:
 	
 	if _slot_name:
 		_prev_text = _current_slot.text
-		_current_slot.set_meta('has_save', true)
+		_current_slot.set_meta("has_save", true)
 	
 	close()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#endregion
+
+#region Public #####################################################################################
 func open_save() -> void:
 	_show_save()
 
@@ -76,9 +80,11 @@ func open_load() -> void:
 	_show_load()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _show_save(slot_text := "") -> void:
-	lbl_title.text = 'Choose a slot to save the game'
+	lbl_title.text = "Choose a slot to save the game"
 	_slot_name = slot_text
 	
 	if _slot_name.is_empty():
@@ -91,11 +97,11 @@ func _show_save(slot_text := "") -> void:
 
 
 func _show_load() -> void:
-	lbl_title.text = 'Choose the slot to load'
-	_slot_name = ''
+	lbl_title.text = "Choose the slot to load"
+	_slot_name = ""
 	
 	for btn in slots.get_children():
-		btn.disabled = !(btn as Button).get_meta('has_save')
+		btn.disabled = !(btn as Button).get_meta("has_save")
 	
 	open()
 
@@ -120,6 +126,9 @@ func _select_slot(btn: Button) -> void:
 
 
 func _format_date(date: Dictionary) -> String:
-	return '%d/%02d/%02d %02d:%02d:%02d' % [
+	return "%d/%02d/%02d %02d:%02d:%02d" % [
 		date.year, date.month, date.day, date.hour, date.minute, date.second
 	]
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/settings_popup/settings_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/settings_popup/settings_popup.gd
@@ -8,7 +8,7 @@ signal quit_pressed
 @onready var quit: Button = %Quit
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -19,7 +19,9 @@ func _ready() -> void:
 	quit.pressed.connect(_on_quit_pressed)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
+#endregion
+
+#region Virtual ####################################################################################
 ## Called when the popup is opened. At this point it is not visible yet.
 func _open() -> void:
 	pass
@@ -40,7 +42,9 @@ func _on_cancel() -> void:
 	pass
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _on_save_pressed() -> void:
 	G.show_save()
 
@@ -56,3 +60,6 @@ func _on_history_pressed() -> void:
 func _on_quit_pressed() -> void:
 	close()
 	quit_pressed.emit()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/sound_settings_popup/sound_settings_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/sound_settings_popup/sound_settings_popup.gd
@@ -3,7 +3,7 @@ extends PopochiuPopup
 @onready var sound_volumes: GridContainer = %SoundVolumes
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -11,10 +11,15 @@ func _ready() -> void:
 	G.sound_settings_requested.connect(open)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
+#endregion
+
+#region Virtual ####################################################################################
 func _open() -> void:
 	sound_volumes.update_sliders()
 
 
 func _on_cancel() -> void:
 	sound_volumes.restore_last_volumes()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/sound_volumes/sound_volumes.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/sound_volumes/sound_volumes.gd
@@ -6,13 +6,15 @@ const MUTE_VOLUME := -70
 var dflt_volumes := {}
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	# Connect to AudioManager ready signal
 	E.am.ready.connect(_on_audio_manager_ready)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#endregion
+
+#region Public #####################################################################################
 func update_sliders() -> void:
 	for slider in $SlidersContainer.get_children():
 		if not slider.has_meta("bus_name"): continue
@@ -31,7 +33,9 @@ func restore_last_volumes() -> void:
 		E.am.set_bus_volume_db(bus_name, dflt_volumes[bus_name])
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _on_audio_manager_ready() -> void:
 	E.am.load_sound_settings()
 	
@@ -67,3 +71,6 @@ func _on_audio_manager_ready() -> void:
 					value if value > MIN_VOLUME else MUTE_VOLUME
 				)
 		).bind(bus_name))
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/components/system_text/system_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/system_text/system_text.gd
@@ -4,7 +4,7 @@ extends RichTextLabel
 
 signal shown
 
-const DFLT_SIZE := 'dflt_size'
+const DFLT_SIZE := "dflt_size"
 
 
 #region Godot ######################################################################################
@@ -53,7 +53,7 @@ func close() -> void:
 #endregion
 
 #region Private ####################################################################################
-func _show_text(msg := '') -> void:
+func _show_text(msg := "") -> void:
 	clear()
 	text = ""
 	size = get_meta(DFLT_SIZE)
@@ -73,7 +73,7 @@ func _show_text(msg := '') -> void:
 	rt.free()
 	# ========================================================= Calculate the width of the node ====
 	
-	append_text('[center]%s[/center]' % msg)
+	append_text("[center]%s[/center]" % msg)
 	
 	if msg:
 		appear()

--- a/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
@@ -45,6 +45,10 @@ func _ready():
 		# NOTE: Maybe here we should take into account if the game is marked as Pixel (or if the
 		# 		font is the default one.
 		texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		
+		# Adjust nodes with a "text" property that is a String in order to try to prevent glitches
+		# when rendering its font
+		_adjust_nodes_text(get_children())
 
 
 #endregion
@@ -152,6 +156,18 @@ func get_component(component_name: String) -> Control:
 ## Returns the name of the cursor texture to show. [code]"normal"[/code] is returned by default.
 func get_cursor_name() -> String:
 	return "normal" if _get_cursor_name().is_empty() else _get_cursor_name()
+
+
+#endregion
+
+#region Private ####################################################################################
+func _adjust_nodes_text(nodes_array: Array) -> void:
+	for node: Node in nodes_array:
+		_adjust_nodes_text(node.get_children())
+		if not node.get("text") or not typeof(node.get("text")) == TYPE_STRING: continue
+		if node.text.length() % 2 != 0:
+			node.text += " "
+			prints(node.text, node.size)
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
@@ -38,8 +38,10 @@ func _ready():
 	D.dialog_finished.connect(_on_dialog_finished)
 	I.item_selected.connect(_on_inventory_item_selected)
 	
-#	if E.settings.scale_gui:
-#		$MainContainer.scale = E.scale
+	if E.settings.scale_gui:
+		size = get_viewport_rect().size / E.scale
+		scale = E.scale
+		texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
@@ -41,6 +41,9 @@ func _ready():
 	if E.settings.scale_gui:
 		size = get_viewport_rect().size / E.scale
 		scale = E.scale
+		# Apply this filter so the font doesn't blur
+		# NOTE: Maybe here we should take into account if the game is marked as Pixel (or if the
+		# 		font is the default one.
 		texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.tscn
@@ -172,7 +172,6 @@ size_flags_vertical = 3
 theme = ExtResource("1_kdcwt")
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-theme_override_font_sizes/normal_font_size = 12
 fit_content = true
 script = ExtResource("10_kg6cq")
 follows_cursor = true

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
@@ -2,39 +2,48 @@ extends PopochiuHoverText
 
 @export var follows_cursor := false
 
+var _gui_width := 0.0
+var _gui_height := 0.0
+
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready() -> void:
 	super()
 	
+	_gui_width = E.width
+	_gui_height = E.height
+	
+	if E.settings.scale_gui:
+		_gui_width /= E.scale.x
+		_gui_height /= E.scale.y
+	
 	E.current_command = NineVerbCommands.Commands.WALK_TO
 	_show_text()
 	
 	set_process(follows_cursor)
-	autowrap_mode = (
-		TextServer.AUTOWRAP_OFF
-		if follows_cursor
-		else TextServer.AUTOWRAP_WORD_SMART
-	)
+	autowrap_mode = TextServer.AUTOWRAP_OFF if follows_cursor else TextServer.AUTOWRAP_WORD_SMART
 
 
 func _process(delta: float) -> void:
 	position = get_viewport().get_mouse_position()
+	
+	if E.settings.scale_gui:
+		position /= E.scale
+	
 	position -= size / 2.0
-	# TODO: Make this value depend of the height of the cursor or a value in
-	#       a settings file.
-	position.y -= 16.0
+	# TODO: Make this value depend of the height of the cursor or a value in a settings file.
+	position.y -= Cursor.get_cursor_height() / 2
 	
 	# Check viewport limits
 	if position.x < 0.0:
 		position.x = 0.0
-	elif position.x + size.x > E.width:
-		position.x = E.width - size.x
+	elif position.x + size.x > _gui_width:
+		position.x = _gui_width - size.x
 	
 	if position.y < 0.0:
 		position.y = 0.0
-	elif position.y + size.y > E.height:
-		position.y = E.height - size.y
+	elif position.y + size.y > _gui_height:
+		position.y = _gui_height - size.y
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
@@ -58,6 +67,4 @@ func _show_text(txt := "") -> void:
 		super(txt)
 	
 	if follows_cursor:
-		# TODO: Make this value depend of the height of the cursor or a value in
-	#       a settings file.
-		size += Vector2.ONE * 16.0
+		size += Vector2.ONE * (Cursor.get_cursor_height() / 2)

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
@@ -6,7 +6,7 @@ var _gui_width := 0.0
 var _gui_height := 0.0
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -45,7 +45,9 @@ func _process(delta: float) -> void:
 		position.y = _gui_height - size.y
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _show_text(txt := "") -> void:
 	text = ""
 	
@@ -67,3 +69,6 @@ func _show_text(txt := "") -> void:
 	
 	if follows_cursor:
 		size += Vector2.ONE * (Cursor.get_cursor_height() / 2)
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
@@ -31,7 +31,6 @@ func _process(delta: float) -> void:
 		position /= E.scale
 	
 	position -= size / 2.0
-	# TODO: Make this value depend of the height of the cursor or a value in a settings file.
 	position.y -= Cursor.get_cursor_height() / 2
 	
 	# Check viewport limits

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_inventory_grid/9_verb_inventory_grid.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_inventory_grid/9_verb_inventory_grid.tscn
@@ -39,8 +39,9 @@ atlas = ExtResource("3_uqfpl")
 region = Rect2(48, 0, 16, 16)
 
 [node name="9VerbInventoryGrid" type="HBoxContainer"]
-offset_right = 158.0
-offset_bottom = 52.0
+custom_minimum_size = Vector2(191, 49)
+offset_right = 191.0
+offset_bottom = 49.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 0

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_inventory_grid/9_verb_inventory_slot.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_inventory_grid/9_verb_inventory_slot.tscn
@@ -1,8 +1,8 @@
 [gd_scene format=3 uid="uid://b4juyi6em7wja"]
 
 [node name="9VerbInventorySlot" type="PanelContainer"]
-custom_minimum_size = Vector2(0, 25)
-offset_right = 31.0
-offset_bottom = 25.0
+custom_minimum_size = Vector2(40, 24)
+offset_right = 40.0
+offset_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_panel/9_verb_panel.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_panel/9_verb_panel.tscn
@@ -16,7 +16,7 @@ anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_top = -48.0
+offset_top = -64.0
 grow_horizontal = 2
 grow_vertical = 0
 mouse_filter = 2
@@ -27,16 +27,16 @@ metadata/_edit_group_ = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
-theme_override_constants/separation = 0
+theme_override_constants/separation = 1
+alignment = 2
 
 [node name="HoverTextCentered" parent="VBoxContainer" instance=ExtResource("1_8t0fs")]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 size_flags_vertical = 3
+theme = ExtResource("1_8cwro")
 theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 4
-theme_override_font_sizes/normal_font_size = 12
 fit_content = true
 script = ExtResource("2_qt1af")
 follows_cursor = false
@@ -46,6 +46,8 @@ layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/Verbs&InventoryContainer"]
 layout_mode = 2
+size_flags_vertical = 8
+theme_override_constants/separation = 0
 
 [node name="CommandsContainer" type="GridContainer" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer"]
 unique_name_in_owner = true
@@ -59,7 +61,7 @@ script = ExtResource("3_q8l3d")
 [node name="Open" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Open"
@@ -69,7 +71,7 @@ command = 1
 [node name="PickUp" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Pick Up"
@@ -79,7 +81,7 @@ command = 2
 [node name="Push" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Push"
@@ -89,7 +91,7 @@ command = 3
 [node name="Close" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Close"
@@ -99,7 +101,7 @@ command = 4
 [node name="LookAt" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Look At"
@@ -109,7 +111,7 @@ command = 5
 [node name="Pull" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Pull"
@@ -119,7 +121,7 @@ command = 6
 [node name="Give" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Give"
@@ -129,7 +131,7 @@ command = 7
 [node name="TalkTo" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Talk To"
@@ -139,7 +141,7 @@ command = 8
 [node name="Use" type="Button" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer/CommandsContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_font_sizes/font_size = 12
+theme_override_font_sizes/font_size = 15
 toggle_mode = true
 button_group = ExtResource("4_6lnif")
 text = "Use"
@@ -148,3 +150,4 @@ command = 9
 
 [node name="9VerbInventoryGrid" parent="VBoxContainer/Verbs&InventoryContainer/HBoxContainer" instance=ExtResource("6_r1cmu")]
 layout_mode = 2
+size_flags_horizontal = 1

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/commands_container/9_verb_command_button.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/commands_container/9_verb_command_button.gd
@@ -3,12 +3,17 @@ extends Button
 @export var command: NineVerbCommands.Commands = NineVerbCommands.Commands.WALK_TO
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	pressed.connect(_on_pressed)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _on_pressed() -> void:
 	E.current_command = command
 	G.show_hover_text()
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/commands_container/9_verb_commands_container.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/commands_container/9_verb_commands_container.gd
@@ -22,7 +22,6 @@ func highlight_command(command: int, highlighted := true) -> void:
 	
 	if btn:
 		btn.grab_focus() if highlighted else btn.release_focus()
-		#btn.set_pressed_no_signal(highlighted)
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.gd
@@ -3,6 +3,7 @@ extends PopochiuPopup
 signal quit_pressed
 signal classic_sentence_toggled(pressed)
 
+@onready var classic_sentence: CheckButton = %ClassicSentence
 @onready var save: Button = %Save
 @onready var load: Button = %Load
 @onready var history: Button = %History
@@ -18,7 +19,7 @@ func _ready() -> void:
 	load.pressed.connect(_on_load_pressed)
 	history.pressed.connect(_on_history_pressed)
 	quit.pressed.connect(_on_quit_pressed)
-	%ClassicSentence.toggled.connect(_on_classic_sentence_toggled)
+	classic_sentence.toggled.connect(_on_classic_sentence_toggled)
 	
 	if OS.has_feature("web"):
 		quit.hide()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.tscn
@@ -27,6 +27,7 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_roir4")
 script = ExtResource("2_fpv5p")
 
 [node name="PopupPanel" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(264, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -72,6 +73,7 @@ tooltip_text = "Show hover text centered"
 text = "Classic sentence"
 
 [node name="Buttons" type="VBoxContainer" parent="PopupPanel/VBoxContainer/OptionsContainer"]
+custom_minimum_size = Vector2(96, 0)
 layout_mode = 2
 
 [node name="Save" type="Button" parent="PopupPanel/VBoxContainer/OptionsContainer/Buttons"]

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.tscn
@@ -73,6 +73,7 @@ tooltip_text = "Show hover text centered"
 text = "Classic sentence"
 
 [node name="Buttons" type="VBoxContainer" parent="PopupPanel/VBoxContainer/OptionsContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(96, 0)
 layout_mode = 2
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/resources/9_verb_theme.tres
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/resources/9_verb_theme.tres
@@ -6,58 +6,58 @@
 [ext_resource type="Texture2D" uid="uid://dukr75slqli45" path="res://addons/popochiu/engine/objects/graphic_interface/resources/sprites/check_button_unchecked.png" id="3_v1wp4"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5x338"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_w1gq5"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_obedf"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_bqsem"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_p66r8"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ud0f1"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_2rny4"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_vor3l"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_3vypu"]
-content_margin_left = 8.0
-content_margin_top = 4.0
-content_margin_right = 8.0
-content_margin_bottom = 4.0
+content_margin_left = 4.0
+content_margin_top = 2.0
+content_margin_right = 4.0
+content_margin_bottom = 3.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pr0tq"]
 bg_color = Color(0.698039, 0.698039, 0.698039, 1)

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_bar/sierra_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_bar/sierra_bar.gd
@@ -7,7 +7,7 @@ extends PanelContainer
 @onready var lbl_score: Label = %LblScore
 
 
-#region Public #################################################################
+#region Public #####################################################################################
 func set_game_name(game_name: String) -> void:
 	lbl_game_name.text = game_name
 
@@ -29,7 +29,7 @@ func subtract_score(value: int) -> void:
 
 #endregion
 
-#region Public #################################################################
+#region Private ####################################################################################
 func _update_text() -> void:
 	lbl_score.text = "%d/%d" % [score, max_score]
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_command_button/sierra_command_button.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_command_button/sierra_command_button.gd
@@ -3,12 +3,17 @@ extends TextureButton
 @export var command: SierraCommands.Commands = 0
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	toggled.connect(on_toggled)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#endregion
+
+#region Public #####################################################################################
 func on_toggled(button_pressed: bool) -> void:
 	if button_pressed:
 		E.current_command = command
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_slot/sierra_inventory_slot.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_slot/sierra_inventory_slot.gd
@@ -18,6 +18,14 @@ func _ready() -> void:
 
 #endregion
 
+#region Public #####################################################################################
+func get_content_height() -> float:
+	# Subtract the value of the sum of the top and bottom borders of the StyleBoxFlat of this slot
+	return size.y - 2
+
+
+#endregion
+
 #region Private ####################################################################################
 func _on_mouse_entered() -> void:
 	_style_box_flat.border_color = Color("edf171")

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_commands_container.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_commands_container.gd
@@ -1,15 +1,20 @@
 extends HBoxContainer
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
+#region Godot ######################################################################################
 func _ready() -> void:
 	E.command_selected.connect(_on_command_selected)
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#endregion
+
+#region Public #####################################################################################
 func _on_command_selected() -> void:
 	for b in get_children():
 		(b as TextureButton).set_pressed_no_signal(false)
 	
 	(get_child(E.current_command) as TextureButton).set_pressed_no_signal(true)
 	Cursor.show_cursor(E.get_current_command_name().to_snake_case())
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_menu.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_menu.gd
@@ -19,13 +19,24 @@ func _input(event: InputEvent) -> void:
 	if G.is_blocked: return
 	
 	if event is InputEventMouseMotion:
-		if get_global_mouse_position().y < 16.0:
+		var rect := get_rect()
+		
+		if E.settings.scale_gui:
+			rect = Rect2(
+				get_rect().position * E.scale,
+				(Vector2(
+					get_rect().size.x,
+					get_rect().size.y if visible else get_rect().size.y / 2.0
+				)) * E.scale
+			)
+		
+		if not visible and rect.has_point(get_global_mouse_position()):
 			# Show the top menu
 			if not I.active:
 				Cursor.show_cursor("gui")
 			
 			show()
-		elif get_global_mouse_position().y > size.y and visible:
+		elif visible and not rect.has_point(get_global_mouse_position()):
 			# Hide the top menu
 			if not I.active:
 				Cursor.show_cursor(E.get_current_command_name().to_snake_case())

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_settings_popup/sierra_settings_popup.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_settings_popup/sierra_settings_popup.tscn
@@ -20,6 +20,7 @@ script = ExtResource("2_3iqg8")
 script_name = &"SierraSettingsPopup"
 
 [node name="PopupPanel" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(120, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
@@ -49,6 +50,7 @@ texture_pressed = ExtResource("4_38rye")
 texture_hover = ExtResource("4_38rye")
 
 [node name="BodyContainer" type="VBoxContainer" parent="PopupPanel/VBoxContainer"]
+custom_minimum_size = Vector2(112, 0)
 layout_mode = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="PopupPanel/VBoxContainer/BodyContainer"]

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/text_popup/sierra_text_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/text_popup/sierra_text_popup.gd
@@ -5,6 +5,7 @@ extends PopochiuPopup
 @onready var continue_mode: CheckBox = %ContinueMode
 
 
+#region Godot ######################################################################################
 func _ready() -> void:
 	super()
 	
@@ -18,6 +19,9 @@ func _ready() -> void:
 	continue_mode.toggled.connect(_on_continue_mode_toggled)
 
 
+#endregion
+
+#region Private ####################################################################################
 func _on_text_speed_changed(value: float) -> void:
 	E.text_speed = 0.1 - value
 
@@ -28,3 +32,6 @@ func _on_dialog_style_selected(idx: int) -> void:
 
 func _on_continue_mode_toggled(toggled_on: bool) -> void:
 	E.settings.auto_continue_text = toggled_on
+
+
+#endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
@@ -101,8 +101,8 @@ func _on_dialog_finished(_dialog: PopochiuDialog) -> void:
 ## default cursor.
 func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	if is_instance_valid(item):
-		Cursor.hide_main_cursor()
 		Cursor.set_secondary_cursor_texture(item.texture, true)
+		Cursor.hide_main_cursor()
 	else:
 		Cursor.remove_secondary_cursor_texture()
 		Cursor.show_cursor()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_auto.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_auto.gd
@@ -1,7 +1,7 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 @export var btn_states := [] # (Array, Texture2D)
-@export var states_descriptions := ['manual', 'auto']
+@export var states_descriptions := ["manual", "auto"]
 
 
 #region Godot ######################################################################################
@@ -24,7 +24,7 @@ func _on_pressed() -> void:
 
 #region SetGet #####################################################################################
 func get_description() -> String:
-	return '%s: %s' % [description, states_descriptions[1 if E.settings.auto_continue_text else 0]]
+	return "%s: %s" % [description, states_descriptions[1 if E.settings.auto_continue_text else 0]]
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_history.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_history.gd
@@ -1,4 +1,4 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 
 #region Virtual ####################################################################################

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd
@@ -1,5 +1,5 @@
 @tool
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 const TextSpeedOption = preload(
 	PopochiuResources.GUI_TEMPLATES_FOLDER
@@ -17,6 +17,10 @@ func _ready() -> void:
 		return
 	
 	super()
+	
+	if speed_options.is_empty():
+		hide()
+	
 	texture_normal = (speed_options[_speed_idx] as TextSpeedOption).icon
 
 
@@ -35,7 +39,7 @@ func get_description() -> String:
 	if speed_options.is_empty() or Engine.is_editor_hint():
 		return description
 	
-	return '%s: %s' % [description, (speed_options[_speed_idx] as TextSpeedOption).description]
+	return "%s: %s" % [description, (speed_options[_speed_idx] as TextSpeedOption).description]
 
 
 func set_speed_options(value: Array) -> void:
@@ -47,6 +51,11 @@ func set_speed_options(value: Array) -> void:
 			x.resource_name = "Speed %d" % idx
 			
 			value[idx] = x
+	
+	if speed_options.is_empty():
+		texture_normal = null
+	else:
+		texture_normal = speed_options[0].icon
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_load.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_load.gd
@@ -1,4 +1,4 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 
 #region Godot ######################################################################################

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_quit.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_quit.gd
@@ -1,4 +1,4 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 #region Godot ######################################################################################
 func _ready() -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_save.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_save.gd
@@ -1,4 +1,4 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 
 #region Virtual ####################################################################################

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_sound_settings.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_sound_settings.gd
@@ -1,4 +1,4 @@
-extends 'settings_bar_button.gd'
+extends "settings_bar_button.gd"
 
 
 #region Virtual ####################################################################################

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/settings_bar_button.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/settings_bar_button.gd
@@ -1,7 +1,7 @@
 extends TextureButton
 
-@export var description := '' : get = get_description
-@export var script_name := ''
+@export var description := "" : get = get_description
+@export var script_name := ""
 
 
 #region Godot ######################################################################################

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
@@ -1,6 +1,9 @@
 extends PanelContainer
 
-const ToolbarButton := preload('buttons/settings_bar_button.gd')
+const ToolbarButton := preload(
+	PopochiuResources.GUI_TEMPLATES_FOLDER +
+	"simple_click/components/settings_bar/buttons/settings_bar_button.gd"
+)
 
 @export var used_in_game := true
 @export var always_visible := false
@@ -11,9 +14,9 @@ var _can_hide := true
 var _is_hidden := true
 
 @onready var _tween: Tween = null
-@onready var _box: BoxContainer = find_child('Box')
-@onready var _btn_dialog_speed: ToolbarButton = find_child('BtnDialogSpeed')
-@onready var _btn_power: ToolbarButton = find_child('BtnQuit')
+@onready var _box: BoxContainer = find_child("Box")
+@onready var _btn_dialog_speed: ToolbarButton = find_child("BtnDialogSpeed")
+@onready var _btn_power: ToolbarButton = find_child("BtnQuit")
 @onready var _hide_y := position.y - (size.y - 4)
 
 
@@ -71,7 +74,7 @@ func _open() -> void:
 		_tween.kill()
 	
 	_tween = create_tween()
-	_tween.tween_property(self, 'position:y', 0.0, 0.5)\
+	_tween.tween_property(self, "position:y", 0.0, 0.5)\
 	.from(_hide_y if not is_disabled else position.y)\
 	.set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
 	
@@ -92,7 +95,7 @@ func _close() -> void:
 	
 	_tween = create_tween()
 	_tween.tween_property(
-		self, 'position:y',
+		self, "position:y",
 		_hide_y if not is_disabled else _hide_y - 3.5,
 		0.2
 	).from(0.0).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
@@ -41,10 +41,15 @@ func _ready() -> void:
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventMouseMotion:
-		if _is_hidden and get_rect().has_point(get_global_mouse_position()):
+		var rect := get_rect()
+		
+		if E.settings.scale_gui:
+			rect = Rect2(get_rect().position * E.scale, get_rect().size * E.scale)
+		
+		if _is_hidden and rect.has_point(get_global_mouse_position()):
 			_open()
 		elif not _is_hidden\
-		and not get_rect().has_point(get_global_mouse_position()):
+		and not rect.has_point(get_global_mouse_position()):
 			_close()
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.tscn
@@ -81,7 +81,6 @@ script_name = "LoadGame"
 
 [node name="BtnDialogSpeed" type="TextureButton" parent="Box"]
 layout_mode = 2
-texture_normal = ExtResource("7_otoev")
 script = ExtResource("8_xj7pu")
 speed_options = [SubResource("Resource_ie5nq"), SubResource("Resource_dhkav"), SubResource("Resource_kqq7u")]
 description = "Text speed"

--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -94,8 +94,8 @@ func _enter_tree() -> void:
 	# ==== Connect to signals ======================================================================
 	_editor_interface.get_file_system_dock().file_removed.connect(_on_file_removed)
 	_editor_interface.get_file_system_dock().files_moved.connect(_on_files_moved)
-	# TODO: This connection might be needed only by TabAudio.gd, so probably
-	# would be better if it is done there
+	# TODO: This connection might be needed only by TabAudio.gd, so probably would be better if it
+	# is done there
 	_editor_file_system.sources_changed.connect(_on_sources_changed)
 	
 	scene_changed.connect(main_dock.scene_changed)
@@ -114,9 +114,7 @@ func _enter_tree() -> void:
 	# the plugin or if there is no GUI scene (template) selected.
 	if not (PopochiuResources.is_setup_done() or PopochiuResources.is_gui_set()):
 		main_dock.setup_dialog.appear(true)
-		(main_dock.setup_dialog as AcceptDialog).confirmed.connect(
-			_set_setup_done
-		)
+		(main_dock.setup_dialog as AcceptDialog).confirmed.connect(_set_setup_done)
 	
 	PopochiuResources.update_autoloads(true)
 	_editor_file_system.scan_sources()

--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -35,7 +35,7 @@ const MAIN_TYPES := [
 	Types.ROOM, Types.CHARACTER, Types.INVENTORY_ITEM, Types.DIALOG
 ]
 const ROOM_TYPES := [Types.PROP, Types.HOTSPOT, Types.REGION, Types.MARKER, Types.WALKABLE_AREA]
-const WIKI := "https://github.com/mapedorr/popochiu/wiki/"
+const DOCUMENTATION := "https://carenalgas.github.io/popochiu/"
 const CFG := "res://addons/popochiu/plugin.cfg"
 const GUI_SCRIPT_TEMPLATES_FOLDER := "res://addons/popochiu/engine/templates/graphic_interface/"
 const GUI_TEMPLATES_FOLDER := "res://addons/popochiu/engine/objects/graphic_interface/templates/"


### PR DESCRIPTION
Makes `PopochiuSettings.scale_gui` to be taken into account by the plugin to scale the GUI. It also makes this scaling work on the 3 templates available so far.

[Here](https://mega.nz/folder/frQzFQqD#lWMaQNnBP0l6Dm-yu5ymng) are the some assets you can use to create the scene to test creating a game in HD (1280x720).

## How the scaling works (open to discussion):

1. If scaling is enabled, Popochiu sets the size of the GUI (the root node in the `res://game/graphic_interface/graphic_interface.tscn`) to its original size (320x180) **during runtime**, and then scales that node to the value calculated in the Setup window.
2. Some GUI components take this scale value into account to change the way elements are rendered:
    - **InventoryBar** and **InventoryGrid** make the texture of items to expand (using `TextureRect.EXPAND_FIT_WIDTH`) so they fit the height of the inventory slot. I made this to assure devs don't have to design their assets (in this case the PNGs of each inventory item) in a smaller size. E.j. if the image of each inventory item is 64x64, it will be scaled up during runtime because the whole GUI is scaled up.
    - **Cursor** scales the texture of selected inventory items (this affects the Sierra and 2-click Context-sensitive GUIs) to match the height of the texture used in by the main cursor (this is the cursor used by default, when no inventory item is selected). Similar to the previous point, this ensures that the texture used by the secondary cursor (the one used to render selected inventory items) doesn't look bigger than the one used by the main cursor.


## Known issues with this approach

- Devs will have to know that the images for the inventory items will be scaled down by Popochiu during runtime.
- It is hard to know the right amount of space occupied by the GUI when editing the `.tscn` files inside `res://game/graphic_interface`. Since the scaling is done during runtime, this is how the GUI looks in the Editor:
  
  ![image](https://github.com/carenalgas/popochiu/assets/4536477/624db256-8e91-4c7b-b0af-da741acf936b)

  ☝️ **This is the one that concerns me the most at the moment** 🙈 .

- Godot has some issues rendering fonts. So, not all of them will look good. Most are readable, but others look weird. Here's an example of how the Settings window in the 9 Verb GUI is rendered in a Full HD (1280x720) game (look how "Resume Game" is rendered):

  ![image](https://github.com/carenalgas/popochiu/assets/4536477/e33e4930-0e33-45ef-9ed5-31376115199c)


## Other approaches I've been thinking of

- More than scaling, is having a different theme for each GUI template in which the font and the assets are designed for HD (or Full HD) games and beyond.
- Instead of scaling the GUI at runtime, we could scale the components (I'm referring to the root nodes inside the .tscn files) that are copied to the `res://game/graphic_interface/` folder. This way, developers will see that the scenes are scaled in the Editor itself.

