### PR TITLE
Fixed bug with using Inventory Items so the item is no longer active after you use it

### DIFF
--- a/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
+++ b/addons/popochiu/engine/objects/clickable/popochiu_clickable.gd
@@ -249,6 +249,8 @@ func on_middle_click() -> void:
 ## Called when an [param item] is used on this object.
 func on_item_used(item: PopochiuInventoryItem) -> void:
 	await _on_item_used(item)
+	# after item has been used return to normal state
+	I.active = null
 
 
 ## Triggers the proper GUI command for the clicked mouse button identified with [param button_idx],
@@ -348,6 +350,8 @@ func _on_input_event(_viewport: Node, event: InputEvent, _shape_idx: int):
 		MOUSE_BUTTON_LEFT:
 			if I.active:
 				await on_item_used(I.active)
+				# after item has been used return to normal state
+				I.active = null
 			else:
 				await handle_command(event_index)
 				times_clicked += 1

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -270,6 +270,8 @@ func on_middle_click() -> void:
 ## Called when the item is clicked and there is another [param item] currently selected.
 func on_item_used(item: PopochiuInventoryItem) -> void:
 	await _on_item_used(item)
+	# after item has been used return to normal state
+	I.active = null
 
 
 ## Triggers the proper GUI command for the clicked mouse button identified with [param button_idx],
@@ -352,6 +354,8 @@ func _on_gui_input(event: InputEvent) -> void:
 		MOUSE_BUTTON_LEFT:
 			if I.active:
 				await on_item_used(I.active)
+				# after item has been used return to normal state
+				I.active = null
 			else:
 				if DisplayServer.is_touchscreen_available():
 					G.mouse_entered_inventory_item.emit(self)


### PR DESCRIPTION
In point and click adventure games when you select an inventory item and click to use the inventory item with clickable objects in the game or with other inventory items, the inventory item should no longer be active as the user has already used the item and the game has either done something or displayed a message saying they can't do that.

The sierra and 9 verb templates seem to take care of it as part of the templates.

The simple two click template games was not working as expected, so I fixed it to work as described above.