### PR TITLE
Add feature #202

### DIFF
--- a/addons/popochiu/editor/helpers/popochiu_gui_templates_helper.gd
+++ b/addons/popochiu/editor/helpers/popochiu_gui_templates_helper.gd
@@ -38,7 +38,7 @@ static func copy_gui_template(
 	
 	var script_path := PopochiuResources.GUI_GAME_SCENE.replace(".tscn", ".gd")
 	
-	await EditorInterface.get_base_control().get_tree().create_timer(1.0).timeout
+	await _wait()
 	on_progress.call(5, "Creating Graphic Interface scene")
 	
 	# ---- Make a copy of the selected GUI template ------------------------------------------------
@@ -50,7 +50,7 @@ static func copy_gui_template(
 		
 		return
 	
-	await EditorInterface.get_base_control().get_tree().create_timer(2.0).timeout
+	await _wait(2.0)
 	on_progress.call(10, "Copying a bunch of components")
 	
 	# Copy the components used by the GUI template to the res://game/graphic_interface/components
@@ -62,7 +62,7 @@ static func copy_gui_template(
 	# Create a copy of the corresponding commands template -----------------------------------------
 	_copy_scripts(commands_template_path, PopochiuResources.GUI_COMMANDS, script_path, scene_path)
 	
-	await EditorInterface.get_base_control().get_tree().create_timer(1.5).timeout
+	await _wait(1.5)
 	on_progress.call(80, "Assigning scripts")
 	
 	# Update the script of the created graphic_interface.tscn so it uses the copy created above ----
@@ -73,18 +73,18 @@ static func copy_gui_template(
 		
 		return
 	
-	await EditorInterface.get_base_control().get_tree().create_timer(1.0).timeout
-	on_progress.call(90, "Updating Settings and Config files")
+	await _wait()
+	on_progress.call(90, "Updating config file")
 	
 	# Update the info related to the GUI template and the GUI commands script
 	# in the popochiu_data.cfg file ----------------------------------------------------------------
 	PopochiuResources.set_data_value("ui", "template", template_name)
-	await EditorInterface.get_base_control().get_tree().create_timer(0.8).timeout
+	await _wait(0.8)
 	
 	on_progress.call(100, "All in place. Thanks for your patience.")
 	PopochiuUtils.print_normal("[wave]Selected GUI template successfully applied[/wave]")
 	
-	await EditorInterface.get_base_control().get_tree().create_timer(1.0).timeout
+	await _wait()
 	on_complete.call()
 
 
@@ -248,6 +248,10 @@ static func _copy_script(
 	source_file_path: String, _target_folder: String, target_file_path: String
 ) -> void:
 	var file_write = FileAccess.open(target_file_path, FileAccess.WRITE)
+	
+	if load(source_file_path).is_tool():
+		file_write.store_string("@tool\n")
+	
 	file_write.store_string('extends "%s"' % source_file_path)
 	file_write.close()
 
@@ -331,6 +335,10 @@ static func _update_scene_script(script_path: String) -> int:
 	packed_scene.pack(scene)
 	
 	return ResourceSaver.save(packed_scene, PopochiuResources.GUI_GAME_SCENE)
+
+
+static func _wait(max := 1.0) -> void:
+	await EditorInterface.get_base_control().get_tree().create_timer(randf_range(0.5, max)).timeout
 
 
 #endregion

--- a/addons/popochiu/editor/main_dock/tab_room.gd
+++ b/addons/popochiu/editor/main_dock/tab_room.gd
@@ -396,19 +396,12 @@ func _create_row_in_dock(type_id: int, child: Node) -> PopochiuObjectRow:
 func _get_row_path(type_id: int, child: Node) -> String:
 	var row_path := ""
 	
-	if type_id == Constants.Types.PROP:
-		row_path = '%s/props/%s/prop_%s.tscn' % [
-			opened_room.scene_file_path.get_base_dir(),
-			(child.name as String).to_snake_case(),
-			(child.name as String).to_snake_case()
-		]
-	elif child.script.resource_path.find('addons') == -1:
+	if child.script and child.script.resource_path.find('addons') == -1:
 		row_path = child.script.resource_path
 	else:
-		row_path = '%s/%s' % [
-			opened_room.scene_file_path.get_base_dir(),
-			(_types[type_id].parent as String).to_snake_case()
-		]
+		# If the node doesn't have an associated script, then clicking on its
+		# row should select its scene (.tscn) file
+		row_path = child.scene_file_path
 	
 	return row_path
 

--- a/addons/popochiu/engine/audio_manager/audio_manager.gd
+++ b/addons/popochiu/engine/audio_manager/audio_manager.gd
@@ -231,6 +231,11 @@ func load_sound_settings():
 				volume_settings[bus_name] = AudioServer.get_bus_volume_db(bus_idx)
 
 
+## Returns [code]true[/code] if the [PopochiuAudioCue] identified by [param cue_name] is playing.
+func is_playing_cue(cue_name: String) -> bool:
+	return get_cue_playback_position(cue_name) > -1
+
+
 #endregion
 
 #region Private ####################################################################################

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -434,6 +434,10 @@ func say(dialog: String, emo := "") -> void:
 	
 	await G.dialog_line_finished
 	
+	# Stop the voice if it is still playing (feature #202)
+	if E.am.is_playing_cue(vo_name):
+		A[vo_name].stop(0.3)
+	
 	emotion = ''
 	idle()
 

--- a/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 	clear()
 	
 	modulate.a = 0.0
-	_secs_per_character = E.current_text_speed
+	_secs_per_character = E.text_speed
 	_x_limit = E.width / (E.scale.x if E.settings.scale_gui else 1.0)
 	_y_limit = E.height / (E.scale.y if E.settings.scale_gui else 1.0)
 	
@@ -238,7 +238,7 @@ func disappear() -> void:
 
 
 func change_speed() -> void:
-	_secs_per_character = E.current_text_speed
+	_secs_per_character = E.text_speed
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/text_popup/sierra_text_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/text_popup/sierra_text_popup.gd
@@ -8,7 +8,7 @@ extends PopochiuPopup
 func _ready() -> void:
 	super()
 	
-	text_speed.value = 0.1 - E.current_text_speed
+	text_speed.value = 0.1 - E.text_speed
 	dialog_style.selected = E.settings.dialog_style
 	continue_mode.button_pressed = E.settings.auto_continue_text
 	
@@ -19,7 +19,7 @@ func _ready() -> void:
 
 
 func _on_text_speed_changed(value: float) -> void:
-	E.current_text_speed = 0.1 - value
+	E.text_speed = 0.1 - value
 
 
 func _on_dialog_style_selected(idx: int) -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd
@@ -1,22 +1,30 @@
+@tool
 extends 'settings_bar_button.gd'
 
-@export var btn_states := [] # (Array, Texture2D)
-@export var states_descriptions := ['normal', 'fast', 'immediate']
+const TextSpeedOption = preload(
+	PopochiuResources.GUI_TEMPLATES_FOLDER
+	+ "simple_click/components/settings_bar/resources/text_speed_option.gd"
+)
+
+@export var speed_options: Array : set = set_speed_options
+
+var _speed_idx := 0
 
 
 #region Godot ######################################################################################
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+	
 	super()
-	texture_normal = btn_states[E.current_text_speed_idx]
+	texture_normal = (speed_options[_speed_idx] as TextSpeedOption).icon
 
 
 #endregion
 
 #region Virtual ####################################################################################
 func _on_pressed() -> void:
-	E.change_text_speed()
-	texture_normal = btn_states[E.current_text_speed_idx]
-
+	_change_text_speed()
 	G.show_hover_text(self.description)
 
 
@@ -24,7 +32,32 @@ func _on_pressed() -> void:
 
 #region SetGet #####################################################################################
 func get_description() -> String:
-	return '%s: %s' % [description, states_descriptions[E.current_text_speed_idx]]
+	if speed_options.is_empty() or Engine.is_editor_hint():
+		return description
+	
+	return '%s: %s' % [description, (speed_options[_speed_idx] as TextSpeedOption).description]
+
+
+func set_speed_options(value: Array) -> void:
+	speed_options = value
+	
+	for idx in value.size():
+		if not value[idx]:
+			var x := TextSpeedOption.new()
+			x.resource_name = "Speed %d" % idx
+			
+			value[idx] = x
+
+
+#endregion
+
+#region Private ####################################################################################
+## Changes the speed of the text in dialog lines looping through the values in
+## [member PopochiuSettings.text_speeds].
+func _change_text_speed() -> void:
+	_speed_idx = wrapi(_speed_idx + 1, 0, speed_options.size())
+	texture_normal = (speed_options[_speed_idx] as TextSpeedOption).icon
+	E.text_speed = (speed_options[_speed_idx] as TextSpeedOption).speed
 
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/resources/text_speed_option.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/resources/text_speed_option.gd
@@ -1,0 +1,5 @@
+extends Resource
+
+@export var icon: Texture2D = null
+@export var description := ""
+@export var speed := 0.0

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.tscn
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://0cqerawlxb3o"]
+[gd_scene load_steps=25 format=3 uid="uid://0cqerawlxb3o"]
 
 [ext_resource type="Texture2D" uid="uid://c4lgasdx1ow1d" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/toolbar_bg.png" id="1_hwsmr"]
 [ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd" id="2_hk0vm"]
@@ -7,10 +7,11 @@
 [ext_resource type="Texture2D" uid="uid://bns33w6nl2qkb" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_load.png" id="5_8xdf1"]
 [ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_load.gd" id="6_dfxoh"]
 [ext_resource type="Texture2D" uid="uid://bkwo41gqhl5ic" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_speed_01.png" id="7_otoev"]
-[ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd" id="8_7atal"]
-[ext_resource type="Texture2D" uid="uid://dl2gqtc0ay0nk" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_speed_02.png" id="9_jfw1a"]
-[ext_resource type="Texture2D" uid="uid://s7ksvmp5vkc8" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_speed_03.png" id="10_a2bgs"]
+[ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_speed.gd" id="8_xj7pu"]
+[ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/resources/text_speed_option.gd" id="9_81q7g"]
+[ext_resource type="Texture2D" uid="uid://dl2gqtc0ay0nk" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_speed_02.png" id="10_kfiam"]
 [ext_resource type="Texture2D" uid="uid://cyvd8h2ouw8rg" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_audio.png" id="11_id5s2"]
+[ext_resource type="Texture2D" uid="uid://s7ksvmp5vkc8" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_speed_03.png" id="11_mkapw"]
 [ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_sound_settings.gd" id="12_jqlr0"]
 [ext_resource type="Texture2D" uid="uid://brnf51r7xuec4" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/sprites/btn_dialog_auto_01.png" id="13_n5ueq"]
 [ext_resource type="Script" path="res://addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/buttons/btn_dialog_auto.gd" id="14_e58le"]
@@ -29,6 +30,27 @@ texture_margin_top = 1.0
 texture_margin_right = 11.0
 texture_margin_bottom = 5.0
 region_rect = Rect2(0, 0, 36, 24)
+
+[sub_resource type="Resource" id="Resource_ie5nq"]
+resource_name = "Speed 0"
+script = ExtResource("9_81q7g")
+icon = ExtResource("7_otoev")
+description = "normal"
+speed = 0.1
+
+[sub_resource type="Resource" id="Resource_dhkav"]
+resource_name = "Speed 1"
+script = ExtResource("9_81q7g")
+icon = ExtResource("10_kfiam")
+description = "fast"
+speed = 0.01
+
+[sub_resource type="Resource" id="Resource_kqq7u"]
+resource_name = "Speed 2"
+script = ExtResource("9_81q7g")
+icon = ExtResource("11_mkapw")
+description = "immediate"
+speed = 0.0
 
 [node name="SettingsBar" type="PanelContainer" groups=["popochiu_gui_component"]]
 texture_filter = 1
@@ -60,8 +82,8 @@ script_name = "LoadGame"
 [node name="BtnDialogSpeed" type="TextureButton" parent="Box"]
 layout_mode = 2
 texture_normal = ExtResource("7_otoev")
-script = ExtResource("8_7atal")
-btn_states = [ExtResource("7_otoev"), ExtResource("9_jfw1a"), ExtResource("10_a2bgs")]
+script = ExtResource("8_xj7pu")
+speed_options = [SubResource("Resource_ie5nq"), SubResource("Resource_dhkav"), SubResource("Resource_kqq7u")]
 description = "Text speed"
 script_name = "TextSpeed"
 

--- a/addons/popochiu/engine/objects/popochiu_settings.gd
+++ b/addons/popochiu/engine/objects/popochiu_settings.gd
@@ -5,11 +5,16 @@ extends Resource
 
 ## The time, in seconds, that will take the game to skip a cutscene.
 var skip_cutscene_time := 0.0
+## @deprecated
 ## The text speed options that will be available in the game. In the ContextSensitive GUI you can
 ## loop between them usin the text speed button in the SettingsBar.
 var text_speeds := [0.1, 0.01, 0.0]
+## @deprecated
 ## The index of the default text speed value in [member text_speeds].
 var default_text_speed_idx := 0
+## The speed at which characters are displayed when a character speaks and the text is being
+## animated
+var text_speed := 0.0
 ## If [code]true[/code], then dialog lines should auto continue once the animation that shows them
 ## finishes. Otherwise, players will have to click the screen in order to continue.
 var auto_continue_text := false
@@ -60,17 +65,22 @@ var dialog_style := 0
 
 #region Godot ######################################################################################
 func _init() -> void:
+	# ---- GUI -------------------------------------------------------------------------------------
+	scale_gui = PopochiuConfig.is_scale_gui()
+	fade_color = PopochiuConfig.get_fade_color()
 	skip_cutscene_time = PopochiuConfig.get_skip_cutscene_time()
+	# ---- Dialogs ---------------------------------------------------------------------------------
+	text_speed = PopochiuConfig.get_text_speed()
 	auto_continue_text = PopochiuConfig.is_auto_continue_text()
 	use_translations = PopochiuConfig.is_use_translations()
-	items_on_start = PopochiuConfig.get_inventory_items_on_start()
-	inventory_limit = PopochiuConfig.get_inventory_limit()
-	fade_color = PopochiuConfig.get_fade_color()
-	scale_gui = PopochiuConfig.is_scale_gui()
 	max_dialog_options = PopochiuConfig.get_max_dialog_options()
+	dialog_style = PopochiuConfig.get_dialog_style()
+	# ---- Inventory -------------------------------------------------------------------------------
+	inventory_limit = PopochiuConfig.get_inventory_limit()
+	items_on_start = PopochiuConfig.get_inventory_items_on_start()
+	# ---- Pixel game ------------------------------------------------------------------------------
 	is_pixel_art_game = PopochiuConfig.is_pixel_art_textures()
 	is_pixel_perfect = PopochiuConfig.is_pixel_perfect()
-	dialog_style = PopochiuConfig.get_dialog_style()
 
 
 #endregion

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -88,14 +88,9 @@ var height := 0.0 : get = get_height
 var half_width := 0.0 : get = get_half_width
 ## [member height] divided by 2.
 var half_height := 0.0 : get = get_half_height
-## Used to access the value of the current text speed. The possible text speed values are stored
-## in the [member PopochiuSettings.text_speeds] [Array], so this property has the index of the
-## speed being used by the game.
-var current_text_speed_idx := settings.default_text_speed_idx
 ## The text speed being used by the game. When this property changes, the
 ## [signal text_speed_changed] signal is emitted.
-var current_text_speed: float = settings.text_speeds[current_text_speed_idx] :
-	set = set_current_text_speed
+var text_speed: float = settings.text_speed : set = set_text_speed
 ## The number of seconds to wait before moving to the next dialog line (when playing dialog lines
 ## triggered inside a [method queue].
 var auto_continue_after := -1.0
@@ -725,17 +720,6 @@ func play_transition(type: int, duration: float) -> void:
 	await tl.transition_finished
 
 
-# TODO: Move this logic to the button in the 2-click Context-sensitive template in charge of
-# 		changing the text speed.
-## Changes the speed of the text in dialog lines looping through the values in
-## [member PopochiuSettings.text_speeds].
-func change_text_speed() -> void:
-	current_text_speed_idx = wrapi(current_text_speed_idx + 1, 0, settings.text_speeds.size())
-	current_text_speed = settings.text_speeds[current_text_speed_idx]
-	
-	text_speed_changed.emit()
-
-
 ## Checks if there are any saved game sessions in the game's folder. By default Godot's
 ## [code]user://[/code] (you can open this folder with [b]Project > Open User Data Folder[/b]).
 func has_save() -> bool:
@@ -890,8 +874,8 @@ func get_hovered() -> PopochiuClickable:
 	return null
 
 
-func set_current_text_speed(value: float) -> void:
-	current_text_speed = value
+func set_text_speed(value: float) -> void:
+	text_speed = value
 	text_speed_changed.emit()
 
 


### PR DESCRIPTION
Now text speed options for 2-click Context-sensitive SettingsBar component are configured as properties of itself instead of relying on Popochiu and PopochiuSettings.

- [fea] Add `is_playing_cue` function to AudioManager so one can now if a PopochiuAudioCue is playing.
- [fea] When a PopochiuCharacter stops speaking, its voice stops too if it is still playing. For this to work properly, the PopochiuAudioCue should not be marked as `can_play_simultaneous`.
- [upd] Now moving the GUI to "res://game/graphic_interface" takes into accound if a script is a tool so it adds the @tool annotation to the target file.
- [upd] Room tab selects the scene of created Markers in the FileSystem when clicking the Marker row.