### PR TITLE
Fix changing PopochiuClickable.clickable in runtime

### DIFF
--- a/addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.gd
@@ -1,5 +1,5 @@
 @tool
-@icon("res://addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.svg")
+@icon("res://addons/popochiu/editor/main_dock/popochiu_group/images/popochiu_group.svg")
 class_name PopochiuGroup
 extends PanelContainer
 

--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -17,7 +17,7 @@ const CURSOR := preload("res://addons/popochiu/engine/cursor/cursor.gd")
 ## The text shown to players when the cursor hovers the object.
 @export var description := ""
 ## Whether the object will listen to interactions.
-@export var clickable := true
+@export var clickable := true : set = set_clickable
 ## The [code]y[/code] position of the baseline relative to the center of the object.
 @export var baseline := 0 : set = set_baseline
 ## The [Vector2] position where characters will move when aproaching the object.
@@ -284,6 +284,11 @@ func handle_command(button_idx: int) -> void:
 #endregion
 
 #region SetGet #####################################################################################
+func set_clickable(value: bool) -> void:
+	clickable = value
+	input_pickable = clickable
+
+
 func set_baseline(value: int) -> void:
 	baseline = value
 


### PR DESCRIPTION
Now it has a setter method that changes the `Area2D.input_pickable` value based on the `clickable` property.

- **fix** Set right path to **PopochiuGroup** icon.