### PR TITLE
9 verbs interface: working GIVE command

### DIFF
--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_commands.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_commands.gd
@@ -110,10 +110,20 @@ func pull() -> void:
 ## Called when [code]E.current_command == Commands.GIVE[/code] and [code]E.command_fallback()[/code]
 ## is triggered.
 func give() -> void:
+	await _give_or_use(give_item_to)
+
+
+## Called when [code]E.current_command == Commands.USE[/code] and [code]E.command_fallback()[/code]
+## is triggered.
+func use() -> void:
+	await _give_or_use(use_item_on)
+
+
+func _give_or_use(callback: Callable) -> void:
 	if I.active and E.clicked:
-		give_item_to(I.active, E.clicked)
+		callback.call(I.active, E.clicked)
 	elif I.active and I.clicked and I.active != I.clicked:
-		give_item_to(I.active, I.clicked)
+		callback.call(I.active, I.clicked)
 	elif I.clicked:
 		match I.clicked.last_click_button:
 			MOUSE_BUTTON_LEFT:
@@ -136,31 +146,6 @@ func give() -> void:
 ## [code]E.command_fallback()[/code] is triggered.
 func talk_to() -> void:
 	await C.player.say("Emmmm...")
-
-
-## Called when [code]E.current_command == Commands.USE[/code] and [code]E.command_fallback()[/code]
-## is triggered.
-func use() -> void:
-	if I.active and E.clicked:
-		use_item_on(I.active, E.clicked)
-	elif I.active and I.clicked and I.active != I.clicked:
-		use_item_on(I.active, I.clicked)
-	elif I.clicked:
-		match I.clicked.last_click_button:
-			MOUSE_BUTTON_LEFT:
-				I.clicked.set_active(true)
-			MOUSE_BUTTON_RIGHT:
-				# TODO: I'm not sure this is the right way to do this. Maybe GUIs should capture
-				# 		click inputs on clickables and inventory items. ----------------------------
-				E.current_command = (
-					I.clicked.suggested_command if I.clicked.get("suggested_command")
-					else Commands.LOOK_AT
-				)
-				
-				I.clicked.handle_command(MOUSE_BUTTON_LEFT)
-				# ----------------------------------------------------------------------------------
-	else:
-		await C.player.say("What?")
 
 
 func use_item_on(_item: PopochiuInventoryItem, _target: Node) -> void:

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_commands.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_commands.gd
@@ -110,7 +110,26 @@ func pull() -> void:
 ## Called when [code]E.current_command == Commands.GIVE[/code] and [code]E.command_fallback()[/code]
 ## is triggered.
 func give() -> void:
-	await C.player.say("What?")
+	if I.active and E.clicked:
+		give_item_to(I.active, E.clicked)
+	elif I.active and I.clicked and I.active != I.clicked:
+		give_item_to(I.active, I.clicked)
+	elif I.clicked:
+		match I.clicked.last_click_button:
+			MOUSE_BUTTON_LEFT:
+				I.clicked.set_active(true)
+			MOUSE_BUTTON_RIGHT:
+				# TODO: I'm not sure this is the right way to do this. Maybe GUIs should capture
+				# 		click inputs on clickables and inventory items. ----------------------------
+				E.current_command = (
+					I.clicked.suggested_command if I.clicked.get("suggested_command")
+					else Commands.LOOK_AT
+				)
+				
+				I.clicked.handle_command(MOUSE_BUTTON_LEFT)
+				# ----------------------------------------------------------------------------------
+	else:	
+		await C.player.say("What?")
 
 
 ## Called when [code]E.current_command == Commands.TALK_TO[/code] and
@@ -148,5 +167,9 @@ func use_item_on(_item: PopochiuInventoryItem, _target: Node) -> void:
 	I.active = null
 	await C.player.say("I don't want to do that")
 
+
+func give_item_to(_item: PopochiuInventoryItem, _target: Node) -> void:
+	I.active = null
+	await C.player.say("I don't want to do that")
 
 #endregion

