### PR TITLE
Various fixes related (mostly) to visual issues

### DIFF
--- a/addons/popochiu/editor/main_dock/tab_room/tab_room.gd
+++ b/addons/popochiu/editor/main_dock/tab_room/tab_room.gd
@@ -389,6 +389,9 @@ func _on_child_removed(node: Node, type_id: int) -> void:
 
 
 func _check_undoredo_history() -> void:
+	if not opened_room or not is_instance_valid(opened_room):
+		return
+	
 	var walkable_areas: Array = opened_room.call(
 		_types[PopochiuResources.Types.WALKABLE_AREA].method
 	)

--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -200,7 +200,12 @@ func room_readied(room: PopochiuRoom) -> void:
 		# Calling this will make the camera be set to its default values and will store the state of
 		# the main room (the last parameter will prevent Popochiu from changing the scene to the
 		# same that is already loaded)
-		goto_room(room.script_name, false, true, true)
+		# TODO: We should have an option in Popochiu Settings which allows devs to turn on the scene
+		# transition effect even when they are opened from the Editor (by pressing F5, F6 or using
+		# the buttons to play a scene. This option will be linked to the second parameter of the
+		# goto_room function, and we'll have to make sure the transition layer starts visible in
+		# those cases (as if it were coming from another room).
+		await goto_room(room.script_name, false, true, true)
 	
 	# Make the camera be ready for the room
 	current.setup_camera()

--- a/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_overhead/dialog_overhead.gd
+++ b/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_overhead/dialog_overhead.gd
@@ -9,12 +9,13 @@ func _modify_size(msg: String, target_position: Vector2) -> void:
 	rich_text_label.size = _size
 	rich_text_label.position = target_position - rich_text_label.size / 2.0
 	rich_text_label.position.y -= rich_text_label.size.y / 2.0
-
 	# Calculate overflow and reposition
 	if rich_text_label.position.x < 0.0:
 		rich_text_label.position.x = limit_margin
-	elif rich_text_label.position.x + rich_text_label.size.x > _x_limit:
-		rich_text_label.position.x = _x_limit - limit_margin - rich_text_label.size.x
+	elif rich_text_label.position.x + rich_text_label.size.x + continue_icon_size.x > _x_limit:
+		rich_text_label.position.x = (
+			_x_limit - limit_margin - rich_text_label.size.x - continue_icon_size.x
+		)
 	if rich_text_label.position.y < 0.0:
 		rich_text_label.position.y = limit_margin
 	elif rich_text_label.position.y + rich_text_label.size.y > _y_limit:

--- a/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
@@ -26,6 +26,7 @@ var _y_limit := 0.0
 
 @onready var rich_text_label: RichTextLabel = %RichTextLabel
 @onready var continue_icon: TextureProgressBar = %ContinueIcon
+@onready var continue_icon_size := continue_icon.texture_progress.get_size()
 
 
 #region Godot ######################################################################################

--- a/addons/popochiu/engine/objects/gui/components/hover_text/hover_text.gd
+++ b/addons/popochiu/engine/objects/gui/components/hover_text/hover_text.gd
@@ -3,7 +3,7 @@ class_name PopochiuHoverText
 
 @export var hide_during_dialogs := false
 
-@onready var label: RichTextLabel = $Label
+@onready var label: RichTextLabel = $RichTextLabel
 
 
 #region Godot ######################################################################################

--- a/addons/popochiu/engine/objects/gui/components/hover_text/hover_text.tscn
+++ b/addons/popochiu/engine/objects/gui/components/hover_text/hover_text.tscn
@@ -14,7 +14,7 @@ mouse_filter = 2
 theme = ExtResource("1_s7kd8")
 script = ExtResource("2_r2ckj")
 
-[node name="Label" type="RichTextLabel" parent="."]
+[node name="RichTextLabel" type="RichTextLabel" parent="."]
 layout_mode = 1
 anchors_preset = 10
 anchor_right = 1.0

--- a/addons/popochiu/engine/objects/gui/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb/components/9_verb_hover_text/9_verb_hover_text.gd
@@ -76,6 +76,8 @@ func _show_text(txt := "") -> void:
 	
 	if follows_cursor and _can_change_size:
 		label.size += Vector2.ONE * (Cursor.get_cursor_height() / 2)
+		# Adding 2.0 fixes a visual bug that was showing the first character of the text cutted
+		label.size.x += 2.0
 
 
 #endregion

--- a/addons/popochiu/migration/migrations/popochiu_migration_2.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_2.gd
@@ -27,8 +27,7 @@ const GAME_DIALOG_MENU_OPTION_PATH =\
 const ADDON_DIALOG_MENU_PATH =\
 "res://addons/popochiu/engine/objects/gui/components/dialog_menu/dialog_menu.tscn"
 const TextSpeedOption = preload(
-	PopochiuResources.GUI_TEMPLATES_FOLDER
-	+ "simple_click/components/settings_bar/resources/text_speed_option.gd"
+	PopochiuResources.GUI_ADDON_FOLDER + "components/settings_bar/resources/text_speed_option.gd"
 )
 
 var _gui_templates_helper := preload(

--- a/addons/popochiu/popochiu_resources.gd
+++ b/addons/popochiu/popochiu_resources.gd
@@ -43,8 +43,9 @@ const MAIN_TYPES = [
 const ROOM_TYPES = [Types.PROP, Types.HOTSPOT, Types.REGION, Types.MARKER, Types.WALKABLE_AREA]
 const DOCUMENTATION = "https://carenalgas.github.io/popochiu/"
 const CFG = "res://addons/popochiu/plugin.cfg"
+const GUI_ADDON_FOLDER = "res://addons/popochiu/engine/objects/gui/"
+const GUI_TEMPLATES_FOLDER = GUI_ADDON_FOLDER + "templates/"
 const GUI_SCRIPT_TEMPLATES_FOLDER = "res://addons/popochiu/engine/templates/gui/"
-const GUI_TEMPLATES_FOLDER = "res://addons/popochiu/engine/objects/gui/templates/"
 const RETRO_RESOLUTION = Vector2(356.0, 200.0)
 # SINGLETONS ---------------------------------------------------------------------------------------
 const GLOBALS_SNGL = "res://game/popochiu_globals.gd"
@@ -66,7 +67,6 @@ const G_SNGL = "res://game/autoloads/g.gd"
 # FIRST INSTALL ------------------------------------------------------------------------------------
 const GI = 0
 const TL = 1
-const GUI_ADDON_FOLDER = "res://addons/popochiu/engine/objects/gui/"
 const TRANSITION_LAYER_ADDON =\
 "res://addons/popochiu/engine/objects/transition_layer/transition_layer.tscn"
 # ENGINE -------------------------------------------------------------------------------------------

--- a/project.godot
+++ b/project.godot
@@ -75,7 +75,6 @@ common/enable_pause_aware_picking=true
 [popochiu]
 
 pixel/pixel_art_textures=true
-inventory/items_on_start=["Key"]
 
 [rendering]
 


### PR DESCRIPTION
- **fix** Make 9VerbHoverText component render its text properly without cutting the first letter of the string.
- **fix** Take into account the size of the continue icon in the DialogOverhead component so it is not rendered out of screen when it exceeds the size of the viewport.
- **fix** Add null validation in Room tab when importing Aseprite rooms.
- **fix** Remove the Key string from the `items_on_start` property in project.godot.
- **fix** Update path of TextSpeedOption script in Migration 2 script.