### PR TITLE
Issue_350 fix inventory window double closing if await commands have completed

### DIFF
--- a/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
@@ -130,9 +130,12 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 		_open()
 		await get_tree().create_timer(2.0).timeout
 		
-		_close()
-		await get_tree().create_timer(0.5).timeout
-		
+		# The mouse not being on the inventory can close the inventory prior to the 2 seconds
+		# expiring. This check fixes this. Bug 350.
+		if _is_hidden == false:
+			_close()
+			await get_tree().create_timer(0.5).timeout
+
 		set_process_input(true)
 	else:
 		await get_tree().process_frame

--- a/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
@@ -132,7 +132,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 		
 		# The mouse not being on the inventory can close the inventory prior to the 2 seconds
 		# expiring. This check fixes this. Bug 350.
-		if _is_hidden == false:
+		if not _is_hidden:
 			_close()
 			await get_tree().create_timer(0.5).timeout
 


### PR DESCRIPTION
Fixes https://github.com/carenalgas/popochiu/issues/350
Fixes a fault where the inventory window will close twice after picking up an object if "await" has completed.