### PR TITLE
refs #413: Toolchain improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,58 +1,55 @@
 # GitHub Copilot Repository Instructions for Popochiu
 
-Popochiu is a Godot addon that helps developers create classic point-and-click adventure games. It is composed of two main components:
+Popochiu is a Godot addon for building classic point-and-click adventure games. It is organized into two main components:
 
-## Editor Plugin (`editor/`)
+## Architecture Overview
 
-This component extends the Godot Editor with a full suite of tools and interfaces to build, organize, and maintain all elements of a graphic adventure.
+- **Editor Plugin (`addons/popochiu/editor/`)**: Extends the Godot Editor with tools for managing game assets (characters, rooms, inventory, audio, etc.), custom inspector views, asset importers, migration logic, and UI popups. All editor-side scripts/classes must be named with the `Popochiu` prefix and use tabs for indentation.
+- **Game Engine (`addons/popochiu/engine/`)**: Contains runtime logic, base classes for game entities, audio/cursor managers, and high-level APIs. All engine scripts/classes must also use the `Popochiu` prefix and tabs for indentation.
 
-- `main_dock/`: The central UI that lists and manages characters, rooms, inventory items, audio cues, and more.
-- `canvas_editor_menu/`: Adds buttons to the Scene Preview toolbar for enabling Popochiu’s interactive gizmos.
-- `inspector/`: Customizes how Popochiu objects appear in the Godot Inspector to hide or expose relevant properties.
-- `popups/`: Provides modal dialogs for creating and managing game objects and settings.
-- `migration/`: Implements version migrations to update existing projects when upgrading Popochiu.
-- `gizmos/`: Adds in-editor visual handlers (walk-to points, baselines, etc.) for interactive scene editing.
-- `importers/`: Allows importing of assets (e.g., Aseprite animations) and auto-generating rooms and characters.
-- `factories/`: Builds game object instances (characters, props, rooms) from engine templates.
-- `config/`: Exposes and reads project/editor settings related to Popochiu.
-- `helpers/`: Shared utility functions and classes used across the plugin.
+Scripts in `game/` are for actual game logic and may access engine singletons directly (e.g., `E`, `C`, `D`). Scripts in `editor/` and `engine/` must use `PopochiuUtils` for singleton access, mapping each singleton to a lowercase variable (e.g., `PopochiuUtils.r.get_prop("PropName")`).
 
-## Game Engine (`engine/`)
+## Developer Workflows
 
-This is the runtime layer that is bundled with the game and handles all core logic and reusable functionality.
+- **Building/Exporting**: Use the Godot Editor's export functionality. The file `addons/popochiu/popochiu_export_plugin.gd` customizes export behavior.
+- **Testing**: No standard test framework is present; manual testing via the Godot Editor is typical. Debug using Godot's built-in debugger whenever possible (not available during Editor Plugin development).
+- **Migration**: Version migrations are handled in `addons/popochiu/editor/migration/`. Update logic here when introducing changes to Popochiu objects that require an update in the `game` folder to work properly.
+- **Graphical Assets Importing**: Use importers in `addons/popochiu/editor/importers/` for assets like Aseprite animations.
 
-- `popochiu.gd`: The main controller that initializes the engine, routes input, and manages the game's lifecycle.
-- `audio_manager/`: Manages music and sound effects playback, including positional and non-positional audio.
-- `cursor/`: Handles the runtime mouse pointer (not to be confused with the GUI Cursor component).
-- `objects/`: Base classes for game entities like characters, rooms, props, hotspots, inventory items, and more.
-- `interfaces/`: High-level APIs (via singletons) for accessing and manipulating game objects from scripts.
-- `templates/`: Script templates used by the Editor Plugin to generate new game objects and GUI components.
+## Project-Specific Conventions
 
