### PR TITLE
fixes #465: inventory item

### DIFF
--- a/addons/popochiu/editor/main_dock/popochiu_row/object_row/inventory_item_row/popochiu_inventory_item_row.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_row/object_row/inventory_item_row/popochiu_inventory_item_row.gd
@@ -50,20 +50,27 @@ func _update_menu_state() -> void:
 	
 	# Get the menu item index for the "Start with it" option
 	var start_with_it_idx := menu_popup.get_item_index(InventoryItemOptions.START_WITH_IT)
+
+	# Check if we've reached the inventory limit
+	# The option should be disabled if:
+	# - The inventory limit is set (> 0)
+	# - The limit has been reached
+	# - The current item is not already in the starting inventory
+	var should_disable := (
+		inventory_limit > 0
+		and items.size() >= inventory_limit
+		and script_name not in items
+	)
 	
-	if start_with_it_idx >= 0:
-		# Check if we've reached the inventory limit
-		# The option should be disabled if:
-		# - The inventory limit is set (> 0)
-		# - The limit has been reached
-		# - The current item is not already in the starting inventory
-		var should_disable := (
-			inventory_limit > 0
-			and items.size() >= inventory_limit
-			and script_name not in items
-		)
-		
-		menu_popup.set_item_disabled(start_with_it_idx, should_disable)
+	# Enable or disable the menu item accordingly
+	menu_popup.set_item_disabled(start_with_it_idx, should_disable)
+	# Add a tooltip to inform the user why the option is disabled
+	menu_popup.set_item_tooltip(
+		start_with_it_idx,
+		("You have reached the inventory size limit set in Popochiu Config (%d)." % inventory_limit)
+			if should_disable
+			else ""
+	)
 
 
 func _get_menu_cfg() -> Array:


### PR DESCRIPTION
If the limit of items in the inventory is reached, the menu to add item on start gets disabled.