### PR TITLE
refs #474: Use PopochiuInventoryItemData to get scene for migrate

### DIFF
--- a/addons/popochiu/migration/migrations/popochiu_migration_4.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_4.gd
@@ -4,7 +4,7 @@ extends PopochiuMigration
 
 # Update constant values to be correct for your migration
 const VERSION = 4
-const DESCRIPTION = "short description of migration goes here"
+const DESCRIPTION = "Upgrade gui elements"
 const STEPS = [
 	"Remove InventoryBar, SettingsBar, TextSettingsPopup and SoundSettingsPopup",
 	"Add SimpleClickBar and SimpleClickSettingsPopup.",

--- a/addons/popochiu/migration/migrations/popochiu_migration_6.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_6.gd
@@ -42,10 +42,12 @@ func _add_animation_players_to_inventory_items() -> Completion:
 	
 	while file_name != "":
 		if dir.current_is_dir():
-			var item_scene_path: String = PopochiuResources.get_data_value("inventory_items", file_name.to_snake_case(), null)
-			if item_scene_path != null and FileAccess.file_exists(item_scene_path):
+			var item_path = PopochiuResources.get_data_value("inventory_items", file_name.to_pascal_case(), null)
+			if item_path == null or not FileAccess.file_exists(item_path):
+				item_path = PopochiuResources.get_data_value("inventory_items", file_name.to_snake_case(), null)
+			if item_path != null and FileAccess.file_exists(item_path):
 				# Process one item at a time to avoid memory issues
-				if _update_inventory_item_by_path(item_scene_path):
+				if _update_inventory_item_by_path(item_path):
 					any_item_updated = true
 		file_name = dir.get_next()
 
@@ -54,13 +56,20 @@ func _add_animation_players_to_inventory_items() -> Completion:
 
 
 ## Update a single inventory item by loading it from its scene path.
-func _update_inventory_item_by_path(scene_path: String) -> bool:
-	var packed_scene: PackedScene = load(scene_path)
+func _update_inventory_item_by_path(item_data_path: String) -> bool:
+	var item_data = load(item_data_path)
+	if not item_data:
+		return false
+
+	var packed_scene = item_data as PackedScene
+	if item_data is PopochiuInventoryItemData:
+		packed_scene = item_data.scene
+
 	if not packed_scene:
 		return false
 	
 	var item_instance = packed_scene.instantiate()
-	if not item_instance is PopochiuInventoryItem:
+	if item_instance is not PopochiuInventoryItem:
 		item_instance.queue_free()
 		return false
 	

--- a/addons/popochiu/migration/migrations/popochiu_migration_8.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_8.gd
@@ -33,7 +33,7 @@ func _do_migration() -> bool:
 ## Add NavigationObstacle2D nodes to all props that don't already have one.
 func _add_obstacle_polygons_to_props() -> Completion:
 	var rooms_path := PopochiuResources.ROOMS_PATH
-	PopochiuUtils.print_normal("Migration %d: Adding obstacle polygon to all props.")
+	PopochiuUtils.print_normal("Migration %d: Adding obstacle polygon to all props." % [VERSION])
 	
 	if not DirAccess.dir_exists_absolute(rooms_path):
 		PopochiuUtils.print_error("Migration %d: Rooms directory does not exist: %s" % [VERSION, rooms_path])
@@ -156,7 +156,7 @@ func _update_signal_references_in_game_scripts() -> Completion:
 		if _update_signal_references_in_file(script_path):
 			any_script_updated = true
 	
-	PopochiuUtils.print_normal("Migration %d: Signal references update completed. %s script updated: %s" % [VERSION, "Some" if any_script_updated else "No"])
+	PopochiuUtils.print_normal("Migration %d: Signal references update completed. %s scripts updated." % [VERSION, "Some" if any_script_updated else "No"])
 	return Completion.DONE if any_script_updated else Completion.IGNORED
 
 


### PR DESCRIPTION
Resolve blocking issues in Migration 6:
* item_scene_path's type is String but it might be null on failure. Godot (4.3)'s type checking barfs when assigning null to a String.
* We're converting a file name to snake_case, but the filenames are already snake_case. The key names are PascalCase.
* The path we pull out of popochiu_data.cfg is the path to a PopochiuInventoryItemData. I'm not sure if at some point it was a scene, so still handle that possibility.

Also address minor issues:
* Migration 4: No description
* Migration 8: Some logs don't have enough values passed to format string.

Unresolved: Sometimes Migration 4 fails to run but I haven't figured out why. I suspect it's more reliable on Godot 4.5.

Test
* Upgrade popochiu-sample-game to latest develop and run migration.