-Note: scripts in the `game/` folder are meant for actual game logic and may access engine singletons like `E`, `C`, `D`, etc. Scripts in `editor/` and `engine/` must **not** use those directly, but must use `PopochiuUtils` instead.
- Just map each singleton to a lowercase variable name, under `PopochiuUtils`, like this:
+- **Class Naming**: All classes in `editor/` and `engine/` must start with `Popochiu`.
+- **Indentation**: Always use tabs, never use spaces.
+- **File Naming**: Use `snake_case` matching the class name.
+- **Commenting**:
+  - In `engine/`: Use `##` for documentation comments on public/virtual methods, classes, constants, enums, signals, and exported variables. Use `#` for internal/private comments.
+  - In `editor/`: Use `#` for all comments, never `##`.
+  - Comments should explain *why* code is written a certain way, not just what it does.
+  - Place comments above the referenced code.
+  - **Singleton Access**: Only game scripts access engine singletons directly. Editor/engine scripts must use `PopochiuUtils`.
 
-```gdscript
-# Inside game scripts
-R.get_prop("PropName")
+## Integration Points
 
-# Inside engine or editor scripts
-PopochiuUtils.r.get_prop("PropName")
-```
+- **External Dependencies**: Asset importers may depend on external formats (e.g., Aseprite). No other major external dependencies are present.
+- **Cross-Component Communication**: Use interfaces in `addons/popochiu/engine/interfaces/` for high-level API access.
 
-## Coding standards
+## Key Files & Directories
 
-When generating code, please follow these guidelines:
+- `addons/popochiu/editor/main_dock/`: Main UI for managing game elements.
+- `addons/popochiu/editor/importers/`: Asset importers.
+- `addons/popochiu/editor/migration/`: Migration logic.
+- `addons/popochiu/engine/popochiu.gd`: Main engine controller.
+- `addons/popochiu/engine/objects/`: Base classes for game entities.
+- `addons/popochiu/engine/interfaces/`: APIs for game object access.
+- `addons/popochiu/engine/templates/`: Script templates for new objects.
 
-- **Always** follow the official Godot GDScript style guide.
-- Use **tabs**, NOT spaces, for indentation.
-- Do **not** leave trailing whitespace at the end of lines or on empty lines.
-- File names should use `snake_case` and reflect the class they define.
-- All classes in the `engine/` and `editor/` folders must be explicitly named and start with `Popochiu`, due to the lack of namespaces in GDScript.
+## Example Patterns
 
