### PR TITLE
Move 2-click Context-sensitive GUI settings out of ProjectSettings

### DIFF
--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -14,8 +14,6 @@ enum DialogStyle {
 # Godot's ProjectSettings instead of using a Resource file.
 # ---- GUI -----------------------------------------------------------------------------------------
 const SCALE_GUI = "popochiu/gui/experimental_scale_gui"
-const INVENTORY_ALWAYS_VISIBLE = "popochiu/gui/inventory_always_visible"
-const TOOLBAR_ALWAYS_VISIBLE = "popochiu/gui/toolbar_always_visible"
 const FADE_COLOR = "popochiu/gui/fade_color"
 const SKIP_CUTSCENE_TIME = "popochiu/gui/skip_cutscene_time"
 const DIALOG_STYLE = "popochiu/gui/dialog_style"
@@ -46,12 +44,6 @@ const PIXEL_PERFECT = "popochiu/pixel/pixel_perfect"
 static func initialize_project_settings():
 	# ---- GUI -------------------------------------------------------------------------------------
 	_initialize_project_setting(SCALE_GUI, false, TYPE_BOOL)
-	# TODO: Move this to the properties of the 2-click Context-sensitive template or its InventoryBar
-	# 		component
-	_initialize_project_setting(INVENTORY_ALWAYS_VISIBLE, false, TYPE_BOOL)
-	# TODO: Move this to the properties of the 2-click Context-sensitive template or its SettingsBar
-	# 		component
-	_initialize_project_setting(TOOLBAR_ALWAYS_VISIBLE, false, TYPE_BOOL)
 	_initialize_project_setting(FADE_COLOR, Color.BLACK, TYPE_COLOR)
 	_initialize_project_setting(SKIP_CUTSCENE_TIME, 0.2, TYPE_FLOAT)
 	# ---- Dialogs ---------------------------------------------------------------------------------
@@ -88,18 +80,6 @@ static func initialize_project_settings():
 # ---- GUI -----------------------------------------------------------------------------------------
 static func is_scale_gui() -> bool:
 	return _get_project_setting(SCALE_GUI, false)
-
-
-# TODO: Move this to the properties of the 2-click Context-sensitive template or its InventoryBar
-# 		component
-static func is_inventory_always_visible() -> bool:
-	return _get_project_setting(INVENTORY_ALWAYS_VISIBLE, false)
-
-
-# TODO: Move this to the properties of the 2-click Context-sensitive template or its SettingsBar
-# 		component
-static func is_toolbar_always_visible() -> bool:
-	return _get_project_setting(TOOLBAR_ALWAYS_VISIBLE, false)
 
 
 static func get_fade_color() -> Color:

--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -62,7 +62,7 @@ var _has_double_click: bool = false
 #region Godot ######################################################################################
 func _ready():
 	add_to_group('PopochiuClickable')
-		
+	
 	if Engine.is_editor_hint():
 		hide_helpers()
 		
@@ -95,8 +95,9 @@ func _ready():
 			get_node("InteractionPolygon").position = interaction_polygon_position
 	
 	visibility_changed.connect(_toggle_input)
-
-	if clickable:
+	
+	# Ignore this object if it is a temporary one (its name has *)
+	if clickable and not "*" in name:
 		# Connect to own signals
 		mouse_entered.connect(_on_mouse_entered)
 		mouse_exited.connect(_on_mouse_exited)
@@ -106,7 +107,6 @@ func _ready():
 		# Connect to singleton signals
 		E.language_changed.connect(_translate)
 	
-	set_process_unhandled_input(false)
 	_translate()
 
 
@@ -318,10 +318,6 @@ func set_room(value: Node2D) -> void:
 
 #region Private ####################################################################################
 func _on_mouse_entered() -> void:
-	if G.is_blocked: return
-	
-	set_process_unhandled_input(true)
-	
 	if E.hovered and is_instance_valid(E.hovered) and (
 		E.hovered.get_parent() == self or get_index() < E.hovered.get_index()
 	):
@@ -334,8 +330,6 @@ func _on_mouse_entered() -> void:
 
 
 func _on_mouse_exited() -> void:
-	set_process_unhandled_input(false)
-	
 	last_click_button = -1
 	
 	if E.remove_hovered(self):
@@ -381,7 +375,6 @@ func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int):
 func _toggle_input() -> void:
 	if clickable:
 		input_pickable = visible
