### PR TITLE
Recognize frame_changed from AnimatedSprite2D

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -206,7 +206,9 @@ func _ready():
 	# Connect the logic for anti-glide animations.
 	# The handler function will know what to do, based on configuration.
 	for child in get_children():
-		# Check for signal instead of node type to make resilient to change.
+		# Use the presence of the "frame_changed" signal instead of checking for a
+		# specific node type (would be Sprite2D). Improves resilience if the
+		# node structure gets altered, as long as the new node still emits the same signal.
 		if not child.has_signal("frame_changed"):
 			continue
 		child.frame_changed.connect(_update_position)


### PR DESCRIPTION
Fix anti_glide_animation doesn't work if you change a Character's Sprite2D to an AnimatedSprite2D.

We only need to ensure the signal exists so we can connect to it, so check that instead of the type. This is only done on _ready, so it shouldn't be a perf problem.

While the Popochiu recommended method is to use a Sprite2D + AnimationPlayer, there doesn't seem to be any reason to limit what we support.