### PR TITLE
Fix #219

### DIFF
--- a/addons/popochiu/engine/interfaces/i_graphic_interface.gd
+++ b/addons/popochiu/engine/interfaces/i_graphic_interface.gd
@@ -55,15 +55,19 @@ signal popup_requested(script_name: StringName)
 # NOTE: Maybe add some signals for clicking objects and items
 #signal clicked_clickable(clickable: PopochiuClickable)
 #signal clicked_inventory_item(inventory_item: PopochiuInventoryItem)
+# TODO: deprecate this
 ## Emitted when [method show_history] is called in order to open the History popup.
-signal history_opened # TODO: deprecate this
+signal history_opened
 ## Emitted to open the popup to save the game. You can specify the name of the saved game with
+# TODO: deprecate this
 ## [param slot_text].
-signal save_requested(slot_text: String) # TODO: deprecate this
+signal save_requested(slot_text: String)
+# TODO: deprecate this
 ## Emitted to open the popup to load the game.
-signal load_requested # TODO: deprecate this
+signal load_requested
+# TODO: deprecate this
 ## Emitted to open the popup that allows to change the volume of the audio buses in the game.
-signal sound_settings_requested # TODO: deprecate this
+signal sound_settings_requested
 ## Emitted when the dialog options of the running [PopochiuDialog] are shown.
 signal dialog_options_shown
 

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -87,7 +87,6 @@ func clean_inventory(in_bg := false) -> void:
 		if not pii.in_inventory: continue
 		if not in_bg: await pii.discard()
 		
-		item_discarded.emit(pii)
 		pii.remove(!in_bg)
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
@@ -55,7 +55,7 @@ func _input(event: InputEvent) -> void:
 	if not PopochiuUtils.is_click_or_touch_pressed(event) or modulate.a == 0.0:
 		return
 	
-	get_viewport().set_input_as_handled()
+	accept_event()
 	
 	if PopochiuUtils.get_click_or_touch_index(event) != MOUSE_BUTTON_LEFT:
 		return

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_grid/inventory_grid.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_grid/inventory_grid.gd
@@ -104,14 +104,16 @@ func _update_box() -> void:
 	box.add_theme_constant_override("h_separation", h_separation)
 	box.add_theme_constant_override("v_separation", v_separation)
 	
+	# Fix: remove the child immediately (instead of calling queue_free()), and do not await for
+	# a process frame cause it can cause an issue when adding items marked as "Start with it".
 	for child in box.get_children():
-		child.queue_free()
-	
-	await RenderingServer.frame_post_draw
+		child.free()
 	
 	for idx in number_of_slots:
 		var slot := (SLOT if not slot_scene else slot_scene).instantiate()
 		box.add_child(slot)
