### PR TITLE
refs #463: Fix audio cue loop mode in Godot 4.5

### DIFF
--- a/addons/popochiu/engine/audio_manager/audio_manager.gd
+++ b/addons/popochiu/engine/audio_manager/audio_manager.gd
@@ -286,7 +286,6 @@ func _play(
 	# Fixes #463 Audio cues looping inappropriately in Godot 4.5
 	#
 	# TODO: remove this as soon as it becomes irrelevant
-	
 	if player.stream.get_class() == 'AudioStreamWAV': 
 		player.stream.loop_mode = (
 			AudioStreamWAV.LOOP_FORWARD if cue.loop else AudioStreamWAV.LOOP_DISABLED


### PR DESCRIPTION
Set the loop mode right before playing the audio cue in the Audio Manager. MP3s and OGGs loop correctly. See https://github.com/carenalgas/popochiu/issues/463 .