### PR TITLE
Fix #224

### DIFF
--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -173,9 +173,7 @@ static func is_use_addon_template() -> bool:
 static func _initialize_project_setting(
 	key: String, default_value, type: int, hint := PROPERTY_HINT_NONE, hint_string := ""
 ) -> void:
-	if ProjectSettings.has_setting(key): return
-	
-	_create_setting(key, default_value, type, hint)
+	_create_setting(key, default_value, type, hint, hint_string)
 	ProjectSettings.set_as_basic(key, true)
 
 
@@ -188,7 +186,7 @@ static func _initialize_advanced_project_setting(
 static func _create_setting(
 	key: String, default_value, type: int, hint := PROPERTY_HINT_NONE, hint_string := ""
 ) -> void:
-	ProjectSettings.set_setting(key, default_value)
+	ProjectSettings.set_setting(key, ProjectSettings.get_setting(key, default_value))
 	ProjectSettings.set_initial_value(key, default_value)
 	ProjectSettings.add_property_info({
 		"name": key,

--- a/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/dialog_text/dialog_text.gd
@@ -52,13 +52,15 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if not PopochiuUtils.is_click_or_touch_pressed(event) or modulate.a == 0.0:
+	if (
+		not PopochiuUtils.get_click_or_touch_index(event) in [
+			MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT
+		]
+		or modulate.a == 0.0
+	):
 		return
 	
 	accept_event()
-	
-	if PopochiuUtils.get_click_or_touch_index(event) != MOUSE_BUTTON_LEFT:
-		return
 	
 	if visible_ratio == 1.0:
 		disappear()

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -103,9 +103,8 @@ func _on_graphic_interface_unblocked() -> void:
 func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	box.add_child(item)
 	
-	if E.settings.scale_gui:
-		item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
-		item.custom_minimum_size.y = box.size.y
+	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
+	item.custom_minimum_size.y = box.size.y
 	
 	item.selected.connect(_change_cursor)
 	

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_grid/inventory_grid.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_grid/inventory_grid.gd
@@ -160,13 +160,12 @@ func _add_item(item: PopochiuInventoryItem, _animate := true) -> void:
 	slot.name = "[%s]" % item.script_name
 	slot.add_child(item)
 	
-	if E.settings.scale_gui:
-		item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
-		
-		if slot.has_method("get_content_height"):
-			item.custom_minimum_size.y = slot.get_content_height()
-		else:
-			item.custom_minimum_size.y = slot.size.y
+	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
+	
+	if slot.has_method("get_content_height"):
+		item.custom_minimum_size.y = slot.get_content_height()
+	else:
+		item.custom_minimum_size.y = slot.size.y
 	
 	box.set_meta(item.script_name, slot)
 	

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/components/settings_bar/settings_bar.gd
@@ -12,6 +12,7 @@ var is_disabled := false
 
 var _can_hide := true
 var _is_hidden := true
+var _is_mouse_hover := false
 
 @onready var _tween: Tween = null
 @onready var _box: BoxContainer = find_child("Box")
@@ -43,17 +44,27 @@ func _ready() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	if event is InputEventMouseMotion:
-		var rect := get_rect()
-		
-		if E.settings.scale_gui:
-			rect = Rect2(get_rect().position * E.scale, get_rect().size * E.scale)
-		
-		if _is_hidden and rect.has_point(get_global_mouse_position()):
-			_open()
-		elif not _is_hidden\
-		and not rect.has_point(get_global_mouse_position()):
-			_close()
+	if not event is InputEventMouseMotion: return
+	
+	var rect := get_rect()
+	
+	if E.settings.scale_gui:
+		rect = Rect2(get_rect().position * E.scale, get_rect().size * E.scale)
+	
+	if rect.has_point(get_global_mouse_position()):
+		_is_mouse_hover = true
+		Cursor.show_cursor("gui")
+	elif _is_mouse_hover:
+		_is_mouse_hover = false
+		Cursor.show_cursor(
+			"wait" if (D.current_dialog or G.gui.is_showing_dialog_line)
+			else "normal"
+		)
+	
+	if _is_hidden and rect.has_point(get_global_mouse_position()):
+		_open()
+	elif not _is_hidden and not rect.has_point(get_global_mouse_position()):
+		_close()
 
 
 #endregion
@@ -78,8 +89,6 @@ func _open() -> void:
 	.from(_hide_y if not is_disabled else position.y)\
 	.set_trans(Tween.TRANS_EXPO).set_ease(Tween.EASE_OUT)
 	
-	Cursor.show_cursor("gui")
-	
 	_is_hidden = false
 
 
@@ -94,13 +103,8 @@ func _close() -> void:
 		_tween.kill()
 	
 	_tween = create_tween()
-	_tween.tween_property(
-		self, "position:y",
-		_hide_y if not is_disabled else _hide_y - 3.5,
-		0.2
-	).from(0.0).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
-	
-	Cursor.show_cursor()
+	_tween.tween_property(self, "position:y", _hide_y if not is_disabled else _hide_y - 3.5, 0.2)\
+	.from(0.0).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_IN)
 	
 	_is_hidden = true
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
@@ -103,6 +103,7 @@ func _on_mouse_exited_inventory_item(inventory_item: PopochiuInventoryItem) -> v
 ## Called when a dialog line starts. It shows the [code]"wait"[/code] cursor.
 func _on_dialog_line_started() -> void:
 	is_showing_dialog_line = true
+	
 	Cursor.show_cursor("wait")
 
 
@@ -110,6 +111,7 @@ func _on_dialog_line_started() -> void:
 ## [PopochiuDialog] active, otherwise shows the [code]"use"[/code] cursor.
 func _on_dialog_line_finished() -> void:
 	is_showing_dialog_line = false
+	
 	if D.current_dialog:
 		Cursor.show_cursor("gui")
 	elif E.hovered:

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -333,16 +333,18 @@ func _toggle_description(is_hover: bool) -> void:
 		last_click_button = -1
 		
 		G.mouse_exited_inventory_item.emit(self)
-	
-	# NOTE: Not sure this should go here
-	#Cursor.set_cursor(cursor if is_hover else CURSOR.Type.IDLE)
-	#G.show_hover_text(self.description if is_hover else '')
 
 
 func _on_gui_input(event: InputEvent) -> void: 
 	if not PopochiuUtils.is_click_or_touch_pressed(event): return
 	
 	var event_index := PopochiuUtils.get_click_or_touch_index(event)
+	
+	# Fix #224 Clean E.clicked when an inventory item is clicked to ensure that the event is not
+	# mishandled by the GUI
+	if E.clicked:
+		E.clicked = null
+	
 	I.clicked = self
 	last_click_button = event_index
 	

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -114,8 +114,16 @@ func _physics_process(delta):
 
 
 func _unhandled_input(event: InputEvent):
-	if not has_player: return
+	if (
+		not PopochiuUtils.get_click_or_touch_index(event) in [
+			MOUSE_BUTTON_LEFT, MOUSE_BUTTON_RIGHT
+		]
+		or (not event is InputEventScreenTouch and E.hovered)
+	):
+		return
 	
+	# Fix #224 Item should be removed only if the click was done anywhere in the room when the
+	# cursor is not hovering another object
 	if I.active:
 		if event.is_action_released("popochiu-look")\
 		or event.is_action_pressed("popochiu-interact"):
@@ -125,13 +133,7 @@ func _unhandled_input(event: InputEvent):
 			I.set_active_item()
 		return
 	
-	if PopochiuUtils.get_click_or_touch_index(event) != MOUSE_BUTTON_LEFT:
-		return
-	
-	if not event is InputEventScreenTouch and E.hovered:
-		return
-	
-	if is_instance_valid(C.player) and C.player.can_move:
+	if has_player and is_instance_valid(C.player) and C.player.can_move:
 		# Set this property to null in order to cancel any running interaction with a
 		# PopochiuClickable (check PopochiuCharacter.walk_to_clicked(...))
 		E.clicked = null


### PR DESCRIPTION
Clean E.clicked when an inventory item is clicked and make sure items are removed when clicking anywhere in the room only if there is no PopochiuClickable hovered.

- **fix** The modified options in Project Settings > Popochiu were being hidden.
- **upd** Cursor texture is properly rendered when the mouse enters and exits the SettingsBar.
- **fea** (!) Inventory items fit the height of the inventory slot (in case of InventoryGrid) or the InventoryBar. This was only available when Experimental Scale GUI was on.