### PR TITLE
refs #273: Fix Room tab not working as expected

### DIFF
--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -190,6 +190,8 @@ func _on_dock_ready() -> void:
 	
 	if EditorInterface.get_edited_scene_root():
 		dock.scene_changed(EditorInterface.get_edited_scene_root())
+	else:
+		dock.check_open_scenes()
 	
 	PopochiuResources.update_autoloads(true)
 	_editor_file_system.scan_sources()


### PR DESCRIPTION
Fixes #273 

If there are no opened scenes in the Editor, now the PopochiuDock listens to a node selection (EditorSelection.selection_changed) in order to ensure that the Room tab continues to function as expected.