### PR TITLE
Fix #196

### DIFF
--- a/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
+++ b/addons/popochiu/editor/main_dock/object_row/popochiu_object_row.gd
@@ -200,15 +200,11 @@ func show_add_to_core() -> void:
 
 func show_create_state_script() -> void:
 	btn_state_script.disabled = true
-	menu_popup.set_item_disabled(
-		menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT), false
-	)
+	menu_popup.set_item_disabled(menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT), false)
 
 
 func remove_create_state_script() -> void:
-	menu_popup.remove_item(
-		menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT)
-	)
+	menu_popup.remove_item(menu_popup.get_item_index(MenuOptions.CREATE_STATE_SCRIPT))
 
 
 func remove_menu_option(opt: int) -> void:
@@ -496,6 +492,8 @@ func _search_audio_files(dir: EditorFileSystemDirectory) -> Array:
 
 
 func _remove_from_core() -> void:
+	var room_child_to_free: Node = null
+	
 	# Delete the object from Popochiu
 	match type:
 		Constants.Types.ROOM:
@@ -519,24 +517,13 @@ func _remove_from_core() -> void:
 			if is_instance_valid(opened_room):
 				match type:
 					Constants.Types.PROP:
-						opened_room.get_prop(str(name)).queue_free()
+						room_child_to_free = opened_room.get_prop(str(name))
 					Constants.Types.HOTSPOT:
-						opened_room.get_hotspot(str(name)).queue_free()
+						room_child_to_free = opened_room.get_hotspot(str(name))
 					Constants.Types.REGION:
-						opened_room.get_region(str(name)).queue_free()
+						room_child_to_free = opened_room.get_region(str(name))
 					Constants.Types.WALKABLE_AREA:
-						opened_room.get_walkable_area(str(name)).queue_free()
-				
-				# Delete the row of the deleted object
-				queue_free()
-				
-				await opened_room.get_tree().process_frame
-				
-				# Save the changes in the scene
-				EditorInterface.save_scene()
-			else:
-				# TODO: open the Room' scene, delete the node and save the Room
-				pass
+						room_child_to_free = opened_room.get_walkable_area(str(name))
 			
 			# TODO: If it is a non-interactable Object, just delete the node from the
 			# scene, and maybe its sprite?
@@ -553,6 +540,12 @@ func _remove_from_core() -> void:
 		queue_free()
 	
 	_disconnect_popup()