-		set_process_unhandled_input(false)
 
 
 func _translate() -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -1,5 +1,6 @@
 extends Control
-# warning-ignore-all:return_value_discarded
+
+@export var always_visible := false
 
 var is_disabled := false
 
@@ -12,7 +13,7 @@ var _is_hidden := true
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ GODOT ░░░░
 func _ready():
-	if not E.settings.inventory_always_visible:
+	if not always_visible:
 		position.y = _hidden_y
 	
 	# Connect to singletons signals
@@ -30,7 +31,7 @@ func _ready():
 			ii.in_inventory = true
 			ii.selected.connect(_change_cursor)
 	
-	set_process_input(not E.settings.inventory_always_visible)
+	set_process_input(not always_visible)
 
 
 func _input(event: InputEvent) -> void:
@@ -44,7 +45,7 @@ func _input(event: InputEvent) -> void:
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
 func _open() -> void:
-	if E.settings.inventory_always_visible: return
+	if always_visible: return
 	if not is_disabled and position.y != _hidden_y: return
 	
 	if is_instance_valid(_tween) and _tween.is_running():
@@ -59,7 +60,7 @@ func _open() -> void:
 
 
 func _close() -> void:
-	if E.settings.inventory_always_visible: return
+	if always_visible: return
 	
 	await get_tree().process_frame
 	
@@ -97,9 +98,9 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	
 	item.selected.connect(_change_cursor)
 	
-	if not E.settings.inventory_always_visible and animate:
-		# Show the inventory for a while and hide after a couple of seconds
-		# so players can see the item being added to the inventory
+	if not always_visible and animate:
+		# Show the inventory for a while and hide after a couple of seconds so players can see the
+		# item being added to the inventory
 		set_process_input(false)
 		
 		_open()
@@ -120,7 +121,7 @@ func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
 	
 	_box.remove_child(item)
 	
-	if not E.settings.inventory_always_visible:
+	if not always_visible:
 		Cursor.show_cursor()
 		G.show_hover_text()
 		
@@ -133,9 +134,7 @@ func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
 	I.item_remove_done.emit(item)
 
 
-func _replace_item(
-	item: PopochiuInventoryItem, new_item: PopochiuInventoryItem
-) -> void:
+func _replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
 	item.replace_by(new_item)
 	
 	await get_tree().process_frame

--- a/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/popochiu_graphic_interface.gd
@@ -7,6 +7,8 @@ extends Control
 
 ## Stack of opened popups.
 var popups_stack := []
+## Whether a dialog line is being displayed.
+var is_showing_dialog_line := false
 
 var _components_map := {}
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
@@ -2,8 +2,8 @@ extends PanelContainer
 
 const ToolbarButton := preload('buttons/settings_bar_button.gd')
 
-@export var script_name := ''
 @export var used_in_game := true
+@export var always_visible := false
 
 var is_disabled := false
 
@@ -19,7 +19,7 @@ var _is_hidden := true
 
 #region Godot ######################################################################################
 func _ready() -> void:
-	if not E.settings.toolbar_always_visible:
+	if not always_visible:
 		position.y = _hide_y
 	
 	# Connect to child signals
@@ -34,7 +34,7 @@ func _ready() -> void:
 	if not used_in_game:
 		hide()
 	
-	set_process_input(not E.settings.toolbar_always_visible)
+	set_process_input(not always_visible)
 	
 	size.x = $Box.size.x
 
