### PR TITLE
fix: gibberish in spoken texts not working

### DIFF
--- a/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
@@ -78,7 +78,10 @@ func play_text(props: Dictionary) -> void:
 	rich_text_label.push_color(props.color)
 	
 	# Assign the text and align mode
-	_append_text(msg, props)
+	if PopochiuConfig.should_talk_gibberish():
+		_append_text(D.create_gibberish(msg), props)
+	else:
+		_append_text(msg, props)
 	
 	if _secs_per_character > 0.0:
 		# The text will appear with an animation


### PR DESCRIPTION
Somehow the "Gibberish Spoken Text" option in the Project Settings isn't used in Popochiu in any way. This PR fixes this, so when you toggle this setting on, characters speak Gibberish instead.

Fixes: #331 