### PR TITLE
Fix characters not updating their walk_to_point property

### DIFF
--- a/addons/popochiu/editor/gizmos/gizmo_clickable_plugin.gd
+++ b/addons/popochiu/editor/gizmos/gizmo_clickable_plugin.gd
@@ -44,6 +44,9 @@ func _enter_tree() -> void:
 #region Virtual ####################################################################################
 
 func _edit(object: Object) -> void:
+	if object.get_class() == "EditorDebuggerRemoteObject":
+		return
+	
 	_target_node = object
 	_active_gizmos.clear()
 

--- a/addons/popochiu/editor/inspector/aseprite_importer_inspector_plugin.gd
+++ b/addons/popochiu/editor/inspector/aseprite_importer_inspector_plugin.gd
@@ -24,8 +24,11 @@ func _parse_begin(object: Object):
 	_target_node = object
 
 
-func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide):
-	if name != 'popochiu_placeholder': return false
+func _parse_property(object, type, name, hint_type, hint_string, usage_flags, wide) -> bool:
+	if object.get_class() == "EditorDebuggerRemoteObject":
+		return false
+	if name != 'popochiu_placeholder':
+		return false
 	# Instanciate and configure the dock
 	var dock = INSPECTOR_DOCK.instantiate()
 	# Load the specific script in the dock

--- a/addons/popochiu/editor/inspector/character_inspector_plugin.gd
+++ b/addons/popochiu/editor/inspector/character_inspector_plugin.gd
@@ -9,6 +9,9 @@ func _can_handle(object: Object) -> bool:
 
 
 func _parse_begin(object: Object) -> void:
+	if object.get_class() == "EditorDebuggerRemoteObject":
+		return
+	
 	if not object.get_parent() is Node2D: return
 	
 	var panel := PanelContainer.new()
@@ -49,10 +52,19 @@ func _parse_property(
 	usage,
 	wide: bool
 ) -> bool:
+	if object.get_class() == "EditorDebuggerRemoteObject":
+		return false
+	
 	# NOTE: We could add this as an option of the plugin settings. So devs can add extra properties
 	# 		if needed.
 	if object and object.get_parent() is Node2D and not path in [
-		"position", "visible", "modulate", "self_modulate", "light_mask"
+		"baseline",
+		"walk_to_point",
+		"position",
+		"visible",
+		"modulate",
+		"self_modulate",
+		"light_mask",
 	]:
 		return true
 	

--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -238,6 +238,8 @@ func room_readied(room: PopochiuRoom) -> void:
 		chr.modulate = Color.from_string(chr_dic.modulate, Color.WHITE)
 		chr.self_modulate = Color.from_string(chr_dic.self_modulate, Color.WHITE)
 		chr.light_mask = chr_dic.light_mask
+		chr.baseline = chr_dic.baseline
+		chr.walk_to_point = chr_dic.walk_to_point
 		
 		current.add_character(chr)
 	

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -792,6 +792,47 @@ func get_dialog_pos() -> float:
 	return dialog_pos.y
 
 
+func update_position() -> void:
+	position = (
+		position_stored 
+		if position_stored 
+		else position
+	)
+
+
+## Updates the scale depending on the properties of the scaling region where it is located.
+func update_scale():
+	if on_scaling_region:
+		var polygon_range = (
+			on_scaling_region["polygon_bottom_y"] - on_scaling_region["polygon_top_y"]
+			)
+		var scale_range = (
+			on_scaling_region["scale_bottom"] - on_scaling_region["scale_top"]
+			)
+
+		var position_from_the_top_of_region = (
+			position.y-on_scaling_region["polygon_top_y"]
+			)
+
+		var scale_for_position = (
+			on_scaling_region["scale_top"]+(
+				scale_range/polygon_range*position_from_the_top_of_region
+		)
+		)
+		scale.x = [
+			[scale_for_position, on_scaling_region["scale_min"]].max(), 
+			on_scaling_region["scale_max"]
+		].min()
+		scale.y = [
+			[scale_for_position, on_scaling_region["scale_min"]].max(), 
+			on_scaling_region["scale_max"]
+		].min()
+		walk_speed = default_walk_speed/default_scale.x*scale_for_position
+	else:
+		scale = default_scale
+		walk_speed = default_walk_speed
+
+
 #endregion
 
 #region SetGet #####################################################################################

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -49,8 +49,6 @@ func _ready() -> void:
 	for c in get_children():
 		if c.get('position') is Vector2:
 			c.position.y -= baseline * c.scale.y
