### PR TITLE
Update tutorials.md

### DIFF
--- a/docs/src/getting-started/tutorials.md
+++ b/docs/src/getting-started/tutorials.md
@@ -4,7 +4,7 @@ weight: 1040
 
 ## Tutorials
 
-* [Creating a game stub](../../../getting-started/creating-a-game-stub/introduction): This step-by-step tutorial will guide you to learn the very basics of Popochiu, providing a lot of explanations along the way.
+* [Creating a game stub](../../getting-started/creating-a-game-stub/introduction): This step-by-step tutorial will guide you to learn the very basics of Popochiu, providing a lot of explanations along the way.
 
 ## Video Tutorials
 


### PR DESCRIPTION
Fixed link to "Creating a game stub", as I'm getting a 404 when clicking on it from the tutorial page on the wiki

https://carenalgas.github.io/popochiu/getting-started/tutorials/, clicking it gives the url https://carenalgas.github.io/getting-started/creating-a-game-stub/introduction which has dropped the "popochiu" part.