### PR TITLE
refs #343: Fix walk and look points storage and retrieval

### DIFF
--- a/addons/popochiu/engine/helpers/popochiu_characters_helper.gd
+++ b/addons/popochiu/engine/helpers/popochiu_characters_helper.gd
@@ -56,8 +56,7 @@ static func execute_string(text: String) -> void:
 static func _trigger_dialog_line(text: String) -> void:
 	var regex = RegEx.new()
 	regex.compile(r'^%s%s%s$' % [char_pattern, emo_or_time_pattern, line_pattern])
-	var result = regex.search(text)
-	
+	var result := regex.search(text)
 	var character_name := result.get_string("character")
 	var emotion := result.get_string("emotion")
 	var change_time := result.get_string("time")

--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -241,8 +241,26 @@ func room_readied(room: PopochiuRoom) -> void:
 		chr.self_modulate = Color.from_string(chr_dic.self_modulate, Color.WHITE)
 		chr.light_mask = chr_dic.light_mask
 		chr.baseline = chr_dic.baseline
-		chr.walk_to_point = chr_dic.walk_to_point
-		chr.look_at_point = chr_dic.look_at_point
+		
+		# ---- fix #343 by checking the type of the stored value in the chr_dic Dictionary ---------
+		if chr_dic.has("walk_to_point_x"):
+			chr.walk_to_point = Vector2(chr_dic.walk_to_point_x, chr_dic.walk_to_point_y)
+		elif chr_dic.has("walk_to_point"):
+			if chr_dic.walk_to_point is String:
+				var walk_split := (chr_dic.walk_to_point as String).split_floats(",")
+				chr.walk_to_point = Vector2(walk_split[0], walk_split[1])
+			else:
+				chr.walk_to_point = chr_dic.walk_to_point
+		
+		if chr_dic.has("look_at_point_x"):
+			chr.look_at_point = Vector2(chr_dic.look_at_point_x, chr_dic.look_at_point_y)
+		elif chr_dic.has("look_at_point"):
+			if chr_dic.look_at_point is String:
+				var look_split := (chr_dic.look_at_point as String).split_floats(",")
+				chr.look_at_point = Vector2(look_split[0], look_split[1])
+			else:
+				chr.look_at_point = chr_dic.look_at_point
+		# ---------------------------------------------------------------------------- fix #343 ----
 		
 		current.add_character(chr)
 	

--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -242,25 +242,11 @@ func room_readied(room: PopochiuRoom) -> void:
 		chr.light_mask = chr_dic.light_mask
 		chr.baseline = chr_dic.baseline
 		
-		# ---- fix #343 by checking the type of the stored value in the chr_dic Dictionary ---------
-		if chr_dic.has("walk_to_point_x"):
-			chr.walk_to_point = Vector2(chr_dic.walk_to_point_x, chr_dic.walk_to_point_y)
-		elif chr_dic.has("walk_to_point"):
-			if chr_dic.walk_to_point is String:
-				var walk_split := (chr_dic.walk_to_point as String).split_floats(",")
-				chr.walk_to_point = Vector2(walk_split[0], walk_split[1])
-			else:
-				chr.walk_to_point = chr_dic.walk_to_point
+		if chr_dic.has("walk_to_point"):
+			chr.walk_to_point = PopochiuUtils.unpack_vector_2(chr_dic.walk_to_point)
 		
-		if chr_dic.has("look_at_point_x"):
-			chr.look_at_point = Vector2(chr_dic.look_at_point_x, chr_dic.look_at_point_y)
-		elif chr_dic.has("look_at_point"):
-			if chr_dic.look_at_point is String:
-				var look_split := (chr_dic.look_at_point as String).split_floats(",")
-				chr.look_at_point = Vector2(look_split[0], look_split[1])
-			else:
-				chr.look_at_point = chr_dic.look_at_point
-		# ---------------------------------------------------------------------------- fix #343 ----
+		if chr_dic.has("look_at_point"):
+			chr.look_at_point = PopochiuUtils.unpack_vector_2(chr_dic.look_at_point)
 		
 		current.add_character(chr)
 	

--- a/addons/popochiu/engine/objects/room/popochiu_room_data.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room_data.gd
@@ -150,23 +150,25 @@ func save_children_states() -> void:
 ##     light_mask = PopochiuCharacter.light_mask
 ## }[/codeblock]
 func save_characters() -> void:
