### PR TITLE
refs #262: Fix DialogText to properly align and color texts

### DIFF
--- a/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_overhead/dialog_overhead.gd
+++ b/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_overhead/dialog_overhead.gd
@@ -27,13 +27,13 @@ func _set_default_label_size(lbl: Label) -> void:
 
 
 func _append_text(msg: String, props: Dictionary) -> void:
-	var center: float = floor(position.x + (rich_text_label.size.x / 2))
+	var center: float = floor(rich_text_label.position.x + (rich_text_label.size.x / 2))
 	if center == props.position.x:
-		rich_text_label.append_text("[center]%s[/center]" % msg)
+		rich_text_label.text = "[center]%s[/center]" % msg
 	elif center < props.position.x:
-		rich_text_label.append_text("[right]%s[/right]" % msg)
+		rich_text_label.text = "[right]%s[/right]" % msg
 	else:
-		rich_text_label.append_text(msg)
+		rich_text_label.text = msg
 
 
 func _get_icon_from_position() -> float:

--- a/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
+++ b/addons/popochiu/engine/objects/gui/components/dialog_text/dialog_text.gd
@@ -71,17 +71,16 @@ func play_text(props: Dictionary) -> void:
 	_is_waiting_input = false
 	_dialog_pos = props.position
 	
+	if PopochiuConfig.should_talk_gibberish():
+		msg = D.create_gibberish(msg)
+	
 	# Call the virtual method that modifies the size of the RichTextLabel in case the dialog style
 	# requires it.
 	await _modify_size(msg, props.position)
 	
-	rich_text_label.push_color(props.color)
-	
 	# Assign the text and align mode
-	if PopochiuConfig.should_talk_gibberish():
-		_append_text(D.create_gibberish(msg), props)
-	else:
-		_append_text(msg, props)
+	msg = "[color=%s]%s[/color]" % [props.color.to_html(), msg]
+	_append_text(msg, props)
 	
 	if _secs_per_character > 0.0:
 		# The text will appear with an animation


### PR DESCRIPTION
Fixes #262 : The RichTextLabel.push_color method wasn't working properly when the dialog's alignment changed. Thanks to @BenjaTK for the fix suggestion.