### PR TITLE
Update how camera limits are defined for rooms

### DIFF
--- a/addons/popochiu/editor/factories/factory_popochiu_room.gd
+++ b/addons/popochiu/editor/factories/factory_popochiu_room.gd
@@ -38,6 +38,8 @@ func create(obj_name: String, set_as_main := false) -> int:
 	
 	new_obj.name = "Room" + _pascal_name
 	new_obj.script_name = _pascal_name
+	new_obj.width = ProjectSettings.get_setting(PopochiuResources.DISPLAY_WIDTH)
+	new_obj.height = ProjectSettings.get_setting(PopochiuResources.DISPLAY_HEIGHT)
 	# ---- END OF LOCAL CODE -----------------------------------------------------------------------
 	
 	# Save the scene (.tscn)

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -251,11 +251,11 @@ func has_character(character_name: String) -> bool:
 
 ## Called by Popochiu when loading the room to assign its camera limits to the player camera.
 func setup_camera() -> void:
-	if width > 0 and width != E.width:
+	if width > 0 and width > E.width:
 		var h_diff: int = (E.width - width) / 2
 		E.camera.limit_left = h_diff
 		E.camera.limit_right = E.width - h_diff
-	if height > 0 and height != E.height:
+	if height > 0 and height > E.height:
 		var v_diff: int = (E.height - height) / 2
 		E.camera.limit_top = -v_diff
 		E.camera.limit_bottom = E.height - v_diff

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -16,7 +16,18 @@ extends Node2D
 ## If [code]true[/code] the whole GUI will be hidden when the room is loaded. Useful for cutscenes,
 ## splash screens and when showing game menus or popups.
 @export var hide_gui := false
+@export_category("Room size")
+## Defines the width of the room. If it is different from the viewport width defined for the
+## project, this value is used to calculate the camera limits so that it follows the player as they
+## move through the room.
+@export var width: int = 0
+## Defines the height of the room. If it is different from the viewport height defined for the
+## project, this value is used to calculate the camera limits so that it follows the player as they
+## move through the room.
+@export var height: int = 0
+## @deprecated
 @export_category("Camera limits")
+## @deprecated
 ## If this different from [constant INF], the value will define the left limit of the camera
 ## relative to the native game resolution. I.e. if your native game resolution is 320x180, and the
 ## background (size) of the room is 448x180, the left limit of the camera should be -64 (this is the
@@ -24,6 +35,7 @@ extends Node2D
 ## [br][br][i]Set this on rooms that are bigger than the native game resolution so the camera will
 ## follow the character.[/i]
 @export var limit_left := INF
+## @deprecated
 ## If this different from [constant INF], the value will define the right limit of the camera
 ## relative to the native game resolution. I.e. if your native game resolution is 320x180, and the
 ## background (size) of the room is 448x180, the right limit of the camera should be 384 (320 + 64
@@ -31,11 +43,13 @@ extends Node2D
 ## [br][br][i]Set this on rooms that are bigger than the native game resolution so the camera will
 ## follow the character.[/i]
 @export var limit_right := INF
+## @deprecated
 ## If this different from [constant INF], the value will define the top limit of the camera
 ## relative to the native game resolution.
 ## [br][br][i]Set this on rooms that are bigger than the native game resolution so the camera will
 ## follow the character.[/i]
 @export var limit_top := INF
+## @deprecated
 ## If this different from [constant INF], the value will define the bottom limit of the camera
 ## relative to the native game resolution.
 ## [br][br][i]Set this on rooms that are bigger than the native game resolution so the camera will
@@ -67,6 +81,11 @@ func _enter_tree() -> void:
 		y_sort_enabled = false
 		$Props.y_sort_enabled = false
 		$Characters.y_sort_enabled = false
+		
+		if width == 0:
+			width = ProjectSettings.get_setting(PopochiuResources.DISPLAY_WIDTH)
+		if height == 0:
+			height = ProjectSettings.get_setting(PopochiuResources.DISPLAY_HEIGHT)
 		
 		return
 	else:
@@ -232,14 +251,14 @@ func has_character(character_name: String) -> bool:
 
 ## Called by Popochiu when loading the room to assign its camera limits to the player camera.
 func setup_camera() -> void:
-	if limit_left != INF:
-		E.camera.limit_left = limit_left
-	if limit_right != INF:
-		E.camera.limit_right = limit_right
-	if limit_top != INF:
-		E.camera.limit_top = limit_top
-	if limit_bottom != INF:
-		E.camera.limit_bottom = limit_bottom
+	if width > 0 and width != E.width:
+		var h_diff: int = (E.width - width) / 2
+		E.camera.limit_left = h_diff
+		E.camera.limit_right = E.width - h_diff
+	if height > 0 and height != E.height:
+		var v_diff: int = (E.height - height) / 2
+		E.camera.limit_top = -v_diff
+		E.camera.limit_bottom = E.height - v_diff
 
 
 ## Remove all children from the [b]$Characters[/b] node, storing the children of each node to later

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -17,13 +17,11 @@ extends Node2D
 ## splash screens and when showing game menus or popups.
 @export var hide_gui := false
 @export_category("Room size")