-	for c in R.current.get_characters():
-		var pc: PopochiuCharacter = c
-		
-		characters[pc.script_name] = {
-			x = pc.position.x,
-			y = pc.position.y,
-			facing = pc._looking_dir,
-			visible = pc.visible,
-			modulate = pc.modulate.to_html(),
-			self_modulate = pc.self_modulate.to_html(),
-			light_mask = pc.light_mask,
-			baseline = pc.baseline,
+	for character: PopochiuCharacter in R.current.get_characters():
+		characters[character.script_name] = {
+			x = character.position.x,
+			y = character.position.y,
+			facing = character._looking_dir,
+			visible = character.visible,
+			modulate = character.modulate.to_html(),
+			self_modulate = character.self_modulate.to_html(),
+			light_mask = character.light_mask,
+			baseline = character.baseline,
 			# Store this values using built-in types
-			walk_to_point_x = pc.walk_to_point.x,
-			walk_to_point_y = pc.walk_to_point.y,
-			look_at_point_x = pc.look_at_point.x,
-			look_at_point_y = pc.look_at_point.y,
+			walk_to_point = {
+				x = character.walk_to_point.x,
+				y = character.walk_to_point.y,
+			},
+			look_at_point = {
+				x = character.look_at_point.x,
+				y = character.look_at_point.y,
+			},
 			# TODO: Store the state of the current animation (and more data if
 			# necessary)
 		}

--- a/addons/popochiu/engine/objects/room/popochiu_room_data.gd
+++ b/addons/popochiu/engine/objects/room/popochiu_room_data.gd
@@ -162,8 +162,11 @@ func save_characters() -> void:
 			self_modulate = pc.self_modulate.to_html(),
 			light_mask = pc.light_mask,
 			baseline = pc.baseline,
-			walk_to_point = pc.walk_to_point,
-			look_at_point = pc.look_at_point,
+			# Store this values using built-in types
+			walk_to_point_x = pc.walk_to_point.x,
+			walk_to_point_y = pc.walk_to_point.y,
+			look_at_point_x = pc.look_at_point.x,
+			look_at_point_y = pc.look_at_point.y,
 			# TODO: Store the state of the current animation (and more data if
 			# necessary)
 		}

--- a/addons/popochiu/engine/others/popochiu_utils.gd
+++ b/addons/popochiu/engine/others/popochiu_utils.gd
@@ -103,14 +103,14 @@ static func any_exhaustive(array: Array, callback: Callable) -> bool:
 ## will be used. If it is a [Vector2], it will be returned as is. Otherwise [constant Vector2.ZERO]
 ## is returned.
 static func unpack_vector_2(source) -> Vector2:
-	if source is String:
+	if source is Dictionary:
+		return Vector2(source.x, source.y)
+	elif source is String:
 		var regex = RegEx.new()
 		regex.compile(r'(Vector2\(|\()\s*(?<x>-?\d+)\s*,\s*(?<y>-?\d+)\s*\)')
 		var result := regex.search(source)
 		if result:
 			return Vector2(float(result.get_string("x")), float(result.get_string("y")))
-	elif source is Dictionary:
-		return Vector2(source.x, source.y)
 	elif source is Vector2:
 		return source
 	return Vector2.ZERO

--- a/addons/popochiu/engine/others/popochiu_utils.gd
+++ b/addons/popochiu/engine/others/popochiu_utils.gd
@@ -98,4 +98,22 @@ static func any_exhaustive(array: Array, callback: Callable) -> bool:
 	return any_updated
 
 
+## Returns a [Vector2] with the values of [param source]. If it is a [String], it will be unpacked
+## using a regular expression. If it is a [Dictionary], it's [code]x[/code] and [code]y[/code] keys
+## will be used. If it is a [Vector2], it will be returned as is. Otherwise [constant Vector2.ZERO]
+## is returned.
+static func unpack_vector_2(source) -> Vector2:
+	if source is String:
+		var regex = RegEx.new()
+		regex.compile(r'(Vector2\(|\()\s*(?<x>-?\d+)\s*,\s*(?<y>-?\d+)\s*\)')
+		var result := regex.search(source)
+		if result:
+			return Vector2(float(result.get_string("x")), float(result.get_string("y")))
+	elif source is Dictionary:
+		return Vector2(source.x, source.y)
+	elif source is Vector2:
+		return source
+	return Vector2.ZERO
+
+
 #endregion


### PR DESCRIPTION
Fixes #343 : The data should be stored using built-in types (int, float, String, and so on) in order to avoid hacks in Web games. A validation was added to assign the values for the `walk_to_point` and `look_at_point` based on the available data in the character's Dictionary.