+		
+		slot.name = EMPTY_SLOT
 		slot_size = slot.size.y
 	
 	scroll_container.custom_minimum_size = Vector2(
@@ -182,9 +184,7 @@ func _remove_item(item: PopochiuInventoryItem, _animate := true) -> void:
 	item.selected.disconnect(_change_cursor)
 	
 	box.get_meta(item.script_name).remove_child(item)
-	box.get_meta(item.script_name).queue_free()
-	box.add_child(SLOT.instantiate())
-	box.get_child(-1).name = EMPTY_SLOT
+	box.get_meta(item.script_name).name = EMPTY_SLOT
 	
 	_check_scroll_buttons()
 	

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/popochiu_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/popochiu_popup.gd
@@ -81,7 +81,6 @@ func close() -> void:
 		Cursor.unblock()
 	
 	_close()
-	
 	hide()
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/components/popups/save_and_load_popup/save_and_load_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/popups/save_and_load_popup/save_and_load_popup.gd
@@ -1,5 +1,7 @@
 extends PopochiuPopup
 
+signal slot_selected
+
 const SELECTION_COLOR := Color("edf171")
 const OVERWRITE_COLOR := Color("c46c71")
 
@@ -52,6 +54,8 @@ func _open() -> void:
 
 func _close() -> void:
 	if not _slot: return
+	
+	slot_selected.emit()
 	
 	if _slot_name:
 		E.save_game(_slot, _slot_name)

--- a/addons/popochiu/engine/objects/graphic_interface/components/system_text/system_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/system_text/system_text.gd
@@ -6,6 +6,10 @@ signal shown
 
 const DFLT_SIZE := "dflt_size"
 
+# Used to fix a warning shown by Godot related to the anchors of the node and changing its size
+# during a _ready() execution
+var _can_change_size := false
+
 
 #region Godot ######################################################################################
 func _ready() -> void:
@@ -13,10 +17,8 @@ func _ready() -> void:
 	
 	# Connect to singletons signals
 	G.system_text_shown.connect(_show_text)
+	E.ready.connect(set.bind("_can_change_size", true))
 	
-	# This await fixes a warning shown by Godot related to the anchors of the node and changing its
-	# size during _ready execution
-	await RenderingServer.frame_post_draw
 	close()
 
 
@@ -28,8 +30,7 @@ func _input(event: InputEvent) -> void:
 	if not PopochiuUtils.is_click_or_touch_pressed(event) or not visible:
 		return
 	
-	get_viewport().set_input_as_handled()
-	
+	accept_event()
 	if PopochiuUtils.get_click_or_touch_index(event) == MOUSE_BUTTON_LEFT:
 		close()
 
@@ -47,7 +48,9 @@ func close() -> void:
 	
 	clear()
 	text = ""
-	size = get_meta(DFLT_SIZE)
+	
+	if _can_change_size:
+		size = get_meta(DFLT_SIZE)
 	
 	hide()
 	G.system_text_hidden.emit()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
@@ -30,6 +30,7 @@ func _ready() -> void:
 	settings_popup.classic_sentence_toggled.connect(_on_classic_sentence_toggled)
 	settings_popup.quit_pressed.connect(_on_quit_pressed)
 	
+	
 	# Connect to singletons signals
 	E.ready.connect(_on_popochiu_ready)
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
@@ -4,6 +4,9 @@ extends PopochiuHoverText
 
 var _gui_width := 0.0
 var _gui_height := 0.0
+# Used to fix a warning shown by Godot related to the anchors of the node and changing its size
+# during a _ready() execution
+var _can_change_size := false
 
 
 #region Godot ######################################################################################
@@ -22,10 +25,8 @@ func _ready() -> void:
 	set_process(follows_cursor)
 	autowrap_mode = TextServer.AUTOWRAP_OFF if follows_cursor else TextServer.AUTOWRAP_WORD_SMART
 	
-	# This await fixes a warning shown by Godot related to the anchors of the node and changing its
-	# size during _ready execution
-	await RenderingServer.frame_post_draw
 	_show_text()
+	E.ready.connect(set.bind("_can_change_size", true))
 
 
 func _process(delta: float) -> void:
@@ -55,7 +56,7 @@ func _process(delta: float) -> void:
 func _show_text(txt := "") -> void:
 	text = ""
 	
-	if follows_cursor:
+	if follows_cursor and _can_change_size:
 		size = Vector2.ZERO
 	
 	if txt.is_empty():
@@ -71,7 +72,7 @@ func _show_text(txt := "") -> void:
 	elif I.active:
 		super(txt)
 	
-	if follows_cursor:
+	if follows_cursor and _can_change_size:
 		size += Vector2.ONE * (Cursor.get_cursor_height() / 2)
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/components/settings_popup/9_verb_settings_popup.gd
@@ -1,7 +1,7 @@
 extends PopochiuPopup
 
 signal quit_pressed
-signal classic_sentence_toggled(pressed)
+signal classic_sentence_toggled(pressed: bool)
 
 @onready var classic_sentence: CheckButton = %ClassicSentence
 @onready var save: Button = %Save
@@ -20,6 +20,11 @@ func _ready() -> void:
 	history.pressed.connect(_on_history_pressed)
 	quit.pressed.connect(_on_quit_pressed)
 	classic_sentence.toggled.connect(_on_classic_sentence_toggled)
+	
+	# Connect to autoloads signals
+	# Fix #219: Close the popup whenever a slot is selected for saving or loading
+	E.game_saved.connect(close)
+	E.game_load_started.connect(close)
 	
 	if OS.has_feature("web"):
 		quit.hide()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_slot/sierra_inventory_slot.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_inventory_popup/sierra_inventory_slot/sierra_inventory_slot.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 	mouse_entered.connect(_on_mouse_entered)
 	mouse_exited.connect(_on_mouse_exited)
 	child_entered_tree.connect(_on_item_assigned)
+	child_exiting_tree.connect(_on_item_removed)
 
 
 #endregion
@@ -45,6 +46,18 @@ func _on_item_assigned(node: Node) -> void:
 	inventory_item.mouse_exited.connect(_on_mouse_exited)
 	inventory_item.selected.connect(_on_item_selected)
 	inventory_item.unselected.connect(_on_item_unselected)
+
+
+func _on_item_removed(node: Node) -> void:
+	if not node is PopochiuInventoryItem:
+		return
+	
+	var inventory_item: PopochiuInventoryItem = node
+	
+	inventory_item.mouse_entered.disconnect(_on_mouse_entered)
+	inventory_item.mouse_exited.disconnect(_on_mouse_exited)
+	inventory_item.selected.disconnect(_on_item_selected)
+	inventory_item.unselected.disconnect(_on_item_unselected)
 
 
 func _on_item_selected(item: PopochiuInventoryItem) -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_menu.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_menu/sierra_menu.gd
@@ -12,6 +12,8 @@ func _ready():
 	settings.pressed.connect(_on_settings_pressed)
 	help.pressed.connect(_on_help_pressed)
 	quit.pressed.connect(_on_quit_pressed)
+	
+	hide()
 
 
 func _input(event: InputEvent) -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_settings_popup/sierra_settings_popup.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/components/sierra_settings_popup/sierra_settings_popup.gd
@@ -13,11 +13,17 @@ signal option_selected(option_name)
 func _ready() -> void:
 	super()
 	
+	# Connect to childrens' signals
 	save.pressed.connect(_on_option_pressed.bind("save"))
 	load.pressed.connect(_on_option_pressed.bind("load"))
 	sound.pressed.connect(_on_option_pressed.bind("sound"))
 	text.pressed.connect(_on_option_pressed.bind("text"))
 	quit.pressed.connect(_on_option_pressed.bind("quit"))
+	
+	# Connect to autoloads signals
+	# Fix #219: Close the popup whenever a slot is selected for saving or loading
+	E.game_saved.connect(close)
+	E.game_load_started.connect(close)
 	
 	if OS.has_feature("web"):
 		quit.hide()

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_gui.gd
@@ -34,9 +34,9 @@ func _input(event: InputEvent) -> void:
 			# active.
 			if not $SierraMenu.visible and not E.hovered\
 			 and E.current_command != SierraCommands.Commands.WALK:
-				get_viewport().set_input_as_handled()
+				accept_event()
 		MOUSE_BUTTON_RIGHT:
-			get_viewport().set_input_as_handled()
+			accept_event()
 			
 			E.current_command = posmod(
 				E.current_command + 1, SierraCommands.Commands.size()

--- a/addons/popochiu/engine/others/popochiu_save_load.gd
+++ b/addons/popochiu/engine/others/popochiu_save_load.gd
@@ -6,10 +6,10 @@ extends Resource
 ## https://github.com/GDQuest/godot-demos-2022/tree/main/save-game
 
 # TODO: This could be in PopochiuSettings for devs to change the path
-const SAVE_GAME_PATH := 'user://save_%d.json'
+const SAVE_GAME_PATH := "user://save_%d.json"
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#region Public #####################################################################################
 func count_saves() -> int:
 	var saves := 0
 	
@@ -27,9 +27,11 @@ func get_saves_descriptions() -> Dictionary:
 		if FileAccess.file_exists(SAVE_GAME_PATH % i):
 			var opened := FileAccess.open(SAVE_GAME_PATH % i, FileAccess.READ)
 			if not opened:
-				printerr(\
-				'[Popochiu] Could not open the file %s. Error code: %s'\
-				% [SAVE_GAME_PATH % i, opened.get_open_error()])
+				PopochiuUtils.print_error(
+					"Could not open the file %s. Error code: %s" % [
+						SAVE_GAME_PATH % i, opened.get_open_error()
+					]
+				)
 				return {}
 
 			var content := opened.get_as_text()
@@ -47,12 +49,14 @@ func get_saves_descriptions() -> Dictionary:
 	return saves
 
 
-func save_game(slot := 1, description := '') -> bool:
+func save_game(slot := 1, description := "") -> bool:
 	var opened := FileAccess.open(SAVE_GAME_PATH % slot, FileAccess.WRITE)
 	if not opened:
-		printerr(\
-		'[Popochiu] Could not open the file %s. Error code: %s'\
-		% [SAVE_GAME_PATH % slot, opened.get_open_error()])
+		PopochiuUtils.print_error(
+			"[Popochiu] Could not open the file %s. Error code: %s" % [
+				SAVE_GAME_PATH % slot, opened.get_open_error()
+			]
+		)
 		return false
 	
 	var data := {
@@ -75,11 +79,11 @@ func save_game(slot := 1, description := '') -> bool:
 			y = C.player.global_position.y
 		}
 	
-	# Go over each Popochiu type to save its current state ---------------------
-	for type in ['rooms', 'characters', 'inventory_items', 'dialogs']:
+	# Go over each Popochiu type to save its current state -----------------------------------------
+	for type in ["rooms", "characters", "inventory_items", "dialogs"]:
 		_store_data(type, data)
 	
-	# Save PopochiuGlobals.gd (Globals) ----------------------------------------
+	# Save PopochiuGlobals.gd (Globals) ------------------------------------------------------------
 	# prop = {class_name, hint, hint_string, name, type, usage}
 	for prop in Globals.get_script().get_script_property_list():
 		if not prop.type in PopochiuResources.VALID_TYPES: continue
@@ -91,12 +95,12 @@ func save_game(slot := 1, description := '') -> bool:
 		):
 			data.globals[prop.name] = Globals[prop.name]
 	
-	if Globals.has_method('on_save'):
+	if Globals.has_method("on_save"):
 		data.globals.custom_data = Globals.on_save()
 	
-	if data.globals.is_empty(): data.erase('globals')
+	if data.globals.is_empty(): data.erase("globals")
 	
-	# Write the JSON -----------------------------------------------------------
+	# Write the JSON -------------------------------------------------------------------------------
 	var json_string := JSON.stringify(data)
 	opened.store_string(json_string)
 	opened.close()
@@ -107,9 +111,11 @@ func save_game(slot := 1, description := '') -> bool:
 func load_game(slot := 1) -> Dictionary:
 	var opened := FileAccess.open(SAVE_GAME_PATH % slot, FileAccess.READ)
 	if not opened:
-		printerr(\
-		'[Popochiu] Could not open the file %s. Error code: %s'\
-		% [SAVE_GAME_PATH % slot, opened.get_open_error()])
+		PopochiuUtils.print_error(
+			"Could not open the file %s. Error code: %s" % [
+				SAVE_GAME_PATH % slot, opened.get_open_error()
+			]
+		)
 		return {}
 
 	var content := opened.get_as_text()
@@ -124,25 +130,27 @@ func load_game(slot := 1) -> Dictionary:
 		I.get_item_instance(item).add(false)
 	
 	# Load main object states
-	for type in ['rooms', 'characters', 'inventory_items', 'dialogs']:
+	for type in ["rooms", "characters", "inventory_items", "dialogs"]:
 		if loaded_data.has(type):
 			_load_state(type, loaded_data)
 	
 	# Load globals
-	if loaded_data.has('globals'):
+	if loaded_data.has("globals"):
 		for prop in loaded_data.globals:
 			if typeof(Globals.get(prop)) == TYPE_NIL: continue
 			
 			Globals[prop] = loaded_data.globals[prop]
 		
-		if loaded_data.globals.has('custom_data')\
-		and Globals.has_method('on_load'):
+		if loaded_data.globals.has("custom_data")\
+		and Globals.has_method("on_load"):
 			Globals.on_load(loaded_data.globals.custom_data)
 
 	return loaded_data
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 func _store_data(type: String, save: Dictionary) -> void:
 	for path in PopochiuResources.get_section(type):
 		# load the ___State.tres file
@@ -153,14 +161,14 @@ func _store_data(type: String, save: Dictionary) -> void:
 		PopochiuResources.store_properties(save[type][data.script_name], data)
 		
 		match type:
-			'rooms':
+			"rooms":
 				data.save_childs_states()
 				
 				for category in PopochiuResources.ROOM_CHILDS:
 					save[type][data.script_name][category] = data[category]
 				
-				save[type][data.script_name]['characters'] = data.characters
-			'dialogs':
+				save[type][data.script_name]["characters"] = data.characters
+			"dialogs":
 				save[type][data.script_name].options = {}
 				
 				for opt in (data as PopochiuDialog).options:
@@ -168,7 +176,7 @@ func _store_data(type: String, save: Dictionary) -> void:
 					PopochiuResources.store_properties(
 						save[type][data.script_name].options[opt.id],
 						opt,
-						['id', 'always_on']
+						["id", "always_on"]
 					)
 		
 		if save[type][data.script_name].is_empty():
@@ -180,27 +188,27 @@ func _store_data(type: String, save: Dictionary) -> void:
 
 func _load_state(type: String, loaded_game: Dictionary) -> void:
 	for id in loaded_game[type]:
-		var state := load(PopochiuResources.get_data_value(type, id, ''))
+		var state := load(PopochiuResources.get_data_value(type, id, ""))
 		
 		for p in loaded_game[type][id]:
-			if p == 'custom_data': continue
-			if type == 'dialogs' and p == 'options': continue
+			if p == "custom_data": continue
+			if type == "dialogs" and p == "options": continue
 			
 			state[p] = loaded_game[type][id][p]
 		
 		match type:
-			'rooms':
+			"rooms":
 				E.rooms_states[id] = state
-			'characters':
+			"characters":
 				C.characters_states[id] = state
-			'inventory_items':
+			"inventory_items":
 				I.items_states[id] = state
-			'dialogs':
+			"dialogs":
 				D.trees[id] = state
 				_load_dialog_options(state, loaded_game[type][id].options)
 		
-		if loaded_game[type][id].has('custom_data')\
-		and state.has_method('on_load'):
+		if loaded_game[type][id].has("custom_data")\
+		and state.has_method("on_load"):
 			state.on_load(loaded_game[type][id].custom_data)
 
 
@@ -211,7 +219,10 @@ func _load_dialog_options(
 		if not loaded_options.has(opt.id): continue
 		
 		for prop in opt.get_script().get_script_property_list():
-			if prop.name == 'always_on': continue
+			if prop.name == "always_on": continue
 			
 			if loaded_options[opt.id].has(prop.name):
 				opt[prop.name] = loaded_options[opt.id][prop.name]
+
+
+#endregion


### PR DESCRIPTION
Set `PopochiuRoom.state.visited_first_time` to `true` after the `_on_room_transition_finished()` is executed.

- **fix** InventoryGrid slots were being deleted in the process of adding items in the `ProjectSettings.items_on_start` array. This was causing an issue in the 9 Verb and Sierra templates.
- **upd** Settings popup in 9 Verb and Sierra templates now close automatically when a slot is selected for saving or loading.
- **upd** Slots in InventoryGrid are no longer deleted when removing an item. Instead, only its name changes.
- **fix** Improve fix to avoid Godot printing a Warning related with setting the size of dialog_text and hover_text during a `_ready()` execution.