### PR TITLE
added support to play or stop animations on the popochiu prop

### DIFF
--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -184,9 +184,10 @@ func play_animation_backwards(name: StringName = &"", custom_blend: float = -1) 
 	$AnimationPlayer.play_backwards(name, custom_blend)
 
 
-## Will stop the animation that is currently playing on the Popochiu Prop.
-## The animation position is reset to 0 and the custom_speed is reset to 1.0.
-## Set [param keep_state] to true to avoid the animation to be updated visually.
+## Will stop the animation that is currently playing.
+## The animation position is reset to [code]0[/code] and the [code]custom_speed[/code] is reset to
+## [code]1.0[/code]. Set [param keep_state] to [code]true[/code] to avoid the animation to be
+## updated visually.
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 func queue_stop_animation(keep_state: bool = false) -> Callable:
 	return func (): await stop_animation(keep_state)

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -206,7 +206,8 @@ func queue_pause_animation() -> Callable:
 
 
 ## Will pause the animation that is currently playing on the Popochiu Prop.
-## Call play_animation() without any parameter to resume the animation from the paused animation frame.
+## Will pause the animation that is currently playing.
+## Call [method play_animation] without any parameters to resume the animation.
 func pause_animation() -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.pause()

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -144,9 +144,27 @@ func get_total_frames() -> int:
 ## Prop if the [prop name] animation exists.
 ## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
 ## more details.
+## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
+func queue_play_animation(name: StringName = &"", custom_blend: float = -1, custom_speed: float = 1.0, from_end: bool = false) -> Callable:
+	return func (): await play_animation(name, custom_blend, custom_speed, from_end)
+
+
+## Will play the Popochiu Prop Animation Player [param name] animation on the Popochiu 
+## Prop if the [prop name] animation exists.
+## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
+## more details.
 func play_animation(name: StringName = &"", custom_blend: float = -1, custom_speed: float = 1.0, from_end: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.play(name, custom_blend, custom_speed, from_end)
+
+
+## Will Play the Popochiu Prop Animation Player [param name] animation backwards on the Popochiu
+## Prop if the [prop name] animation exits.
+## This method is a shorthand for play_animation() with custom_speed = -1.0 and from_end = true
+## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
+func queue_play_animation_backwards(name: StringName = &"", custom_blend: float = -1) -> Callable:
+	return func (): await play_animation_backwards(name, custom_blend)
+
 
 ## Will Play the Popochiu Prop Animation Player [param name] animation backwards on the Popochiu
 ## Prop if the [prop name] animation exits.
@@ -159,9 +177,23 @@ func play_animation_backwards(name: StringName = &"", custom_blend: float = -1) 
 ## Will stop the animation that is currently playing on the Popochiu Prop.
 ## The animation position is reset to 0 and the custom_speed is reset to 1.0.
 ## Set [param keep_state] to true to avoid the animation to be updated visually.
+## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
+func queue_stop_animation(keep_state: bool = false) -> Callable:
+	return func (): await stop_animation(keep_state)
+
+
+## Will stop the animation that is currently playing on the Popochiu Prop.
+## The animation position is reset to 0 and the custom_speed is reset to 1.0.
+## Set [param keep_state] to true to avoid the animation to be updated visually.
 func stop_animation(keep_state: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.stop(keep_state)
+
+## Will pause the animation that is currently playing on the Popochiu Prop.
+## If queue_play_animation() is run without parameters it will resume from the paused animation frame.
+## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
+func queue_pause_animation() -> Callable:
+	return func (): await pause_animation()
 
 
 ## Will pause the animation that is currently playing on the Popochiu Prop.

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -190,14 +190,14 @@ func stop_animation(keep_state: bool = false) -> void:
 	$AnimationPlayer.stop(keep_state)
 
 ## Will pause the animation that is currently playing on the Popochiu Prop.
-## If queue_play_animation() is run without parameters it will resume from the paused animation frame.
+## Call play_animation() without any parameter to resume the animation from the paused animation frame.
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 func queue_pause_animation() -> Callable:
 	return func (): await pause_animation()
 
 
 ## Will pause the animation that is currently playing on the Popochiu Prop.
-## If play_animation() is run without parameters it will resume from the paused animation frame.
+## Call play_animation() without any parameter to resume the animation from the paused animation frame.
 func pause_animation() -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.pause()

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -170,6 +170,12 @@ func pause_animation() -> void:
 	$AnimationPlayer.pause()
 
 
+## Will return true if an animation is playing, otherwise it will return false.
+func is_animation_playing() -> bool:
+	if not has_node("AnimationPlayer"): return false
+	return $AnimationPlayer.is_playing()
+
+
 #endregion
 
 #region Private ####################################################################################

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -175,9 +175,10 @@ func queue_play_animation_backwards(name: StringName = &"", custom_blend: float 
 	return func (): await play_animation_backwards(name, custom_blend)
 
 
-## Will Play the Popochiu Prop Animation Player [param name] animation backwards on the Popochiu
-## Prop if the [prop name] animation exits.
-## This method is a shorthand for play_animation() with custom_speed = -1.0 and from_end = true
+## Will play the [param name] animation in reverse if it exists in this prop's [AnimationPlayer]
+## node.
+## This method is a shorthand for [method play_animation] with [code]custom_speed = -1.0[/code]
+## and [code]from_end = true[/code].
 func play_animation_backwards(name: StringName = &"", custom_blend: float = -1) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.play_backwards(name, custom_blend)

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -145,7 +145,12 @@ func get_total_frames() -> int:
 ## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
 ## more details.
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_play_animation(name: StringName = &"", custom_blend: float = -1, custom_speed: float = 1.0, from_end: bool = false) -> Callable:
+func queue_play_animation(
+	name: StringName = &"",
+	custom_blend: float = -1,
+	custom_speed: float = 1.0,
+	from_end: bool = false
+) -> Callable:
 	return func (): await play_animation(name, custom_blend, custom_speed, from_end)
 
 

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -158,7 +158,12 @@ func queue_play_animation(
 ## Prop if the [prop name] animation exists.
 ## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
 ## more details.
-func play_animation(name: StringName = &"", custom_blend: float = -1, custom_speed: float = 1.0, from_end: bool = false) -> void:
+func play_animation(
+	name: StringName = &"",
+	custom_blend: float = -1,
+	custom_speed: float = 1.0,
+	from_end: bool = false
+) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.play(name, custom_blend, custom_speed, from_end)
 

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -166,9 +166,10 @@ func play_animation(
 	$AnimationPlayer.play(name, custom_blend, custom_speed, from_end)
 
 
-## Will Play the Popochiu Prop Animation Player [param name] animation backwards on the Popochiu
-## Prop if the [prop name] animation exits.
-## This method is a shorthand for play_animation() with custom_speed = -1.0 and from_end = true
+## Will play the [param name] animation in reverse if it exists in this prop's [AnimationPlayer]
+## node.
+## This method is a shorthand for [method play_animation] with [code]custom_speed = -1.0[/code]
+## and [code]from_end = true[/code].
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 func queue_play_animation_backwards(name: StringName = &"", custom_blend: float = -1) -> Callable:
 	return func (): await play_animation_backwards(name, custom_blend)

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -140,17 +140,34 @@ func get_total_frames() -> int:
 #endregion
 
 #region AnimationPlayer ############################################################################
-## Will play the Popochiu Prop Animation Player [param animation_name] animation on the Popochiu 
-## Prop if the [prop animation_name] exists.
-func play_animation(animation_name: String) -> void:
+## Will play the Popochiu Prop Animation Player [param name] animation on the Popochiu 
+## Prop if the [prop name] animation exists.
+## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
+## more details.
+func play_animation(name: StringName = &"", custom_blend: float = -1, custom_speed: float = 1.0, from_end: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
-	$AnimationPlayer.play(animation_name)
+	$AnimationPlayer.play(name, custom_blend, custom_speed, from_end)
+
+## Will Play the Popochiu Prop Animation Player [param name] animation backwards on the Popochiu
+## Prop if the [prop name] animation exits.
+## This method is a shorthand for play_animation() with custom_speed = -1.0 and from_end = true
+func play_animation_backwards(name: StringName = &"", custom_blend: float = -1) -> void:
+	if not has_node("AnimationPlayer"): return
+	$AnimationPlayer.play_backwards(name, custom_blend)
 
 
 ## Will stop the animation that is currently playing on the Popochiu Prop.
-func stop_animation() -> void:
+## The animation position is reset to 0 and the custom_speed is reset to 1.0
+func stop_animation(keep_state: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
-	$AnimationPlayer.stop()
+	$AnimationPlayer.stop(keep_state)
+
+
+## Will pause the animation that is currently playing on the Popochiu Prop.
+## If play_animation() is run without parameters it will resume from the paused animation frame.
+func pause_animation() -> void:
+	if not has_node("AnimationPlayer"): return
+	$AnimationPlayer.pause()
 
 
 #endregion

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -224,8 +224,7 @@ func get_assigned_animation() -> String:
 	if not has_node("AnimationPlayer"): return ''
 	return $AnimationPlayer.assigned_animation
 
-## Will set the animation key name for the currently assigned animation on the Popochiu Prop
-## AnimationPlayer
+## Sets the animation key name for the currently assigned animation in the [AnimationPlayer] node.
 func set_assigned_animation(name: StringName) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.assigned_animation = name

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -213,7 +213,7 @@ func pause_animation() -> void:
 	$AnimationPlayer.pause()
 
 
-## Will return true if an animation is playing, otherwise it will return false.
+## Return [code]true[/code] if an animation is playing, otherwise it will return [code]false[/code].
 func is_animation_playing() -> bool:
 	if not has_node("AnimationPlayer"): return false
 	return $AnimationPlayer.is_playing()

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -176,6 +176,16 @@ func is_animation_playing() -> bool:
 	return $AnimationPlayer.is_playing()
 
 
+func get_assigned_animation() -> String:
+	if not has_node("AnimationPlayer"): return ''
+	return $AnimationPlayer.assigned_animation
+
+
+func set_assigned_animation(name: StringName) -> void:
+	if not has_node("AnimationPlayer"): return
+	$AnimationPlayer.assigned_animation = name
+
+
 #endregion
 
 #region Private ####################################################################################

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -191,7 +191,7 @@ func set_assigned_animation(name: StringName) -> void:
 
 ## Will return the current Popochiu Prop animation position in seconds.
 ## returns -1.0 if there is an error.
-func  get_current_animation_position() -> float:
+func get_current_animation_position() -> float:
 	if not has_node("AnimationPlayer"): return -1.0
 	return $AnimationPlayer.current_animation_position
 

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -218,8 +218,7 @@ func is_animation_playing() -> bool:
 	return $AnimationPlayer.is_playing()
 
 
-## Will return the string name of the currently assigned animation key name on the Popochiu Prop
-## AnimationPlayer
+## Returns the string name of the currently assigned animation in the [AnimationPlayer] node.
 func get_assigned_animation() -> String:
 	if not has_node("AnimationPlayer"): return ''
 	return $AnimationPlayer.assigned_animation

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -193,9 +193,10 @@ func queue_stop_animation(keep_state: bool = false) -> Callable:
 	return func (): await stop_animation(keep_state)
 
 
-## Will stop the animation that is currently playing on the Popochiu Prop.
-## The animation position is reset to 0 and the custom_speed is reset to 1.0.
-## Set [param keep_state] to true to avoid the animation to be updated visually.
+## Will stop the animation that is currently playing.
+## The animation position is reset to [code]0[/code] and the [code]custom_speed[/code] is reset to
+## [code]1.0[/code]. Set [param keep_state] to [code]true[/code] to avoid the animation to be
+## updated visually.
 func stop_animation(keep_state: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.stop(keep_state)

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -157,7 +157,8 @@ func play_animation_backwards(name: StringName = &"", custom_blend: float = -1) 
 
 
 ## Will stop the animation that is currently playing on the Popochiu Prop.
-## The animation position is reset to 0 and the custom_speed is reset to 1.0
+## The animation position is reset to 0 and the custom_speed is reset to 1.0.
+## Set [param keep_state] to true to avoid the animation to be updated visually.
 func stop_animation(keep_state: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.stop(keep_state)

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -140,10 +140,9 @@ func get_total_frames() -> int:
 #endregion
 
 #region AnimationPlayer ############################################################################
-## Will play the Popochiu Prop Animation Player [param name] animation on the Popochiu 
-## Prop if the [prop name] animation exists.
-## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
-## more details.
+## Will play the [param name] animation if it exists in this prop's [AnimationPlayer] node.
+## Optionally you can use the other [method AnimationPlayer.play] parameters (see Godot's
+## documentation for more details).
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 func queue_play_animation(
 	name: StringName = &"",

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -189,6 +189,13 @@ func set_assigned_animation(name: StringName) -> void:
 	$AnimationPlayer.assigned_animation = name
 
 
+## Will return the current Popochiu Prop animation position in seconds.
+## returns -1.0 if there is an error.
+func  get_current_animation_position() -> float:
+	if not has_node("AnimationPlayer"): return -1.0
+	return $AnimationPlayer.current_animation_position
+
+
 #endregion
 
 #region Private ####################################################################################

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -139,6 +139,22 @@ func get_total_frames() -> int:
 
 #endregion
 
+#region AnimationPlayer ############################################################################
+## Will play the Popochiu Prop Animation Player [param animation_name] animation on the Popochiu 
+## Prop if the [prop animation_name] exists.
+func play_animation(animation_name: String) -> void:
+	if not has_node("AnimationPlayer"): return
+	$AnimationPlayer.play(animation_name)
+
+
+## Will stop the animation that is currently playing on the Popochiu Prop.
+func stop_animation() -> void:
+	if not has_node("AnimationPlayer"): return
+	$AnimationPlayer.stop()
+
+
+#endregion
+
 #region Private ####################################################################################
 func _on_item_added(item: PopochiuInventoryItem, _animate: bool) -> void:
 	if item.script_name == link_to_item:

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -176,11 +176,14 @@ func is_animation_playing() -> bool:
 	return $AnimationPlayer.is_playing()
 
 
+## Will return the string name of the currently assigned animation key name on the Popochiu Prop
+## AnimationPlayer
 func get_assigned_animation() -> String:
 	if not has_node("AnimationPlayer"): return ''
 	return $AnimationPlayer.assigned_animation
 
-
+## Will set the animation key name for the currently assigned animation on the Popochiu Prop
+## AnimationPlayer
 func set_assigned_animation(name: StringName) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.assigned_animation = name

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -200,8 +200,8 @@ func stop_animation(keep_state: bool = false) -> void:
 	if not has_node("AnimationPlayer"): return
 	$AnimationPlayer.stop(keep_state)
 
-## Will pause the animation that is currently playing on the Popochiu Prop.
-## Call play_animation() without any parameter to resume the animation from the paused animation frame.
+## Will pause the animation that is currently playing.
+## Call [method play_animation] without any parameters to resume the animation.
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 func queue_pause_animation() -> Callable:
 	return func (): await pause_animation()

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -153,10 +153,9 @@ func queue_play_animation(
 	return func (): await play_animation(name, custom_blend, custom_speed, from_end)
 
 
-## Will play the Popochiu Prop Animation Player [param name] animation on the Popochiu 
-## Prop if the [prop name] animation exists.
-## Optionally you can use other AnimationPlayer options, see Godot AnimationPlayer documentation for
-## more details.
+## Will play the [param name] animation if it exists in this prop's [AnimationPlayer] node.
+## Optionally you can use the other [method AnimationPlayer.play] parameters (see Godot's
+## documentation for more details).
 func play_animation(
 	name: StringName = &"",
 	custom_blend: float = -1,


### PR DESCRIPTION
Popochiu does not have the ability to play or stop animations on props without using Godot code. If a Popochiu user learns how to do things the Popochiu way then they should be able to do expected things such as playing or stopping an animation they have on a Popochiu prop.

```
# currently a user needs to to the following to play an animation on a prop
$Props/PropName/AnimationPlayer.play('AnimationName')

# I added the ability to do the following
R.get_prop('PropName').play_animation('AnimationName')

# currently to stop playing an animation you need to do the following:
$Props/PropName/AnimationPlayer.stop()

# I added the ability to do the following
R.get_prop('PropName').stop_animation()

# currently to pause a playing animation needs the following
$Props/PropName/AnimationPlayer.pause()

# I added the ability to do the following
R.get_prop('PropName').pause_animation()

# currently to play a animation backwards needs the following:
$Props/PropName/AnimationPlayer.play_backwards('AnimationName')

# I added the ability to do the following
R.get_prop('PropName').play_animation_backward('AnimationName')

```

I believe this provides the behaviour Popochiu users would expect and is helpful for people learning to make games with Popochiu who do not have a Godot background.

Other things have been added also see the commits log for details.