### PR TITLE
fixes #192: VFrame removed by default room state load.

### DIFF
--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -88,6 +88,7 @@ const PROPS_IGNORE := [
 	"cursor",
 	"always_on_top",
 	"frames",
+	"v_frames",
 	"link_to_item",
 	"_description_code",
 	"editing_polygon",


### PR DESCRIPTION
As suggested by @mapedorr , the v_frames property is now ignored when the room default state is loaded at scene start.