-## Commenting rules
-
-- Only in the `engine/` folder, always use `##` for documentation comments on **public or virtual** methods, classes, constants, enums, signals, and exported variables. These should include a description, details, and usage examples when relevant.
-- Use `#` for internal comments in **private methods or classes**, and in every comment in the `editor` folder, never starting comments with `##` to prevent them from appearing in the API documentation.
-- Comments should always explain *why* the code is written a certain way, not just what it does (which should already be clear from the code).
-- Place comments above the code they reference, not at the end of a line.
-- All comments must start with a capital letter and end with a period.
+- **Accessing a prop in game scripts**:
+  ```gdscript
+  R.get_prop("PropName")
+  ```
+- **Accessing a prop in engine/editor scripts**:
+  ```gdscript
+  PopochiuUtils.r.get_prop("PropName")
+  ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Popochiu is a Godot addon for building classic point-and-click adventure games. 
 
 ## Architecture Overview
 
-- **Editor Plugin (`addons/popochiu/editor/`)**: Extends the Godot Editor with tools for managing game assets (characters, rooms, inventory, audio, etc.), custom inspector views, asset importers, migration logic, and UI popups. All editor-side scripts/classes must be named with the `Popochiu` prefix and use tabs for indentation.
+- **Editor Plugin (`addons/popochiu/editor/`)**: Extends the Godot Editor with tools for managing game assets, custom inspector views, asset importers, migration logic, and UI popups. All editor-side scripts/classes must be named with the `Popochiu` prefix and use tabs for indentation.
 - **Game Engine (`addons/popochiu/engine/`)**: Contains runtime logic, base classes for game entities, audio/cursor managers, and high-level APIs. All engine scripts/classes must also use the `Popochiu` prefix and tabs for indentation.
 
 Scripts in `game/` are for actual game logic and may access engine singletons directly (e.g., `E`, `C`, `D`). Scripts in `editor/` and `engine/` must use `PopochiuUtils` for singleton access, mapping each singleton to a lowercase variable (e.g., `PopochiuUtils.r.get_prop("PropName")`).
@@ -12,36 +12,47 @@ Scripts in `game/` are for actual game logic and may access engine singletons di
 ## Developer Workflows
 
 - **Building/Exporting**: Use the Godot Editor's export functionality. The file `addons/popochiu/popochiu_export_plugin.gd` customizes export behavior.
-- **Testing**: No standard test framework is present; manual testing via the Godot Editor is typical. Debug using Godot's built-in debugger whenever possible (not available during Editor Plugin development).
-- **Migration**: Version migrations are handled in `addons/popochiu/editor/migration/`. Update logic here when introducing changes to Popochiu objects that require an update in the `game` folder to work properly.
-- **Graphical Assets Importing**: Use importers in `addons/popochiu/editor/importers/` for assets like Aseprite animations.
+- **Testing**: Manual testing via the Godot Editor is typical. Debug using Godot's built-in debugger. No standard test framework is present.
+- **Migration**: Version migrations are handled in `addons/popochiu/editor/migration/`. Update logic here when introducing changes to Popochiu objects that require an update in the `game` folder.
+- **Asset Importing**: Use importers in `addons/popochiu/editor/importers/` for assets like Aseprite animations.
 
-## Project-Specific Conventions
+## Key Conventions for AI Agents
 
 - **Class Naming**: All classes in `editor/` and `engine/` must start with `Popochiu`.
-- **Indentation**: Always use tabs, never use spaces.
+- **Indentation**: Use tabs, not spaces.
 - **File Naming**: Use `snake_case` matching the class name.
 - **Commenting**:
   - In `engine/`: Use `##` for documentation comments on public/virtual methods, classes, constants, enums, signals, and exported variables. Use `#` for internal/private comments.
   - In `editor/`: Use `#` for all comments, never `##`.
