### PR TITLE
Fix #239 by auto-enabling WAV looping.

### DIFF
--- a/addons/popochiu/engine/audio_manager/audio_cue.gd
+++ b/addons/popochiu/engine/audio_manager/audio_cue.gd
@@ -156,15 +156,9 @@ func set_loop(value: bool) -> void:
 		'AudioStreamOggVorbis', 'AudioStreamMP3':
 			audio.loop = value
 		'AudioStreamWAV':
-			if (audio as AudioStreamWAV).get_loop_end() == 0 && value:
-				PopochiuUtils.print_warning(
-					"[b]%s[/b]" % resource_name \
-					+ " does not have the correct metadata to loop, please reimport the file by" \
-					+ " setting its Loop Mode to Forward."
-				)
-			else:
-				(audio as AudioStreamWAV).loop_mode =\
+			(audio as AudioStreamWAV).loop_mode = (
 				AudioStreamWAV.LOOP_FORWARD if value else AudioStreamWAV.LOOP_DISABLED
+			)
 	
 	notify_property_list_changed()
 

--- a/addons/popochiu/engine/audio_manager/audio_cue.gd
+++ b/addons/popochiu/engine/audio_manager/audio_cue.gd
@@ -158,14 +158,13 @@ func set_loop(value: bool) -> void:
 		'AudioStreamWAV':
 			if (audio as AudioStreamWAV).get_loop_end() == 0 && value:
 				PopochiuUtils.print_warning(
-					"[b]%s[/b]" % resource_name +\
-					" does not have the correct metadata to loop, please check" +\
-					" AudioStreamWAV documentation"
+					"[b]%s[/b]" % resource_name \
+					+ " does not have the correct metadata to loop, please reimport the file by" \
+					+ " setting its Loop Mode to Forward."
 				)
 			else:
 				(audio as AudioStreamWAV).loop_mode =\
-				AudioStreamWAV.LOOP_FORWARD if value\
-				else AudioStreamWAV.LOOP_DISABLED
+				AudioStreamWAV.LOOP_FORWARD if value else AudioStreamWAV.LOOP_DISABLED
 	
 	notify_property_list_changed()
 


### PR DESCRIPTION
Fix #239 : Popochiu now sets the loop mode for WAV files to `FORWARD` or `DISABLED` based on the type of the **PopochiuAudioCue**. This will save developers from having to manually re-import these files to enable looping.