@@ -59,7 +59,7 @@ func is_open() -> bool:
 
 #region Private ####################################################################################
 func _open() -> void:
-	if E.settings.toolbar_always_visible: return
+	if always_visible: return
 	if not is_disabled and position.y != _hide_y: return
 	
 	if is_instance_valid(_tween) and _tween.is_running():
@@ -76,7 +76,7 @@ func _open() -> void:
 
 
 func _close() -> void:
-	if E.settings.toolbar_always_visible: return
+	if always_visible: return
 	
 	await get_tree().process_frame
 	

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
@@ -43,7 +43,7 @@ func _on_system_text_hidden() -> void:
 func _on_mouse_entered_clickable(clickable: PopochiuClickable) -> void:
 	if G.is_blocked: return
 	
-	if not I.active:
+	if not (I.active or is_showing_dialog_line):
 		if clickable.get("cursor"):
 			Cursor.show_cursor(Cursor.get_type_name(clickable.cursor))
 		else:
@@ -60,11 +60,9 @@ func _on_mouse_entered_clickable(clickable: PopochiuClickable) -> void:
 ## Called when the mouse exits [param clickable]. Clears the text in the [HoverText] component and
 ## shows the default cursor texture if there is no [PopochiuInventoryItem] active.
 func _on_mouse_exited_clickable(clickable: PopochiuClickable) -> void:
-	#if G.is_blocked: return
-	
 	G.show_hover_text()
 	
-	if I.active: return
+	if I.active or is_showing_dialog_line: return
 	
 	Cursor.show_cursor()
 
@@ -104,13 +102,20 @@ func _on_mouse_exited_inventory_item(inventory_item: PopochiuInventoryItem) -> v
 
 ## Called when a dialog line starts. It shows the [code]"wait"[/code] cursor.
 func _on_dialog_line_started() -> void:
+	is_showing_dialog_line = true
 	Cursor.show_cursor("wait")
 
 
 ## Called when a dialog line finishes. It shows the [code]"normal"[/code] cursor if there is no
 ## [PopochiuDialog] active, otherwise shows the [code]"use"[/code] cursor.
 func _on_dialog_line_finished() -> void:
-	Cursor.show_cursor("use" if D.current_dialog else "normal")
+	is_showing_dialog_line = false
+	if D.current_dialog:
+		Cursor.show_cursor("use")
+	elif E.hovered:
+		Cursor.show_cursor(Cursor.get_type_name(E.hovered.cursor))
+	else:
+		Cursor.show_cursor("normal")
 
 
 ## Called when a [PopochiuDialog] starts. It shows the [code]"use"[/code] cursor and clears the

--- a/addons/popochiu/engine/objects/popochiu_settings.gd
+++ b/addons/popochiu/engine/objects/popochiu_settings.gd
@@ -23,9 +23,13 @@ var use_translations := false
 var items_on_start := []
 ## The max number of items players will be able to put in the inventory.
 var inventory_limit := 0
+## @deprecated
+## [b]NOTE[/b] This option is now a property in the InventoryBar component.
 ## Whether the inventory will be always visible, or players will have to do something to make it
 ## appear. [b]This is specific to the ContextSensitive GUI[/b].
 var inventory_always_visible := false
+## @deprecated
+## [b]NOTE[/b] This option is now a property in the SettingsBar component.
 ## Whether the toolbar (SettingsBar) will be always visible, or players will have to do something to
 ## make it appear. [b]This is specific to the ContextSensitive GUI[/b].
 var toolbar_always_visible := false
@@ -61,8 +65,6 @@ func _init() -> void:
 	use_translations = PopochiuConfig.is_use_translations()
 	items_on_start = PopochiuConfig.get_inventory_items_on_start()
 	inventory_limit = PopochiuConfig.get_inventory_limit()
