### PR TITLE
Improve UX by showing a dropdown of inventory items for prop's link_to_item property.

### DIFF
--- a/addons/popochiu/editor/inspector/prop_inspector_plugin.gd
+++ b/addons/popochiu/editor/inspector/prop_inspector_plugin.gd
@@ -1,0 +1,63 @@
+extends EditorInspectorPlugin
+
+
+#region Virtual ####################################################################################
+func _can_handle(object: Object) -> bool:
+	if object is PopochiuProp:
+		return true
+	return false
+
+
+func _parse_property(
+	object: Object,
+	type,
+	path: String,
+	hint,
+	hint_text: String,
+	usage,
+	wide: bool
+) -> bool:
+	if (
+		object.get_class() == "EditorDebuggerRemoteObject"
+		or object is not PopochiuProp
+		or path != "link_to_item"
+	):
+		return false
+	
+	var ep := EditorProperty.new()
+	var ob := OptionButton.new()
+	
+	_update_items_list(ob, object)
+	
+	ob.item_selected.connect(_update_link_to_item.bind(ob, object))
+	ob.pressed.connect(_update_items_list.bind(ob, object))
+	
+	ep.add_child(ob)
+	add_property_editor(path, ep)
+	
+	return true
+
+
+#endregion
+
+#region Private ####################################################################################
+func _update_items_list(ob: OptionButton, prop: PopochiuProp) -> void:
+	ob.clear()
+	var inventory_items := PopochiuResources.get_section_keys("inventory_items")
+	var keys_ids_map := {}
+	
+	inventory_items.sort()
+	ob.add_item("")
+	for key: String in inventory_items:
+		keys_ids_map[key] = ob.item_count
+		ob.add_item(key)
+	
+	if keys_ids_map.has(prop.link_to_item):
+		ob.selected = ob.get_item_index(keys_ids_map[prop.link_to_item])
+
+
+func _update_link_to_item(idx: int, ob: OptionButton, prop: PopochiuProp) -> void:
+	prop.link_to_item = ob.get_item_text(idx)
+
+
+#endregion

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -1,5 +1,5 @@
 @tool
-@icon('res://addons/popochiu/icons/prop.png')
+@icon("res://addons/popochiu/icons/prop.png")
 class_name PopochiuProp
 extends PopochiuClickable
 ## Visual elements in the Room that can have interaction (i.e. the background, the foreground, a
@@ -34,7 +34,7 @@ signal linked_item_discarded(item: PopochiuInventoryItem)
 ## Links the prop to a [PopochiuInventoryItem] by its [member PopochiuInventoryItem.script_name].
 ## This will make the prop disappear from the room, depending on whether or not said inventory item
 ## is inside the inventory.
-@export var link_to_item := ''
+@export var link_to_item := ""
 
 ## Total frames available the texture image has. [code](frames * vframes)[/code]
 var total_frames: get = get_total_frames
@@ -45,12 +45,12 @@ var total_frames: get = get_total_frames
 #region Godot ######################################################################################
 func _ready() -> void:
 	super()
-	add_to_group('props')
+	add_to_group("props")
 	
 	if Engine.is_editor_hint(): return
 	
 	for c in get_children():
-		if c.get('position') is Vector2:
+		if c.get("position") is Vector2:
 			c.position.y -= baseline * c.scale.y
 
 	walk_to_point.y -= baseline * scale.y
@@ -225,7 +225,7 @@ func is_animation_playing() -> bool:
 
 ## Returns the string name of the currently assigned animation in the [AnimationPlayer] node.
 func get_assigned_animation() -> String:
-	if not has_node("AnimationPlayer"): return ''
+	if not has_node("AnimationPlayer"): return ""
 	return $AnimationPlayer.assigned_animation
 
 ## Sets the animation key name for the currently assigned animation in the [AnimationPlayer] node.

--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -59,6 +59,7 @@ func _enter_tree() -> void:
 		"res://addons/popochiu/editor/inspector/character_inspector_plugin.gd",
 		"res://addons/popochiu/editor/inspector/aseprite_importer_inspector_plugin.gd",
 		"res://addons/popochiu/editor/inspector/audio_cue_inspector_plugin.gd",
+		"res://addons/popochiu/editor/inspector/prop_inspector_plugin.gd",
 	]:
 		var eip: EditorInspectorPlugin = load(path).new()
 		_inspector_plugins.append(eip)


### PR DESCRIPTION
Implements #245 to avoid mistakes or typos when linking an inventory item to a prop so it hides when the linked item is in the inventory.