--- a/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/graphic_interface/templates/9_verb/9_verb_gui.gd
@@ -94,14 +94,7 @@ func _on_mouse_entered_clickable(clickable: PopochiuClickable) -> void:
 		$"9VerbPanel".highlight_command(clickable.suggested_command)
 	
 	if I.active:
-		G.show_hover_text(
-			"%s %s %s %s" % [
-				E.get_current_command_name(),
-				I.active.description,
-				"to" if E.current_command == NineVerbCommands.Commands.GIVE else "in",
-				clickable.description
-			]
-		)
+		_show_command_on(I.active.description, clickable.description)
 	else:
 		G.show_hover_text(clickable.description)
 
@@ -116,8 +109,7 @@ func _on_mouse_exited_clickable(clickable: PopochiuClickable) -> void:
 	Cursor.show_cursor()
 	
 	if I.active:
-		_show_use_on(I.active)
-		
+		_show_command_on(I.active.description)
 		return
 	
 	G.show_hover_text()
@@ -135,15 +127,7 @@ func _on_mouse_entered_inventory_item(inventory_item: PopochiuInventoryItem) -> 
 	Cursor.show_cursor()
 	
 	if I.active:
-		if E.current_command == NineVerbCommands.Commands.USE and I.active != inventory_item:
-			# Show a hover text in the form: Use xxx in yyy
-			G.show_hover_text(
-				"%s %s in %s" % [
-					E.get_current_command_name(),
-					I.active.description,
-					inventory_item.description
-				]
-			)
+		_show_command_on(I.active.description, inventory_item.description)
 	else:
 		G.show_hover_text(inventory_item.description)
 
@@ -159,7 +143,7 @@ func _on_mouse_exited_inventory_item(inventory_item: PopochiuInventoryItem) -> v
 	Cursor.show_cursor()
 	
 	if I.active:
-		G.show_hover_text("Use %s in" % I.active.description)
+		_show_command_on(I.active.description)
 		return
 	
 	G.show_hover_text()
@@ -200,7 +184,7 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 		E.current_command = NineVerbCommands.Commands.WALK_TO
 		G.show_hover_text()
 	else:
-		_show_use_on(item)
+		_show_command_on(item.description)
 
 
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText
@@ -244,8 +228,14 @@ func _on_quit_pressed() -> void:
 	quit_popup.open()
 
 
-func _show_use_on(item: PopochiuInventoryItem) -> void:
-	G.show_hover_text("%s %s in" % [E.get_current_command_name(), item.description])
-
+func _show_command_on(item_1_name: String, item_2_name: String = "") -> void:
+	var preposition = "on"
+	if E.current_command == NineVerbCommands.Commands.GIVE:
+		preposition = "to"
+	G.show_hover_text("%s %s %s %s" % [
+		E.get_current_command_name(), 
+		item_1_name, 
+		preposition,
+		item_2_name])
 
 #endregion


### PR DESCRIPTION
On engine level Give is the same as Use, so only few changes to 9_verb_commands.gd and 9_verb_gui.gd
and no changes on the main engine.
Refactored _show_use_on() to _show_command_on() - one function for USE and GIVE and moved prepositions ('use ON', 'give TO') to one place so we can easy translate it in the future.
It calls _on_item_used() just like USE because we often wants to 'Give item to character' and 'Use item on character'  to work the same. We can check and differentiate behaviour by testing E.current_command

Like this:

```
func _on_item_used(item: PopochiuInventoryItem) -> void:
	if E.current_command == NineVerbCommands.Commands.GIVE:
		if item == I.Mushrooms:
			await C.player.say("Give mushroom")
		if item == I.Pumpkin:
			await C.player.say("Give pumpkin")
	else:
		if item == I.Mushrooms:
			await C.player.say("Use mushroom")
		if item == I.Pumpkin:
			await C.player.say("Use pumpkin")
```