### PR TITLE
Feature: Add AnimatedSprite2D support to characters

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -103,7 +103,7 @@ var default_scale := Vector2.ONE
 
 var _looking_dir: int = Looking.DOWN
 
-@onready var _animated_sprite: AnimatedSprite2D = ($Sprite2D as AnimatedSprite2D) if $Sprite2D.get_class() == "AnimatedSprite2D" else null
+@onready var _animated_sprite: AnimatedSprite2D = $Sprite2D if $Sprite2D is AnimatedSprite2D else null
 
 
 
@@ -120,10 +120,8 @@ func _ready():
 	else:
 		set_process(follow_player)
 	
-	for child in get_children():
-		if not child is Sprite2D:
-			continue
-		child.frame_changed.connect(_update_position)
+	for sprite_child in get_children().filter(func(child): return child is Sprite2D or child is AnimatedSprite2D):
+		sprite_child.frame_changed.connect(_update_position)
 	
 	move_ended.connect(_on_move_ended)
 


### PR DESCRIPTION
This supports `AnimatedSprite2D` for character animation as used in my game [With Our Eyes Wide Open](https://edmundito.itch.io/with-our-eyes-wide-open). It supports anti-glide animation and ignores the Animation Player node.

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/5206d886-2f82-490b-a246-440d61611493">

What the user needs to do:
1. Replace the type of the `Sprite2D` node with `AnimatedSprite2D`
2. Add animations
3. Optional: Remove the AnimationPlayer node (currently, it ignores it if it detects the AnimatedSprite2D type)

## TODO
- [ ] Add edge case checks
- [ ] Code cleanup
- [ ] Discuss additional features
- [ ] Add documentation