-	inventory_always_visible = PopochiuConfig.is_inventory_always_visible()
-	toolbar_always_visible = PopochiuConfig.is_toolbar_always_visible()
 	fade_color = PopochiuConfig.get_fade_color()
 	scale_gui = PopochiuConfig.is_scale_gui()
 	max_dialog_options = PopochiuConfig.get_max_dialog_options()

--- a/addons/popochiu/engine/objects/room/popochiu_room_data.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room_data.gd
@@ -112,7 +112,7 @@ func save_childs_states() -> void:
 						continue
 					
 					var node: Node2D = load(script_path).new()
-					node.script_name = folder_name
+					node.script_name = folder_name.to_pascal_case()
 					
 					_save_object_state(
 						node,
@@ -138,14 +138,14 @@ func save_childs_states() -> void:
 func save_characters() -> void:
 	for c in E.current_room.get_characters():
 		var pc: PopochiuCharacter = c
-
+		
 		characters[pc.script_name] = {
 			x = pc.position.x,
 			y = pc.position.y,
 			facing = pc._looking_dir,
 			visible = pc.visible,
-			modulate = pc.modulate,
-			self_modulate = pc.self_modulate,
+			modulate = pc.modulate.to_html(),
+			self_modulate = pc.self_modulate.to_html(),
 			light_mask = pc.light_mask
 			# TODO: Store the state of the current animation (and more data if
 			# necessary)

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -442,8 +442,8 @@ func room_readied(room: PopochiuRoom) -> void:
 		chr.position = Vector2(chr_dic.x, chr_dic.y)
 		chr._looking_dir = chr_dic.facing
 		chr.visible = chr_dic.visible
-		chr.modulate = chr_dic.modulate
-		chr.self_modulate = chr_dic.self_modulate
+		chr.modulate = Color.from_string(chr_dic.modulate, Color.WHITE)
+		chr.self_modulate = Color.from_string(chr_dic.self_modulate, Color.WHITE)
 		chr.light_mask = chr_dic.light_mask
 		
 		current_room.add_character(chr)

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -497,6 +497,9 @@ func room_readied(room: PopochiuRoom) -> void:
 	if not current_room.hide_gi:
 		G.unblock()
 	
+	if hovered:
+		G.mouse_entered_clickable.emit(hovered)
+	
 	self.in_room = true
 	
 	if _loaded_game:
@@ -796,11 +799,7 @@ func remove_hovered(node: PopochiuClickable) -> bool:
 	
 	if not _hovered_queue.is_empty() and is_instance_valid(_hovered_queue[-1]):
 		var clickable: PopochiuClickable = _hovered_queue[-1]
-		G.show_hover_text(clickable.description)
-		
-		if clickable.get("cursor"):
-			Cursor.show_cursor(Cursor.get_type_name(clickable.cursor))
-		
+		G.mouse_entered_clickable.emit(clickable)
 		return false
 	
 	return true

--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -90,6 +90,10 @@ const PROPS_IGNORE := [
 	"frames",
 	"link_to_item",
 	"_description_code",
+	"editing_polygon",
+	"last_click_button",
+	"_double_click_delay",
+	"_has_double_click",
 ]
 const HOTSPOTS_IGNORE := [
 	"description",
@@ -98,6 +102,10 @@ const HOTSPOTS_IGNORE := [
 	"cursor",
 	"always_on_top",
 	"_description_code",
+	"editing_polygon",
+	"last_click_button",
+	"_double_click_delay",
+	"_has_double_click",
 ]
 const WALKABLE_AREAS_IGNORE := [
 	"description",


### PR DESCRIPTION
Now the InventoryBar and SettingsBar always on top properties are defined in each component, instead of being a GUI entry in ProjecSettings > Popochiu.

This also fixes:

- 2-click Context-sensitive mouse hovered handling when room loads.
- Popochiu emits `G.mouse_entered` so the GUI takes care of displaying the info about the hovered mouse.
- Game wasn't storing the room data properly (there were duplicated entries because of the folder name).