### PR TITLE
issue_345 Set a room script name if one wasn't set

### DIFF
--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -198,6 +198,10 @@ func room_readied(room: PopochiuRoom) -> void:
 	if not is_instance_valid(current):
 		current = room
 	
+	# Apply a room script_name if it hasn't been explicitly set for the room
+	if room.script_name == "":
+		room.script_name = room.state.script_name
+
 	# When running from the Editor the first time, use goto_room
 	if Engine.get_process_frames() == 0:
 		await get_tree().process_frame


### PR DESCRIPTION
Fixes https://github.com/carenalgas/popochiu/issues/345

I'm assuming the state will always have the name based off what I saw in testing. If this isn't a valid assumption, maybe it would be better to crash the game with an error message if the script name for a room is not set.