-## Defines the width of the room. If it is different from the viewport width defined for the
-## project, this value is used to calculate the camera limits so that it follows the player as they
-## move through the room.
+## Defines the room's width. If this exceeds from the project's viewport width, this value is used
+## to calculate the camera limits, ensuring it follows the player as they move within the room.
 @export var width: int = 0
-## Defines the height of the room. If it is different from the viewport height defined for the
-## project, this value is used to calculate the camera limits so that it follows the player as they
-## move through the room.
+## Defines the room's height. If this exceeds from the project's viewport height, this value is used
+## to calculate the camera limits, ensuring it follows the player as they move within the room.
 @export var height: int = 0
 ## @deprecated
 @export_category("Camera limits")

--- a/addons/popochiu/migration/migrations/popochiu_migration_2.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_2.gd
@@ -14,6 +14,7 @@ const STEPS = [
 	"Remove [b]BaselineHelper[/b] and [b]WalkToHelper[/b] nodes in [b]PopochiuClickable[/b]s." \
 	+ " Also remove [b]DialogPos[/b] node in [b]PopochiuCharacter[/b]s. (pre [i]release[/i])",
 	"Update uses of deprecated properties and methods. (pre [i]release[/i])",
+	"Update how camera limits are defined",
 ]
 const RESET_CHILDREN_OWNER = "reset_children_owner"
 const GAME_INVENTORY_BAR_PATH =\
@@ -50,6 +51,7 @@ func _do_migration() -> bool:
 			_update_simple_click_settings_bar,
 			_remove_helper_nodes,
 			_replace_deprecated,
+			_update_camera_limits,
 		]
 	)
 
@@ -97,7 +99,7 @@ func _update_room(popochiu_room: PopochiuRoom) -> bool:
 	
 	if PopochiuEditorHelper.pack_scene(popochiu_room) != OK:
 		PopochiuUtils.print_error(
-			"Migration 1: Couldn't update [b]%s[/b] after adding new nodes." %
+			"Migration 2: Couldn't update [b]%s[/b] after adding new nodes." %
 			popochiu_room.script_name
 		)
 	
@@ -110,7 +112,7 @@ func _update_room(popochiu_room: PopochiuRoom) -> bool:
 	
 	if room_object_updated and PopochiuEditorHelper.pack_scene(popochiu_room) != OK:
 		PopochiuUtils.print_error(
-			"Migration 1: Couldn't update [b]%s[/b] after adding lacking nodes." %
+			"Migration 2: Couldn't update [b]%s[/b] after adding lacking nodes." %
 			popochiu_room.script_name
 		)
 	
@@ -622,6 +624,49 @@ func _replace_deprecated() -> Completion:
 		{from = "return super.get_item_instance(", to = "return get_item_instance("},
 		{from = "return E.get_dialog(", to = "return get_instance("},
 	]) else Completion.IGNORED
+
+
+## Update the way camera limits are defined for each room to use the new `width` and `height`
+## properties.
+func _update_camera_limits() -> Completion:
+	var any_room_updated := PopochiuUtils.any_exhaustive(
+		PopochiuEditorHelper.get_rooms(), _update_room_size
+	)
+	
+	_reload_needed = any_room_updated
+	return Completion.DONE if any_room_updated else Completion.IGNORED
+
+
+## Updates the values of [member PopochiuRoom.width] and [member PopochiuRoom.height] in
+## [param popochiu_room] based on the values of the deprecated camera limits properties.
+func _update_room_size(popochiu_room: PopochiuRoom) -> bool:
+	var viewport_width := ProjectSettings.get_setting(PopochiuResources.DISPLAY_WIDTH)
+	var viewport_height := ProjectSettings.get_setting(PopochiuResources.DISPLAY_HEIGHT)
+	
+	if is_inf(popochiu_room.limit_left) and is_inf(popochiu_room.limit_right):
+		popochiu_room.width = viewport_width
+	else:
+		var left := 0.0 if is_inf(popochiu_room.limit_left) else popochiu_room.limit_left
+		var right := 0.0 if is_inf(popochiu_room.limit_right) else popochiu_room.limit_right
+		popochiu_room.width = viewport_width - left
+		popochiu_room.width += right - viewport_width
+	
+	if is_inf(popochiu_room.limit_top) and is_inf(popochiu_room.limit_bottom):
+		popochiu_room.height = viewport_height
+	else:
+		var top := 0.0 if is_inf(popochiu_room.limit_top) else popochiu_room.limit_top
+		var bottom := 0.0 if is_inf(popochiu_room.limit_bottom) else popochiu_room.limit_bottom
+		popochiu_room.height = viewport_height - top
+		popochiu_room.height += bottom - viewport_height
+	
+	if PopochiuEditorHelper.pack_scene(popochiu_room) != OK:
+		PopochiuUtils.print_error(
+			"Migration 2: Couldn't update the [code]width[/code] and [code]height[/code] of" +\
+			" [b]%s[/b] room." % popochiu_room.script_name
+		)
+		return false
+	
+	return true
 
 
 #endregion

