### PR TITLE
refs #398: some improvements to Dock UX

### DIFF
--- a/addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.gd
@@ -97,7 +97,7 @@ func remove_by_name(node_name: String) -> void:
 		var node: HBoxContainer = list.get_node(node_name)
 		
 		list.remove_child(node)
-		node.free()
+		node.queue_free()
 
 
 func add_header_button(btn: Button) -> void:

--- a/addons/popochiu/editor/main_dock/popochiu_row/object_row/popochiu_object_row.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_row/object_row/popochiu_object_row.gd
@@ -148,15 +148,22 @@ func _add_object_to_core() -> void:
 
 ## Selects the main file of the object in the FileSystem and opens it so that it can be edited.
 func _open() -> void:
+	# Defer the scene opening to ensure current operations complete first.
+	# Ugly but necessary to avoid errors (see _deferred_open comments).
+	call_deferred("_deferred_open")
+	select()
+
+# Deferring this call removes an error that happens in Godot 4.4:
+# 'ERROR: editor/editor_data.cpp:1216 - Condition "!p_node->is_inside_tree()" is true.'
+func _deferred_open() -> void:
 	EditorInterface.select_file(path)
 	
 	if ".tres" in path:
 		EditorInterface.edit_resource(load(path))
 	else:
+		# Change to 2D view and open the scene
 		EditorInterface.set_main_screen_editor("2D")
 		EditorInterface.open_scene_from_path(path)
-	
-	select()
 
 
 func _open_script() -> void:


### PR DESCRIPTION
I'm adding a bugfix and a small improvement to the UX of the dock, going in the direction of NOT resorting to the scene tree to navigate a Popochiu project.

Content of this PR:

* Fixing 2 errors switching scene from room tab, due to changes in Godot 4.4
* Auto-selecting the root node for scene opened from the dock, so that gizmos, toolbar and inspectors are all in place when navigating grom the dock