### PR TITLE
Added information about default inventory icon sizes

### DIFF
--- a/docs/src/getting-started/creating-a-game-stub/add-an-inventory-item.md
+++ b/docs/src/getting-started/creating-a-game-stub/add-an-inventory-item.md
@@ -14,16 +14,19 @@ To create a new inventory item click on the **Create Inventory Item** button in 
 We'll name our new inventory item "_ToyCar_", because we are going to make the prop we just created collectible. Go on and click OK. Popochiu will open the new inventory item's scene in the editor.
 
 Inventory items are very simple. They have no interaction polygons or similar because representing them in an interactive grid of sorts is the responsibility of the GUI.  
+
 The only thing we need to do is to assign a texture to them, that will be painted in the inventory GUI by Popochiu.
 
 If you don't have a sprite ready for your inventory item, you can download [this one](https://github.com/carenalgas/popochiu-sample-game/blob/801bdbb5cdc9139e05e496e7a703f5f4e37bc861/game/inventory_items/toy_car/inv_toy_car.png) from the demo game.  
+
 Save it into your project, in the `game/inventory_items/<your inventory item name>/inv_toy_car.png` folder, and rename it as you see fit.
 
 Assigning the texture to the inventory item is done the same as props, by dragging the image from the **FileSystem** to the **Texture** property in the inspector (_33_).
 
 ![Sprite added](../../assets/images/getting-started/game_stub-inv_item-24-set_texture.png "Now the inventory item has an icon")
 
-That's it. Your inventory item is configured and it is now possible to add it to the main character's inventory.  
+That's it. Your inventory item is configured and it is now possible to add it to the main character's inventory.
+  
 We are going to script this part by interacting with the toy car prop we placed in our room.
 
 Go back to the room scene (you can press the **Open in Editor** button on the "_House_" room row in Popochiu's main dock) and use the room tab to open the "_ToyCar_" prop script.
@@ -62,3 +65,11 @@ Save the project and run the game. Now if you click on the toy car on the floor,
     See how the last two lines of the `_on_click()` function are not `await`-ed? The reason is that those functions are just changing the state of the game, without triggering animations, or dialogs.
 
     To learn if a function must be awaited, the best option is to check in the [API reference](/the-engine-handbook/scripting-reference) section. As a rule of thumb, if the function "is not making something happen on the screen as it was in a movie" (animating, moving stuff around, printing text... everything that needs time to be seen), then it probably doesn't need to be awaited.
+
+!!! note
+    The default Popochiu GUI Templates have different inventory icon sizes. Images will be scaled to fit into the inventory slot. As a general rule it's better to scale a larger image down to a smaller one to avoid having unwanted artifacts in the image.
+
+    **2-Click Context-Sensitive:** has an inventory icon size of 16x16 pixels.
+    **Sierra:** has an inventory icon size of 24x24 pixels.
+    **9 Verb (LucasArts):** has an inventory icon size of 40x24 pixels.
+ 


### PR DESCRIPTION
Added the following as a note to the inventory documentation:

The default Popochiu GUI Templates have different inventory icon sizes. Images will be scaled to fit into the inventory slot. As a general rule it's better to scale a larger image down to a smaller one to avoid having unwanted artifacts in the image.

**2-Click Context-Sensitive:** has an inventory icon size of 16x16 pixels.
**Sierra:** has an inventory icon size of 24x24 pixels.
**9 Verb (LucasArts):** has an inventory icon size of 40x24 pixels.