### PR TITLE
Feature: Show system text in queue when text does not contain colon

### DIFF
--- a/addons/popochiu/engine/helpers/popochiu_characters_helper.gd
+++ b/addons/popochiu/engine/helpers/popochiu_characters_helper.gd
@@ -41,7 +41,7 @@ static func execute_string(text: String) -> void:
 	elif ":" in text:
 		await _trigger_dialog_line(text)
 	else:
-		await E.get_tree().process_frame
+		await G.show_system_text(text)
 	
 	E.auto_continue_after = -1.0
 


### PR DESCRIPTION
This adds the ability to show system text when the text does not contain a colon. For example:
```gdscript
await E.queue([
  "Ego: I said something.",
  "Ego raises their hands.", # This be shown as system text
  "Ego: I AM HAPPY!"
]
```