### PR TITLE
Assign focus to name field by default

### DIFF
--- a/addons/popochiu/editor/popups/create_object/create_object.gd
+++ b/addons/popochiu/editor/popups/create_object/create_object.gd
@@ -28,6 +28,8 @@ func _ready() -> void:
 	
 	error_container.hide()
 
+	input.call_deferred("grab_focus")
+
 
 #endregion
 


### PR DESCRIPTION
Make "Create" popups smoother to use by focusing the name field automatically. You can't click OK until you provide a name, so put the focus where you're going to need it.

We need to defer the call or else grab_focus doesn't do anything on a LineEdit node. Seems like it needs to do some internal init first.

For example, now "Room name:" gets focus as soon as this popup appears so you can click "Create room" and immediately start typing the name:
<img width="964" height="227" alt="image" src="https://github.com/user-attachments/assets/49f6f1c4-b0b5-49f2-804c-d6eaa5a13544" />