-		elif c.get('position') is Vector2:
-			c.position.y -= baseline * c.scale.y
 
 	walk_to_point.y -= baseline * scale.y
 	position.y += baseline * scale.y

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -133,7 +133,7 @@ func _check_scaling(
 		
 	if scaling:
 		_update_scaling_region(area)
-		R.current.update_character_scale(area)
+		area.update_scale()
 
 
 func _update_scaling_region(chr: PopochiuCharacter) -> void:

--- a/addons/popochiu/engine/objects/room/popochiu_room.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room.gd
@@ -276,48 +276,10 @@ func clean_characters() -> void:
 		c.queue_free()
 
 
-## Updates the scale of [param chr] depending on the properties of the scaling region where it is
-## located.
-func update_character_scale(chr: PopochiuCharacter):
-	if chr.on_scaling_region:
-		var polygon_range = (
-			chr.on_scaling_region["polygon_bottom_y"] - chr.on_scaling_region["polygon_top_y"]
-			)
-		var scale_range = (
-			chr.on_scaling_region["scale_bottom"] - chr.on_scaling_region["scale_top"]
-			)
-
-		var position_from_the_top_of_region = (
-			chr.position.y-chr.on_scaling_region["polygon_top_y"]
-			)
-
-		var scale_for_position = (
-			chr.on_scaling_region["scale_top"]+(
-				scale_range/polygon_range*position_from_the_top_of_region
-		)
-		)
-		chr.scale.x = [
-			[scale_for_position, chr.on_scaling_region["scale_min"]].max(), 
-			chr.on_scaling_region["scale_max"]
-		].min()
-		chr.scale.y = [
-			[scale_for_position, chr.on_scaling_region["scale_min"]].max(), 
-			chr.on_scaling_region["scale_max"]
-		].min()
-		chr.walk_speed = chr.default_walk_speed/chr.default_scale.x*scale_for_position
-	else:
-		chr.scale = chr.default_scale
-		chr.walk_speed = chr.default_walk_speed
-
-
 ## Updates the position of [param character] in the room, and then updates its scale.
 func update_characters_position(character: PopochiuCharacter):
-	character.position = (
-		character.position_stored 
-		if character.position_stored 
-		else character.position
-		)
-	update_character_scale(character)
+	character.update_position()
+	character.update_scale()
 
 
 ## Returns the [Marker2D] which [member Node.name] matches [param marker_name].
@@ -477,7 +439,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 				moving_character_data.character.position_stored = next_position
 			else:
 				moving_character_data.character.position = next_position
-				update_character_scale(moving_character_data.character)
+				moving_character_data.character.update_scale()
 			return
 
 		distance -= distance_between_points
@@ -485,7 +447,7 @@ func _move_along_path(distance: float, moving_character_data: Dictionary):
 		moving_character_data.path.remove_at(0)
 
 	moving_character_data.character.position = last_point
-	update_character_scale(moving_character_data.character)
+	moving_character_data.character.update_scale()
 	_clear_navigation_path(moving_character_data.character)
 
 

--- a/addons/popochiu/engine/objects/room/popochiu_room_data.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room_data.gd
@@ -146,7 +146,9 @@ func save_characters() -> void:
 			visible = pc.visible,
 			modulate = pc.modulate.to_html(),
 			self_modulate = pc.self_modulate.to_html(),
-			light_mask = pc.light_mask
+			light_mask = pc.light_mask,
+			baseline = pc.baseline,
+			walk_to_point = pc.walk_to_point,
 			# TODO: Store the state of the current animation (and more data if
 			# necessary)
 		}


### PR DESCRIPTION
Fixes #279

Now the property is stored as part of the room data so it is not lost when the room is loaded.

- **upd** Move characters position and scale calculation operations from PopochiuRoom to PopochiuCharacter.
- **fix** Add validations to remove Output error messages when inspecting nodes in Remote.