### PR TITLE
Fix erraneous use of E instead of I when triggering inventory right click

### DIFF
--- a/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_commands.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_commands.gd
@@ -21,7 +21,7 @@ func fallback() -> void:
 	if is_instance_valid(I.clicked):
 		if I.clicked.last_click_button == MOUSE_BUTTON_LEFT:
 			await click_inventory_item()
-		elif E.clicked.last_click_button == MOUSE_BUTTON_RIGHT:
+		elif I.clicked.last_click_button == MOUSE_BUTTON_RIGHT:
 			await right_click_inventory_item()
 		else:
 			await RenderingServer.frame_post_draw


### PR DESCRIPTION
Fix an error when right-clicking on an inventory item: Instead of using the `I` singleton, it was using `E`.