-  - Comments should explain *why* code is written a certain way, not just what it does.
-  - Place comments above the referenced code.
-  - **Singleton Access**: Only game scripts access engine singletons directly. Editor/engine scripts must use `PopochiuUtils`.
+  - Comments should explain *why* code is written a certain way, not just what it does. Place comments above the referenced code.
+  - Reference issues in comments using `#<issue_number>~` when relevant.
+- **Singleton Access**: Only game scripts access engine singletons directly. Editor/engine scripts must use `PopochiuUtils`.
+- **Functions/Variables**: Use explicit, relevant names. Avoid cryptic or generic names.
+
+## Directory Structure
+
+- Place code in the correct directory: `addons/popochiu/editor/` for editor tools, `addons/popochiu/engine/` for engine logic, and `game/` for game scripts.
+- Documentation lives in `docs/src/` and assets in `docs/src/assets/`.
+
+## Versioning & PRs
+
+- Branch naming: `feature/<issue_number>-name`, `fix/<issue_number>-name`, `docs/<issue_number>-name`.
+- Commit messages: `refs #<issue_number>: Clear message explaining why.`
+- PR titles should follow commit message format. Large PRs should include a summary.
+
+## Documentation Contributions
+
+- Use [MkDocs](https://www.mkdocs.org/) and Markdown. Preview changes locally using the provided Docker environment.
+- Documentation must be in clear English, with an informal but accessible tone.
+- Use the Diátaxis framework: Tutorials, How-to Guides, Explanations, Reference.
+- Update documentation for new features, public interface changes, or GUI updates.
+- Update screenshots/visuals as needed, using Godot dark theme and red annotations for clarity.
 
 ## Integration Points
 
-- **External Dependencies**: Asset importers may depend on external formats (e.g., Aseprite). No other major external dependencies are present.
-- **Cross-Component Communication**: Use interfaces in `addons/popochiu/engine/interfaces/` for high-level API access.
-
-## Key Files & Directories
-
-- `addons/popochiu/editor/main_dock/`: Main UI for managing game elements.
-- `addons/popochiu/editor/importers/`: Asset importers.
-- `addons/popochiu/editor/migration/`: Migration logic.
-- `addons/popochiu/engine/popochiu.gd`: Main engine controller.
-- `addons/popochiu/engine/objects/`: Base classes for game entities.
-- `addons/popochiu/engine/interfaces/`: APIs for game object access.
-- `addons/popochiu/engine/templates/`: Script templates for new objects.
+- Asset importers may depend on external formats (e.g., Aseprite). No other major external dependencies are present.
+- Use interfaces in `addons/popochiu/engine/interfaces/` for high-level API access.
+- Avoid introducing third-party Godot addons. All features should be implemented internally.
 
 ## Example Patterns
 
@@ -53,3 +64,12 @@ Scripts in `game/` are for actual game logic and may access engine singletons di
   ```gdscript
   PopochiuUtils.r.get_prop("PropName")
   ```
+
+## Definition of Done
+
+- Address all edge cases, follow naming and project standards, test locally, update documentation, include migrations, remove temporary code, and add meaningful comments.
+
+## Useful Links
+- [Popochiu Documentation](https://github.com/carenalgas/popochiu/tree/main/docs)
+- [Godot GDScript Style Guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html)
+- [Diátaxis Documentation Framework](https://diataxis.fr/)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,58 @@
+# GitHub Copilot Repository Instructions for Popochiu
+
+Popochiu is a Godot addon that helps developers create classic point-and-click adventure games. It is composed of two main components:
+
+## Editor Plugin (`editor/`)
+
+This component extends the Godot Editor with a full suite of tools and interfaces to build, organize, and maintain all elements of a graphic adventure.
+
+- `main_dock/`: The central UI that lists and manages characters, rooms, inventory items, audio cues, and more.
+- `canvas_editor_menu/`: Adds buttons to the Scene Preview toolbar for enabling Popochiu’s interactive gizmos.
+- `inspector/`: Customizes how Popochiu objects appear in the Godot Inspector to hide or expose relevant properties.
+- `popups/`: Provides modal dialogs for creating and managing game objects and settings.
+- `migration/`: Implements version migrations to update existing projects when upgrading Popochiu.
+- `gizmos/`: Adds in-editor visual handlers (walk-to points, baselines, etc.) for interactive scene editing.
+- `importers/`: Allows importing of assets (e.g., Aseprite animations) and auto-generating rooms and characters.
+- `factories/`: Builds game object instances (characters, props, rooms) from engine templates.
+- `config/`: Exposes and reads project/editor settings related to Popochiu.
+- `helpers/`: Shared utility functions and classes used across the plugin.
+
+## Game Engine (`engine/`)
+
+This is the runtime layer that is bundled with the game and handles all core logic and reusable functionality.
+
+- `popochiu.gd`: The main controller that initializes the engine, routes input, and manages the game's lifecycle.
+- `audio_manager/`: Manages music and sound effects playback, including positional and non-positional audio.
+- `cursor/`: Handles the runtime mouse pointer (not to be confused with the GUI Cursor component).
+- `objects/`: Base classes for game entities like characters, rooms, props, hotspots, inventory items, and more.
+- `interfaces/`: High-level APIs (via singletons) for accessing and manipulating game objects from scripts.
+- `templates/`: Script templates used by the Editor Plugin to generate new game objects and GUI components.
+
+Note: scripts in the `game/` folder are meant for actual game logic and may access engine singletons like `E`, `C`, `D`, etc. Scripts in `editor/` and `engine/` must **not** use those directly, but must use `PopochiuUtils` instead.
+ Just map each singleton to a lowercase variable name, under `PopochiuUtils`, like this:
+
+```gdscript
+# Inside game scripts
+R.get_prop("PropName")
+
+# Inside engine or editor scripts
+PopochiuUtils.r.get_prop("PropName")
+```
+
+## Coding standards
+
+When generating code, please follow these guidelines:
+
+- **Always** follow the official Godot GDScript style guide.
+- Use **tabs**, NOT spaces, for indentation.
+- Do **not** leave trailing whitespace at the end of lines or on empty lines.
+- File names should use `snake_case` and reflect the class they define.
+- All classes in the `engine/` and `editor/` folders must be explicitly named and start with `Popochiu`, due to the lack of namespaces in GDScript.
+
+## Commenting rules
+
+- Only in the `engine/` folder, always use `##` for documentation comments on **public or virtual** methods, classes, constants, enums, signals, and exported variables. These should include a description, details, and usage examples when relevant.
+- Use `#` for internal comments in **private methods or classes**, and in every comment in the `editor` folder, never starting comments with `##` to prevent them from appearing in the API documentation.
+- Comments should always explain *why* the code is written a certain way, not just what it does (which should already be clear from the code).
+- Place comments above the code they reference, not at the end of a line.
+- All comments must start with a capital letter and end with a period.

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy-gh-pages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ Thumbs.db
 # Other local stuff
 .vscode
 
+# Ignore everything in addons except popochiu and its content
+addons/*
+!addons/popochiu/
+!addons/popochiu/**
+
 # Project-specific ignores
 popochiu
 popochiu/**
@@ -40,5 +45,3 @@ docs/dist/**/*
 Collector*.gd
 ReferenceCollectorCLI*.gd
 reference.json
-
-!addons/*

--- a/docs/src/contributing-to-popochiu/project-management/issue-tracking.md
+++ b/docs/src/contributing-to-popochiu/project-management/issue-tracking.md
@@ -29,7 +29,7 @@ In addition, we categorize issues into four **lanes** based on their type and pr
 1. **Bugfixing**: These are both urgent and important. They block the correct functioning of the plugin and need immediate attention.
 2. **Polishing**: These issues are less urgent but still important. They’re usually small, low-effort improvements that enhance the quality of life for users and smooth out the tool’s rough edges. They may not be flashy, but they make the plugin _feel_ high quality.
 3. **Maturity**: Features or improvements that require significant effort. Working on these items makes the plugin more capable and feature-rich.
-4. **Nice-to-Have**: These issues have limited impact or are valuable to only a small group of users. While not critical, they can still be worth pursuing—great for contributors who want to stretch their skills without blocking core development.
+4. **Nice-to-Have**: These issues have limited impact or are valuable to only a small group of users. While not critical, they can still be worth pursuing. Great for contributors who want to stretch their skills without blocking core development.
 
 We use these categories to achieve two goals: ensuring a healthy mix of bug fixes, polish, and new features; helping users understand how we prioritize issues in the project’s vision.  
 On one side, indeed, it’s easy for urgent bug fixes and shiny new features to overshadow the importance of maintenance and refinement. On the other side, users are entitled to decide whether to wait for a feature to be implemented in Popochiu or create their own custom solution for their games.
@@ -78,6 +78,6 @@ When opening an issue, please:
    Before opening a new issue, search the issue tracker to ensure your topic hasn’t already been reported. If you find a similar issue, feel free to add your input there instead of creating a duplicate.
 
 6. **Bring other community members in the loop**
-   Remember, the issue tracker is a shared space for the community. Feel free to point the issue out on discord and invite other members to join the discussion. Evidence and feedback are gold to make sensible decisions about the future of the plugin.
+   Remember, the issue tracker is a shared space for the community. Feel free to point the issue out on Discord and invite other members to join the discussion. Evidence and feedback are gold to make sensible decisions about the future of the plugin.
 
 ---

--- a/docs/src/contributing-to-popochiu/qna.md
+++ b/docs/src/contributing-to-popochiu/qna.md
@@ -19,6 +19,9 @@ weight: 9070
 **Are there any coding standards or best practices specific to Popochiu?**
 : [Yes](../conventions).
 
+**Am I allowed to use AI for my contributions?**
+: Yes, but with responsibility. Read [this](../toolchain-and-dependencies/#generative-ai) first.
+
 **How do I know if a feature I want to add is already planned or under development?**
 : Look at the [project board](https://github.com/orgs/carenalgas/projects/1/views/1), particularly the `Ready` and `In Progress` columns.
 

--- a/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
+++ b/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
@@ -39,7 +39,7 @@ Dockerfiles for documentation are located in the `docs` directory:
 
 ### AI-aided coding
 
-We welcomes and encourages the use of Generative AI tools—including GitHub Copilot, Claude Code, Codeium, and similar solutions—throughout the development and documentation process.
+We welcome and encourage the use of Generative AI tools—including GitHub Copilot, Claude Code, Codeium, and similar solutions—throughout the development and documentation process.
 
 The project's repository provides a dedicated [Copilot instructions file](https://docs.github.com/en/copilot/how-tos/custom-instructions) to help guide compatible AI agents in producing code and content that aligns with our standards. 
 

--- a/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
+++ b/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
@@ -35,6 +35,37 @@ Dockerfiles for documentation are located in the `docs` directory:
 
 ---
 
+## Generative AI
+
+### AI-aided coding
+
+We welcomes and encourages the use of Generative AI tools—including GitHub Copilot, Claude Code, Codeium, and similar solutions—throughout the development and documentation process.
+
+The project's repository provides a dedicated [Copilot instructions file](https://docs.github.com/en/copilot/how-tos/custom-instructions) to help guide compatible AI agents in producing code and content that aligns with our standards. 
+
+Among other things, contributors are invited to leverage these technologies to:
+
+* Write, polish, or refactor code.
+* Analyze requirements and identify edge cases.
+* Draft issues or documentation.
+
+While these tools can greatly accelerate and enhance your workflow, it remains the contributor’s responsibility to ensure the final result meets our quality expectations and fully complies with our [Definition of Done](../project-management/definition-of-done).  
+Generative AI is a powerful ally, not a replacement for thoughtful review and accountability. We embrace these advancements wholeheartedly, but expect all contributors to use them responsibly and with care.
+
+### Documentation
+
+We encourage the use of LLMs to structure, draft, review, spellcheck and generally polish the documentation (the very same you are reading now).
+
+Again, be judicious and conscious, verify the accuracy of the information, and maintain full control over your work.
+
+### Other assets
+
+At this time, we do not allow the contribution of AI-generated creative/artistic assets like graphics or audio.
+
+The ethical, legal, and legitimacy concerns raised regarding the training methods of these tools are still too unresolved for us to include them in our toolchain lightheartedly.
+
+---
+
 ## Documentation
 
 Popochiu's documentation is written in [Markdown](https://www.markdownguide.org) and rendered using [MkDocs](https://www.mkdocs.org).

--- a/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
+++ b/docs/src/contributing-to-popochiu/toolchain-and-dependencies.md
@@ -52,13 +52,13 @@ Among other things, contributors are invited to leverage these technologies to:
 While these tools can greatly accelerate and enhance your workflow, it remains the contributor’s responsibility to ensure the final result meets our quality expectations and fully complies with our [Definition of Done](../project-management/definition-of-done).  
 Generative AI is a powerful ally, not a replacement for thoughtful review and accountability. We embrace these advancements wholeheartedly, but expect all contributors to use them responsibly and with care.
 
-### Documentation
+### AI-aided cocumentation
 
 We encourage the use of LLMs to structure, draft, review, spellcheck and generally polish the documentation (the very same you are reading now).
 
 Again, be judicious and conscious, verify the accuracy of the information, and maintain full control over your work.
 
-### Other assets
+### AI for other assets
 
 At this time, we do not allow the contribution of AI-generated creative/artistic assets like graphics or audio.
 


### PR DESCRIPTION
I polished a bit our toolchain with improvements and fixes.

The most important thing is, publishing the documentation on release should be working again now.

I added a _proper_ gitignore for plugins other than popochiu (please, test it on Windows), and a GH Copilot instruction file that will make our copilot chat more to-the-point. I'll provide more for specific file types and docs in the future, but for now it's better than nothing.

The documentation format for engine classes has been split because it's too large of a feature for now.