### PR TITLE
Fix #230

### DIFF
--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -31,8 +31,6 @@ func _ready():
 	
 	# Connect to autoload signals
 	E.ready.connect(show_cursor)
-	G.blocked.connect(_on_gui_blocked)
-	G.unblocked.connect(_on_gui_unblocked)
 
 
 func _process(delta):
@@ -160,19 +158,6 @@ func get_cursor_height() -> int:
 		height = secondary_cursor.texture.get_height()
 	
 	return height
-
-
-#endregion
-
-#region Private ####################################################################################
-func _on_gui_blocked() -> void:
-	show_cursor("wait")
-	is_blocked = true
-
-
-func _on_gui_unblocked() -> void:
-	is_blocked = false
-	show_cursor(G.get_cursor_name())
 
 
 #endregion

--- a/addons/popochiu/engine/interfaces/i_graphic_interface.gd
+++ b/addons/popochiu/engine/interfaces/i_graphic_interface.gd
@@ -100,10 +100,10 @@ func show_system_text(msg: String) -> void:
 	
 	if E.cutscene_skipped:
 		await get_tree().process_frame
+		
 		return
 	
 	system_text_shown.emit(E.get_text(msg))
-	
 	await system_text_hidden
 	
 	if not E.playing_queue and gui.popups_stack.is_empty():

--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -10,12 +10,12 @@ extends Area2D
 ## handle scaling.
 
 ## Used to allow devs to define the cursor type for the clickable.
-const CURSOR := preload('res://addons/popochiu/engine/cursor/cursor.gd')
+const CURSOR := preload("res://addons/popochiu/engine/cursor/cursor.gd")
 
 ## The identifier of the object used in scripts.
-@export var script_name := ''
+@export var script_name := ""
 ## The text shown to players when the cursor hovers the object.
-@export var description := ''
+@export var description := ""
 ## Whether the object will listen to interactions.
 @export var clickable := true
 ## The [code]y[/code] position of the baseline relative to the center of the object.
@@ -61,7 +61,7 @@ var _has_double_click: bool = false
 
 #region Godot ######################################################################################
 func _ready():
-	add_to_group('PopochiuClickable')
+	add_to_group("PopochiuClickable")
 	
 	if Engine.is_editor_hint():
 		hide_helpers()
@@ -75,11 +75,11 @@ func _ready():
 			return
 		
 		if interaction_polygon.is_empty():
-			interaction_polygon = get_node('InteractionPolygon').polygon
-			interaction_polygon_position = get_node('InteractionPolygon').position
+			interaction_polygon = get_node("InteractionPolygon").polygon
+			interaction_polygon_position = get_node("InteractionPolygon").position
 		else:
-			get_node('InteractionPolygon').polygon = interaction_polygon
-			get_node('InteractionPolygon').position = interaction_polygon_position
+			get_node("InteractionPolygon").polygon = interaction_polygon
+			get_node("InteractionPolygon").position = interaction_polygon_position
 		
 		return
 	else:
@@ -112,18 +112,18 @@ func _ready():
 
 func _process(delta):
 	if Engine.is_editor_hint():
-		if walk_to_point != get_node('WalkToHelper').position:
-			walk_to_point = get_node('WalkToHelper').position
+		if walk_to_point != get_node("WalkToHelper").position:
+			walk_to_point = get_node("WalkToHelper").position
 			
 			notify_property_list_changed()
-		elif baseline != get_node('BaselineHelper').position.y:
-			baseline = get_node('BaselineHelper').position.y
+		elif baseline != get_node("BaselineHelper").position.y:
+			baseline = get_node("BaselineHelper").position.y
 			
 			notify_property_list_changed()
 		
 		if editing_polygon:
-			interaction_polygon = get_node('InteractionPolygon').polygon
-			interaction_polygon_position = get_node('InteractionPolygon').position
+			interaction_polygon = get_node("InteractionPolygon").polygon
+			interaction_polygon_position = get_node("InteractionPolygon").position
 
 
 #endregion
@@ -237,28 +237,28 @@ func get_walk_to_point() -> Vector2:
 
 ## Called when the object is left clicked.
 func on_click() -> void:
-	_on_click()
+	await _on_click()
 
 
 ## Called when the object is double clicked.
 func on_double_click() -> void:
 	_reset_double_click()
-	_on_double_click()
+	await _on_double_click()
 
 
 ## Called when the object is right clicked.
 func on_right_click() -> void:
-	_on_right_click()
+	await _on_right_click()
 
 
 ## Called when the object is middle clicked.
 func on_middle_click() -> void:
-	_on_middle_click()
+	await _on_middle_click()
 
 
 ## Called when an [param item] is used on this object.
 func on_item_used(item: PopochiuInventoryItem) -> void:
-	_on_item_used(item)
+	await _on_item_used(item)
 
 
 ## Triggers the proper GUI command for the clicked mouse button identified with [param button_idx],
@@ -297,15 +297,15 @@ func handle_command(button_idx: int) -> void:
 func set_baseline(value: int) -> void:
 	baseline = value
 	
-	if Engine.is_editor_hint() and get_node_or_null('BaselineHelper'):
-		get_node('BaselineHelper').position = Vector2.DOWN * value
+	if Engine.is_editor_hint() and get_node_or_null("BaselineHelper"):
+		get_node("BaselineHelper").position = Vector2.DOWN * value
 
 
 func set_walk_to_point(value: Vector2) -> void:
 	walk_to_point = value
 	
-	if Engine.is_editor_hint() and get_node_or_null('WalkToHelper'):
-		get_node('WalkToHelper').position = value
+	if Engine.is_editor_hint() and get_node_or_null("WalkToHelper"):
+		get_node("WalkToHelper").position = value
 
 
 func set_room(value: Node2D) -> void:
@@ -358,19 +358,21 @@ func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int):
 	match event_index:
 		MOUSE_BUTTON_LEFT:
 			if I.active:
-				on_item_used(I.active)
+				await on_item_used(I.active)
 			else:
-				handle_command(event_index)
+				await handle_command(event_index)
 				times_clicked += 1
 		MOUSE_BUTTON_RIGHT, MOUSE_BUTTON_MIDDLE:
 			if I.active: return
 			
-			handle_command(event_index)
+			await handle_command(event_index)
 			
 			if event_index == MOUSE_BUTTON_RIGHT:
 				times_right_clicked += 1
 			elif event_index == MOUSE_BUTTON_MIDDLE:
 				times_middle_clicked += 1
+	
+	E.clicked = null
 
 
 func _toggle_input() -> void:
@@ -382,9 +384,7 @@ func _translate() -> void:
 	if Engine.is_editor_hint() or not is_inside_tree()\
 	or not E.settings.use_translations: return
 	
-	description = E.get_text(
-		'%s-%s' % [get_tree().current_scene.name, _description_code]
-	)
+	description = E.get_text("%s-%s" % [get_tree().current_scene.name, _description_code])
 
 
 # ---- @anthonyirwin82 -----------------------------------------------------------------------------

--- a/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/components/inventory_bar/inventory_bar.gd
@@ -1,7 +1,7 @@
 extends Control
 
 @export var always_visible := false
-@export var hide_when_gui_is_blocked := true
+@export var hide_when_gui_is_blocked := false
 
 var is_disabled := false
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_commands.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/sierra/sierra_commands.gd
@@ -57,14 +57,20 @@ func look() -> void:
 ## [code]E.command_fallback()[/code] is triggered.
 func interact() -> void:
 	if (I.active and I.clicked) and I.active != I.clicked:
+		# Item used on another item
 		G.show_system_text("%s can't use %s with %s" % [
 			C.player.description, I.active.description, I.clicked.description
 		])
-		I.clicked = null
+	elif I.active and E.clicked:
+		# Item used on a PopochiuClickable
+		G.show_system_text("%s can't use %s with %s" % [
+			C.player.description, I.active.description, E.clicked.description
+		])
 	elif I.clicked:
+		# Item selected in inventory
 		I.clicked.set_active()
-		I.clicked = null
 	else:
+		# PopochiuClickable clicked
 		G.show_system_text("%s doesn't want to do anything with that object" % C.player.description)
 
 

--- a/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/simple_click/simple_click_gui.gd
@@ -20,6 +20,23 @@ func _ready() -> void:
 #endregion
 
 #region Virtual ####################################################################################
+## Called when the GUI is blocked and not intended to handle input events.
+func _on_blocked(props := { blocking = true }) -> void:
+	Cursor.show_cursor("wait")
+	Cursor.is_blocked = true
+
+
+## Called when the GUI is unblocked and can handle input events again.
+func _on_unblocked() -> void:
+	Cursor.is_blocked = false
+	
+	if I.active:
+		Cursor.hide_main_cursor()
+		Cursor.show_secondary_cursor()
+	else:
+		Cursor.show_cursor(get_cursor_name())
+
+
 ## Called when a text is shown in the [SystemText] component. This erases the text in the
 ## [HoverText] component and shows the [code]"wait"[/code] cursor.
 func _on_system_text_shown(msg: String) -> void:

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -1,4 +1,4 @@
-@icon('res://addons/popochiu/icons/inventory_item.png')
+@icon("res://addons/popochiu/icons/inventory_item.png")
 class_name PopochiuInventoryItem
 extends TextureRect
 ## An inventory item.
