### PR TITLE
Pause gameplay while popups are visible

### DIFF
--- a/addons/popochiu/engine/cursor/cursor.gd
+++ b/addons/popochiu/engine/cursor/cursor.gd
@@ -29,6 +29,8 @@ var is_blocked := false
 #region Godot ######################################################################################
 func _init() -> void:
 	Engine.register_singleton(&"Cursor", self)
+	# Allow cursor processing during gameplay pause
+	process_mode = PROCESS_MODE_ALWAYS
 
 
 func _ready():

--- a/addons/popochiu/engine/objects/gui/components/popups/history_popup/history_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/history_popup/history_popup.gd
@@ -52,6 +52,8 @@ func _open() -> void:
 func _close() -> void:
 	for c in lines_list.get_children():
 		(c as Control).queue_free()
+	# Unpause gameplay
+	get_tree().paused = false
 
 
 #endregion

--- a/addons/popochiu/engine/objects/gui/components/popups/popochiu_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/popochiu_popup.gd
@@ -31,6 +31,8 @@ func _ready() -> void:
 	# Connect to singleton signals
 	PopochiuUtils.g.popup_requested.connect(_on_popup_requested)
 	
+	# Don't pause popup processing during gameplay pause
+	process_mode = PROCESS_MODE_ALWAYS
 	close()
 
 
@@ -72,6 +74,8 @@ func open() -> void:
 	PopochiuUtils.e.gui.popups_stack.append(self)
 	
 	show()
+	# Pause gameplay when a popup appears
+	get_tree().paused = true
 
 
 ## Closes the popup unlocking interactions with the graphic interface.

--- a/addons/popochiu/engine/objects/gui/components/popups/save_and_load_popup/save_and_load_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/save_and_load_popup/save_and_load_popup.gd
@@ -52,7 +52,10 @@ func _open() -> void:
 
 
 func _close() -> void:
-	if not _slot: return
+	if not _slot: 
+		# Unpause gameplay
+		get_tree().paused = false
+		return
 	
 	slot_selected.emit()
 	

--- a/addons/popochiu/engine/objects/gui/components/popups/sound_settings_popup/sound_settings_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/sound_settings_popup/sound_settings_popup.gd
@@ -11,6 +11,12 @@ func _open() -> void:
 
 func _on_cancel() -> void:
 	sound_volumes.restore_last_volumes()
+	# Unpause gameplay
+	get_tree().paused = false
 
+
+func _on_ok() -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 
 #endregion

--- a/addons/popochiu/engine/objects/gui/components/popups/text_settings_popup/text_settings_popup.gd
+++ b/addons/popochiu/engine/objects/gui/components/popups/text_settings_popup/text_settings_popup.gd
@@ -37,4 +37,8 @@ func _on_continue_mode_toggled(toggled_on: bool) -> void:
 	PopochiuUtils.e.settings.auto_continue_text = toggled_on
 
 
+func _on_cancel() -> void:
+	# Unpause gameplay
+	get_tree().paused = false
+
 #endregion

--- a/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
@@ -200,12 +200,16 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText
 ## component.
 func _on_game_saved() -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	PopochiuUtils.g.show_system_text("Game saved")
 
 
 ## Called when a game is loaded. [param loaded_game] has the loaded data. By default, it shows
 ## [code]Game loaded[/code] in the SystemText component.
 func _on_game_loaded(loaded_game: Dictionary) -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	await PopochiuUtils.g.show_system_text("Game loaded")
 	
 	super(loaded_game)

--- a/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
@@ -135,12 +135,16 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText
 ## component.
 func _on_game_saved() -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	PopochiuUtils.g.show_system_text("Game saved")
 
 
 ## Called when a game is loaded. [param loaded_game] has the loaded data. By default, it shows
 ## [code]Game loaded[/code] in the SystemText component.
 func _on_game_loaded(loaded_game: Dictionary) -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	await PopochiuUtils.g.show_system_text("Game loaded")
 	
 	super(loaded_game)

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_gui.gd
@@ -182,12 +182,16 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText
 ## component.
 func _on_game_saved() -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	PopochiuUtils.g.show_system_text("Game saved")
 
 
 ## Called when a game is loaded. [param loaded_game] has the loaded data. By default, it shows
 ## [code]Game loaded[/code] in the SystemText component.
 func _on_game_loaded(loaded_game: Dictionary) -> void:
+	# Unpause gameplay
+	get_tree().paused = false
 	await PopochiuUtils.g.show_system_text("Game loaded")
 	
 	super(loaded_game)

--- a/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
+++ b/addons/popochiu/engine/objects/transition_layer/transition_layer.gd
@@ -27,6 +27,8 @@ func _ready() -> void:
 	# Connect to childrens' signals
 	$AnimationPlayer.animation_finished.connect(_transition_finished)
 	$Curtain.modulate = PopochiuUtils.e.settings.fade_color
+	# Allow fades for save/load while gameplay is paused
+	process_mode = PROCESS_MODE_ALWAYS
 
 	# Make sure the transition layer is ready
 	# if it has to be visible in the first room


### PR DESCRIPTION
Adds pausing functionality for when popups appear

Unpausing is done in each popup individually as I didn't want the animations in the room to be running until the fade completed, so the restart needed to be in each popup rather than a single call in popochiu_popup.gd

Known bugs that I haven't been able to fix (some help would be appreciated)
1) Character facing direction isn't corrected until after the game is unpaused. The fixes I've tried haven't worked.
2) If a character is walking when you save the game  - e.g. 
```
			await C.get_OfficerBrown().walk_to_marker("ExitPoint")
```
the character's walking state is not restored when you load the save. This appears to be a generic save-game bug, and not one in my code.
