### PR TITLE
refs #293: Fix broken link to 2.0.0 download in README and LEEME files

### DIFF
--- a/LEEME.md
+++ b/LEEME.md
@@ -57,7 +57,7 @@ Por favor, revisa esta tabla para saber qué versión descargar dependiendo de l
 
 | Versión requerida de Godot | Lanzamiento de Popochiu |
 |---|---|
-| 4.3 y superior | [Popochiu 2.0](https://github.com/carenalgas/popochiu/releases/download/v2.0/popochiu-v2.0.0.zip) |
+| 4.3 y superior | [Popochiu 2.0.0](https://github.com/carenalgas/popochiu/releases/download/v2.0.0/popochiu-v2.0.0.zip) |
 | 3.5 a 3.6 | [Popochiu 1.10.1](https://github.com/carenalgas/popochiu/releases/download/v1.10.1/popochiu-v1.10.1.zip) |
 | 3.3 a 3.4.5 | [Popochiu 1.8.7](https://github.com/carenalgas/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip) |
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Please review this table to know which version to download, depending on the ver
 
 | Required Godot version | Popochiu Release |
 |---|---|
-| 4.3 and above | [Popochiu 2.0](https://github.com/carenalgas/popochiu/releases/download/v2.0/popochiu-v2.0.0.zip) |
+| 4.3 and above | [Popochiu 2.0.0](https://github.com/carenalgas/popochiu/releases/download/v2.0.0/popochiu-v2.0.0.zip) |
 | 3.5 to 3.6 | [Popochiu 1.10.1](https://github.com/carenalgas/popochiu/releases/download/v1.10.1/popochiu-v1.10.1.zip) |
 | 3.3 to 3.4.5 | [Popochiu 1.8.7](https://github.com/carenalgas/popochiu/releases/download/v1.8.7/popochiu-v1.8.7.zip) |
 


### PR DESCRIPTION
Fixes #293 by adding a `.0` to the download link.