+	
+	# Fix #196 by removing the node from the Room scene after (if it is the case) deleting the
+	# folder of the node (this applies to Props, Hotspots, Walkable areas and Regions).
+	if room_child_to_free:
+		room_child_to_free.queue_free()
+		await RenderingServer.frame_post_draw
 	
 	if (
 		EditorInterface.get_edited_scene_root()

--- a/addons/popochiu/editor/main_dock/popochiu_dock.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.gd
@@ -237,6 +237,12 @@ func show_confirmation(
 		delete_extra.show()
 	
 	delete_dialog.popup_centered(min_size)
+	
+	await RenderingServer.frame_post_draw
+	delete_dialog.reset_size()
+	
+	await RenderingServer.frame_post_draw
+	delete_dialog.move_to_center()
 
 
 func get_popup(name: String) -> ConfirmationDialog:

--- a/addons/popochiu/editor/main_dock/popochiu_dock.tscn
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.tscn
@@ -22,7 +22,7 @@
 [ext_resource type="PackedScene" uid="uid://c3r8juwutb1gr" path="res://addons/popochiu/editor/popups/setup/setup.tscn" id="18"]
 [ext_resource type="PackedScene" uid="uid://c054k1ux04waq" path="res://addons/popochiu/editor/popups/create_walkable_area/create_walkable_area.tscn" id="19"]
 
-[sub_resource type="Image" id="Image_38sah"]
+[sub_resource type="Image" id="Image_h206q"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -31,10 +31,10 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_tkd8e"]
-image = SubResource("Image_38sah")
+[sub_resource type="ImageTexture" id="ImageTexture_kg4hx"]
+image = SubResource("Image_h206q")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7msis"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lery6"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -44,7 +44,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.439216, 0.427451, 0.921569, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_b1oqb"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vr205"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -54,7 +54,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.556863, 0.313726, 0.160784, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_u7lwd"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3ycgn"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -64,7 +64,7 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.337255, 0.67451, 0.301961, 0.74902)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7strt"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tnt20"]
 content_margin_left = 8.0
 content_margin_right = 8.0
 draw_center = false
@@ -111,7 +111,7 @@ focus_mode = 2
 layout_mode = 2
 placeholder_text = "Filter Popochiu objects"
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_tkd8e")
+right_icon = SubResource("ImageTexture_kg4hx")
 script = ExtResource("2_i87mb")
 
 [node name="MainScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer/TabContainer/Main"]
@@ -127,7 +127,7 @@ size_flags_vertical = 3
 
 [node name="RoomsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_7msis")
+theme_override_styles/panel = SubResource("StyleBoxFlat_lery6")
 icon = ExtResource("3_uwncn")
 color = Color(0.439216, 0.427451, 0.921569, 0.74902)
 title = "Rooms"
@@ -135,7 +135,7 @@ create_text = "Create room"
 
 [node name="CharactersGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_b1oqb")
+theme_override_styles/panel = SubResource("StyleBoxFlat_vr205")
 icon = ExtResource("4_h14xk")
 color = Color(0.556863, 0.313726, 0.160784, 0.74902)
 title = "Characters"
@@ -143,7 +143,7 @@ create_text = "Create character"
 
 [node name="ItemsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_u7lwd")
+theme_override_styles/panel = SubResource("StyleBoxFlat_3ycgn")
 icon = ExtResource("5_ritjh")
 color = Color(0.337255, 0.67451, 0.301961, 0.74902)
 title = "Inventory items"
@@ -151,7 +151,7 @@ create_text = "Create inventory item"
 
 [node name="DialogsGroup" parent="MarginContainer/VBoxContainer/TabContainer/Main/MainScrollContainer/VBoxContainer" instance=ExtResource("4")]
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_7strt")
+theme_override_styles/panel = SubResource("StyleBoxFlat_tnt20")
 icon = ExtResource("6_evjo7")
 color = Color(0.556863, 0.235294, 0.592157, 0.74902)
 title = "Dialog trees"
@@ -183,25 +183,25 @@ alignment = 2
 [node name="Version" type="Label" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "v2.0-beta_1"
+text = "v2.0-beta_3"
 
 [node name="BtnSetup" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Setup"
-icon = SubResource("ImageTexture_tkd8e")
+icon = SubResource("ImageTexture_kg4hx")
 
 [node name="BtnSettings" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Settings"
-icon = SubResource("ImageTexture_tkd8e")
+icon = SubResource("ImageTexture_kg4hx")
 
 [node name="BtnDocs" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Documentation"
-icon = SubResource("ImageTexture_tkd8e")
+icon = SubResource("ImageTexture_kg4hx")
 
 [node name="Popups" type="Control" parent="."]
 layout_mode = 3
@@ -233,7 +233,6 @@ title = "Create Walkable area"
 
 [node name="DeleteConfirmation" parent="Popups" instance=ExtResource("17")]
 title = "Delete?"
-size = Vector2i(656, 1142)
 
 [node name="Loading" parent="Popups" instance=ExtResource("16")]
 title = "Loading...."

--- a/addons/popochiu/editor/main_dock/tab_room.gd
+++ b/addons/popochiu/editor/main_dock/tab_room.gd
@@ -285,28 +285,18 @@ func _on_remove_character_pressed(row: PopochiuObjectRow) -> void:
 		Vector2(200, 120)
 	)
 	
-	_remove_dialog.confirmed.connect(
-		_on_remove_character_confirmed.bind(row)
-	)
+	_remove_dialog.confirmed.connect(_on_remove_character_confirmed.bind(row))
 	_remove_dialog.canceled.connect(_on_remove_dialog_hide)
 
 
 func _on_remove_dialog_hide() -> void:
-	_remove_dialog.call_deferred(
-		'disconnect',
-		'confirmed', _on_remove_character_confirmed
-	)
-	_remove_dialog.call_deferred(
-		'disconnect',
-		'canceled', _on_remove_dialog_hide
-	)
+	_remove_dialog.call_deferred('disconnect', 'confirmed', _on_remove_character_confirmed)
+	_remove_dialog.call_deferred('disconnect', 'canceled', _on_remove_dialog_hide)
 
 
 func _on_remove_character_confirmed(row: PopochiuObjectRow) -> void:
 	_characters_in_room.erase(str(row.name))
-	opened_room.get_node('Characters').get_node(
-		'Character%s *' % row.name
-	).queue_free()
+	opened_room.get_node('Characters').get_node('Character%s *' % row.name).queue_free()
 	row.queue_free()
 	EditorInterface.save_scene()
 	

--- a/addons/popochiu/editor/popups/delete_confirmation/delete_confirmation.tscn
+++ b/addons/popochiu/editor/popups/delete_confirmation/delete_confirmation.tscn
@@ -4,6 +4,7 @@
 
 [node name="DeleteConfirmation" type="ConfirmationDialog"]
 size = Vector2i(656, 108)
+dialog_autowrap = true
 script = ExtResource("1_j7hpd")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -129,7 +129,6 @@ func _unhandled_input(event: InputEvent):
 		return
 	
 	if not event is InputEventScreenTouch and E.hovered:
-		prints("ayyyyyyyyyyyyyyyyyyy")
 		return
 	
 	if is_instance_valid(C.player) and C.player.can_move:


### PR DESCRIPTION
When deleting Props, Hotspots, Walkable areas and Regions, and checking the box to delete the object's folder in the FileSystem, the node in the Scene tree (Editor) is removed once the folder is deleted, so removing the node from the tree doesn't break the process.

[fix] The DeletionConfirmation popup resizes and centers on the screen when opened to avoid rendering its buttons out of screen.