@@ -7,7 +7,7 @@ extends TextureRect
 ## be used on other objects (i.e. [PopochiuClickable] or other inventory items).
 
 ## Used to allow devs to define the cursor type for the clickable.
-const CURSOR := preload('res://addons/popochiu/engine/cursor/cursor.gd')
+const CURSOR := preload("res://addons/popochiu/engine/cursor/cursor.gd")
 
 ## Emitted when the item is selected. 
 signal selected(item)
@@ -16,9 +16,9 @@ signal selected(item)
 signal unselected
 
 ## The identifier of the item used in scripts.
-@export var script_name := ''
+@export var script_name := ""
 ## The text shown to players when the cursor hovers the item.
-@export var description := '' : get = get_description
+@export var description := "" : get = get_description
 ## The cursor to use when the mouse hovers the object.
 @export var cursor: CURSOR.Type = CURSOR.Type.USE
 
@@ -108,10 +108,7 @@ func queue_add(animate := true) -> Callable:
 ## [/codeblock]
 func add(animate := true) -> void:
 	if I.is_full():
-		printerr(
-			"[Popochiu] Couldn't add %s. Inventory is full." %\
-			script_name
-		)
+		PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
 		
 		await get_tree().process_frame
 		return
@@ -257,25 +254,22 @@ func set_active(_ignore_block := false) -> void:
 
 ## Called when the item is clicked in the inventory.
 func on_click() -> void:
-	_on_click()
+	await _on_click()
 
 
 ## Called when the item is right clicked in the inventory.
 func on_right_click() -> void:
-	_on_right_click()
+	await _on_right_click()
 
 
 ## Called when the item is middle clicked in the inventory.
 func on_middle_click() -> void:
-	_on_middle_click()
+	await _on_middle_click()
 
 
 ## Called when the item is clicked and there is another [param item] currently selected.
 func on_item_used(item: PopochiuInventoryItem) -> void:
-	_on_item_used(item)
-	#await G.show_system_text(
-		#'Nothing happens when using %s in this item' % item.description
-	#)
+	await _on_item_used(item)
 
 
 ## Triggers the proper GUI command for the clicked mouse button identified with [param button_idx],
@@ -303,7 +297,7 @@ func handle_command(button_idx: int) -> void:
 		target = description
 	})
 	
-	call(prefix % suffix)
+	await call(prefix % suffix)
 
 
 #endregion
@@ -351,15 +345,17 @@ func _on_gui_input(event: InputEvent) -> void:
 	match event_index:
 		MOUSE_BUTTON_LEFT:
 			if I.active:
-				on_item_used(I.active)
+				await on_item_used(I.active)
 			else:
 				if DisplayServer.is_touchscreen_available():
 					G.mouse_entered_inventory_item.emit(self)
 				
-				handle_command(event_index)
+				await handle_command(event_index)
 		MOUSE_BUTTON_RIGHT, MOUSE_BUTTON_MIDDLE:
 			if not I.active:
-				handle_command(event_index)
+				await handle_command(event_index)
+	
+	I.clicked = null
 
 
 #endregion

--- a/addons/popochiu/engine/templates/inventory_item_template.gd
+++ b/addons/popochiu/engine/templates/inventory_item_template.gd
@@ -9,7 +9,7 @@ var state: Data = null
 # When the item is clicked in the inventory
 func _on_click() -> void:
 	# Replace the call to E.command_fallback() to implement your code.
-	set_active()
+	E.command_fallback()
 
 
 # When the item is right clicked in the inventory


### PR DESCRIPTION
Fixes #230: Now the Cursor is not in charge of changing its texture based on GUI blocking. It's the GUI's responsibility to determine what happens to the cursor when it's locked or unlocked.

- **upd** Clean E.clicked and I.clicked once the interaction is handled.
- **fix** Sierra GUI inventory item use was not behaving as expected.
- **fix** Rollback call to E.command_fallback() as the default call for the _on_click() function in inventory_item_template.gd.
- **fix** Hiding the InventoryBar by default when the GUI is blocked, was making the animation when adding new items not to shown because the node was invisible.