### PR TITLE
Fix #191

### DIFF
--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -186,9 +186,11 @@ func exit_room() -> void:
 func add_character(chr: PopochiuCharacter) -> void:
 	$Characters.add_child(chr)
 	
-	# Add child nodes (defined in the Scene tree of the room) to the instance of the character
-	for child: Node in _characters_childs[chr.script_name]:
-		chr.add_child(child)
+	# Fix #191 by checking if the character had childs defined in the Room's Scene (Editor)
+	if _characters_childs.has(chr.script_name):
+		# Add child nodes (defined in the Scene tree of the room) to the instance of the character
+		for child: Node in _characters_childs[chr.script_name]:
+			chr.add_child(child)
 	
 	#warning-ignore:return_value_discarded
 	chr.started_walk_to.connect(_update_navigation_path)

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -459,10 +459,15 @@ func room_readied(room: PopochiuRoom) -> void:
 	
 	# If the room must have the player character but it is not part of its $Characters node, then
 	# add the PopochiuCharacter to the room
-	if current_room.has_player and is_instance_valid(C.player):
-		if not current_room.has_character(C.player.script_name):
-			current_room.add_character(C.player)
-			await C.player.idle()
+	if (
+		current_room.has_player
+		and is_instance_valid(C.player)
+		and not current_room.has_character(C.player.script_name)
+	):
+		current_room.add_character(C.player)
+		# Place the PC in the middle of the room
+		C.player.position = Vector2(width, height) / 2.0
+		await C.player.idle()
 	
 	# Load the state of Props, Hotspots, Regions and WalkableAreas
 	for type in PopochiuResources.ROOM_CHILDS:


### PR DESCRIPTION
Checks if the characters exists in the Dictionary used to add child nodes defined for a Character in the .tscn file of the room.

[upd] The PC is positioned in the center of the viewport if it was added to the room during runtime.