### PR TITLE
refs #348: Show the TransitionLayer when no using transition animation

### DIFF
--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -154,6 +154,8 @@ func goto_room(
 	if use_transition and Engine.get_process_frames() > 0:
 		E.tl.play_transition(E.tl.FADE_IN)
 		await E.tl.transition_finished
+	elif Engine.get_process_frames() > 0:
+		E.tl.show_curtain()
 	
 	# Prevent the GUI from showing info coming from the previous room
 	G.show_hover_text()
@@ -295,6 +297,7 @@ func room_readied(room: PopochiuRoom) -> void:
 		
 		await E.wait(0.3)
 	else:
+		E.tl.hide_curtain()
 		await get_tree().process_frame
 	
 	if not current.hide_gui:

--- a/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
+++ b/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
@@ -5,18 +5,22 @@ extends Control
 
 signal transition_finished(transition_name: String)
 
+## Available transition types.
 enum {
+	## Fades in and out.
 	FADE_IN_OUT,
+	## Fades in.
 	FADE_IN,
+	## Fades out.
 	FADE_OUT,
+	## Passes down and up.
 	PASS_DOWN_IN_OUT,
+	## Passes down.
 	PASS_DOWN_IN,
+	## Passes up.
 	PASS_DOWN_OUT,
 }
 
-@onready var n := {
-	fade = find_child("Fade")
-}
 
 #region Godot ######################################################################################
 func _ready() -> void:
@@ -32,11 +36,18 @@ func _ready() -> void:
 	else:
 		$AnimationPlayer.play("RESET")
 		await get_tree().process_frame
+		
 		_hide()
+
 
 #endregion
 
 #region Public #####################################################################################
+## Plays a transition with the animation identified by [param type] and that lasts [param duration]
+## (in seconds). The transition can be one of the following:
+## [enum PopochiuTransitionLayer.FADE_IN_OUT], [enum PopochiuTransitionLayer.FADE_IN],
+## [enum PopochiuTransitionLayer.FADE_OUT], [enum PopochiuTransitionLayer.PASS_DOWN_IN_OUT],
+## [enum PopochiuTransitionLayer.PASS_DOWN_IN], [enum PopochiuTransitionLayer.PASS_DOWN_OUT].
 func play_transition(type := FADE_IN, duration := 1.0) -> void:
 	_show()
 	
@@ -72,6 +83,19 @@ func play_transition(type := FADE_IN, duration := 1.0) -> void:
 			$AnimationPlayer.play_backwards("pass")
 			await $AnimationPlayer.animation_finished
 			_hide()
+
+
+## Shows the curtain without playing any transition.
+func show_curtain() -> void:
+	$Curtain.modulate = E.settings.fade_color
+	$Curtain.show()
+	_show()
+
+
+## Hides the transition layer.
+func hide_curtain() -> void:
+	_hide()
+
 
 #endregion
 


### PR DESCRIPTION
Fixes #348 : Rooms should be in black while their _on_room_entered() function is executing no matter if devs are using or not transition animations. This allows to execute logic that can affect the rendering of the room without allowing players to see what's happening.