### PR TITLE
Fix double call to window close which causes save to run twice

### DIFF
--- a/addons/popochiu/engine/objects/gui/components/popups/save_and_load_popup/save_and_load_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/save_and_load_popup/save_and_load_popup.gd
@@ -69,9 +69,6 @@ func _on_ok() -> void:
 		_prev_text = _current_slot.text
 		_current_slot.set_meta("has_save", true)
 	
-	close()
-
-
 #endregion
 
 #region Public #####################################################################################


### PR DESCRIPTION
Close is called from the end of _on_ok  which doubles up with the call to close in popochiu_popup.gd  in the on_ok_pressed function. This causes the save function to run a second time unnecessarily. 