--- a/addons/popochiu/migration/migrations/popochiu_migration_2.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_2.gd
@@ -643,21 +643,21 @@ func _update_room_size(popochiu_room: PopochiuRoom) -> bool:
 	var viewport_width := ProjectSettings.get_setting(PopochiuResources.DISPLAY_WIDTH)
 	var viewport_height := ProjectSettings.get_setting(PopochiuResources.DISPLAY_HEIGHT)
 	
-	if is_inf(popochiu_room.limit_left) and is_inf(popochiu_room.limit_right):
-		popochiu_room.width = viewport_width
-	else:
-		var left := 0.0 if is_inf(popochiu_room.limit_left) else popochiu_room.limit_left
-		var right := 0.0 if is_inf(popochiu_room.limit_right) else popochiu_room.limit_right
-		popochiu_room.width = viewport_width - left
-		popochiu_room.width += right - viewport_width
+	# Calculate the width based on the camera limits
+	var left := 0.0 if is_inf(popochiu_room.limit_left) else popochiu_room.limit_left
+	var right := 0.0 if is_inf(popochiu_room.limit_right) else popochiu_room.limit_right
+	var width: int = viewport_width - int(left)
+	width += int(right) - viewport_width
 	
-	if is_inf(popochiu_room.limit_top) and is_inf(popochiu_room.limit_bottom):
-		popochiu_room.height = viewport_height
-	else:
-		var top := 0.0 if is_inf(popochiu_room.limit_top) else popochiu_room.limit_top
-		var bottom := 0.0 if is_inf(popochiu_room.limit_bottom) else popochiu_room.limit_bottom
-		popochiu_room.height = viewport_height - top
-		popochiu_room.height += bottom - viewport_height
+	popochiu_room.width = maxi(width, viewport_width)
+	
+	# Calculate the height based on the camera limits
+	var top := 0.0 if is_inf(popochiu_room.limit_top) else popochiu_room.limit_top
+	var bottom := 0.0 if is_inf(popochiu_room.limit_bottom) else popochiu_room.limit_bottom
+	var height: int = viewport_height - int(top)
+	height += int(bottom) - viewport_height
+	
+	popochiu_room.height = maxi(height, viewport_height)
 	
 	if PopochiuEditorHelper.pack_scene(popochiu_room) != OK:
 		PopochiuUtils.print_error(

--- a/addons/popochiu/migration/migrations/popochiu_migration_2.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_2.gd
@@ -14,7 +14,7 @@ const STEPS = [
 	"Remove [b]BaselineHelper[/b] and [b]WalkToHelper[/b] nodes in [b]PopochiuClickable[/b]s." \
 	+ " Also remove [b]DialogPos[/b] node in [b]PopochiuCharacter[/b]s. (pre [i]release[/i])",
 	"Update uses of deprecated properties and methods. (pre [i]release[/i])",
-	"Update how camera limits are defined",
+	"Update rooms sizes",
 ]
 const RESET_CHILDREN_OWNER = "reset_children_owner"
 const GAME_INVENTORY_BAR_PATH =\
@@ -51,7 +51,7 @@ func _do_migration() -> bool:
 			_update_simple_click_settings_bar,
 			_remove_helper_nodes,
 			_replace_deprecated,
-			_update_camera_limits,
+			_update_rooms_sizes,
 		]
 	)
 
@@ -626,9 +626,9 @@ func _replace_deprecated() -> Completion:
 	]) else Completion.IGNORED
 
 
-## Update the way camera limits are defined for each room to use the new `width` and `height`
-## properties.
-func _update_camera_limits() -> Completion:
+## Update camera limit calculations for each room to utilize the new [member PopochiuRoom.width]
+## and [member PopochiuRoom.height] properties.
+func _update_rooms_sizes() -> Completion:
 	var any_room_updated := PopochiuUtils.any_exhaustive(
 		PopochiuEditorHelper.get_rooms(), _update_room_size
 	)


### PR DESCRIPTION
Now instead of using the `camera_limits` properties (which are now **deprecated**), two new properties were added to **PopochiuRoom**s: `width` and `height`. Popochiu will calculate the camera limits based on the values of those properties instead of asking devs to calculate them by hand.

The corresponding migration step was added to Migration 2 in order to ensure old projects will be updated.