### PR TITLE
Fixes #481 and #482

### DIFF
--- a/addons/popochiu/editor/canvas_editor_menu/popochiu_canvas_editor_menu.gd
+++ b/addons/popochiu/editor/canvas_editor_menu/popochiu_canvas_editor_menu.gd
@@ -34,9 +34,11 @@ func _ready() -> void:
 	btn_interaction_polygon.pressed.connect(_select_interaction_polygon)
 	btn_obstacle_polygon.pressed.connect(_select_obstacle_polygon)
 
-	# Connect to singleton signals
+	# Connect to global signals
 	EditorInterface.get_selection().selection_changed.connect(_on_selection_changed)
 	EditorInterface.get_editor_settings().settings_changed.connect(_on_gizmo_settings_changed)
+	PopochiuEditorHelper.signal_bus.scene_changed.connect(_on_scene_changed)
+	PopochiuEditorHelper.signal_bus.scene_closed.connect(_on_scene_closed)
 
 	_set_toolbar_buttons_color()
 	hide()
@@ -44,7 +46,7 @@ func _ready() -> void:
 
 #endregion
 
-#region Private ####################################################################################
+#region Signals ####################################################################################
 func _toggle_markers_visibility() -> void:
 	PopochiuEditorHelper.signal_bus.gizmo_visibility_changed.emit(
 		PopochiuGizmoPlugin.MARKER_POS,
@@ -149,42 +151,6 @@ func _select_obstacle_polygon() -> void:
 	btn_obstacle_polygon.set_pressed_no_signal(true)
 
 
-# This function is used to exit editing mode. It's called by the toolbar buttons
-# polygons selector handlers when we are editing a polygon.
-#
-# NOTE: To keep the naming meaningful and avoid a mess with arguments (like, passing the button
-# which makes little sense), it inspects the type of polygon to identify the
-# button to pop. This requires a bit of maintenance, but the whole polygon thing does
-# so...
-func _exit_editing_mode() -> void:
-	# Pop the right button on the toolbar, depending
-	# on the type of the polygon being edited.
-	if PopochiuEditorHelper.is_popochiu_obj_polygon(_polygon_being_edited):
-		btn_interaction_polygon.set_pressed_no_signal(false)
-	elif PopochiuEditorHelper.is_popochiu_obstacle_polygon(_polygon_being_edited):
-		btn_obstacle_polygon.set_pressed_no_signal(false)
-
-	# Clear selection
-	EditorInterface.get_selection().clear()
-	EditorInterface.get_selection().add_node(
-		_polygon_being_edited.get_parent()
-	)
-
-	# Reset editing mode flags
-	_is_editing_polygon = false
-	_polygon_being_edited = null
-
-	# Refresh the editor interface
-	_on_selection_changed()
-
-
-func _on_gizmo_settings_changed() -> void:
-	# Pretty self explanatory
-	_set_walkable_areas_visibility()
-	_set_room_clickable_polygons_visibility()
-	_set_toolbar_buttons_color()
-
-
 # This overly complex function refreshes the whole interface after a sub-node (interaction
 # or navigation polygon) of a clickable or walkable area has been selected/deselected.
 #
@@ -195,6 +161,18 @@ func _on_selection_changed() -> void:
 	# Only force polygon reselection if edit mode is active
 	if _is_editing_polygon && _polygon_being_edited != null:
 		var selected_nodes = EditorInterface.get_selection().get_selected_nodes()
+		
+		# Fix #482: Cancel polygon edition when selecting another node in the Scene dock.
+		if _is_selection_from_scene_tree():
+			var node_to_select: Node = selected_nodes.filter(
+				func (node: Node) -> bool:
+					return node != _polygon_being_edited
+			)[0]
+			_exit_editing_mode()
+			EditorInterface.get_selection().clear()
+			EditorInterface.get_selection().add_node(node_to_select)
+			return
+		
 		if selected_nodes.is_empty() || !(_polygon_being_edited in selected_nodes):
 			EditorInterface.get_selection().clear()
 			EditorInterface.get_selection().add_node(_polygon_being_edited)
@@ -309,6 +287,57 @@ func _on_selection_changed() -> void:
 
 	# Always reset the button visibility depending on the state of the internal variables	
 	_set_buttons_visibility()
+
+
+func _on_gizmo_settings_changed() -> void:
+	# Pretty self explanatory
+	_set_walkable_areas_visibility()
+	_set_room_clickable_polygons_visibility()
+	_set_toolbar_buttons_color()
+
+
+func _on_scene_changed(scene_root: Node) -> void:
+	# Fix #482: Cancel polygon edition when changing to another scene
+	if _is_editing_polygon && _polygon_being_edited != null:
+		_exit_editing_mode()
+		EditorInterface.get_selection().clear()
+
+
+func _on_scene_closed(filepath: String) -> void:
+	# Fix #482: Cancel polygon edition when closing the current scene
+	if _is_editing_polygon && _polygon_being_edited != null:
+		_exit_editing_mode()
+		EditorInterface.get_selection().clear()
+
+
+#endregion
+
+#region Private ####################################################################################
+# This function is used to exit editing mode. It's called by the toolbar buttons
+# polygons selector handlers when we are editing a polygon.
+#
+# NOTE: To keep the naming meaningful and avoid a mess with arguments (like, passing the button
+# which makes little sense), it inspects the type of polygon to identify the
+# button to pop. This requires a bit of maintenance, but the whole polygon thing does
+# so...
+func _exit_editing_mode() -> void:
+	# Pop the right button on the toolbar, depending
+	# on the type of the polygon being edited.
+	if PopochiuEditorHelper.is_popochiu_obj_polygon(_polygon_being_edited):
+		btn_interaction_polygon.set_pressed_no_signal(false)
+	elif PopochiuEditorHelper.is_popochiu_obstacle_polygon(_polygon_being_edited):
+		btn_obstacle_polygon.set_pressed_no_signal(false)
+
+	# Clear selection
+	EditorInterface.get_selection().clear()
+	EditorInterface.get_selection().add_node(_polygon_being_edited.get_parent())
+
+	# Reset editing mode flags
+	_is_editing_polygon = false
+	_polygon_being_edited = null
+
+	# Refresh the editor interface
+	_on_selection_changed()
 
 
 # Handles the editor config that allows the WAs polygons to be always visible,
@@ -578,6 +607,39 @@ func _reset_buttons_state() -> void:
 	btn_walk_to_point.set_pressed_no_signal(true)
 	btn_look_at_point.set_pressed_no_signal(true)
 	btn_dialog_pos.set_pressed_no_signal(true)
+
+
+# Detects if the current selection change originated from the Scene tree dock
+# by checking if the mouse is over the scene tree area
+func _is_selection_from_scene_tree() -> bool:
+	var mouse_pos := get_viewport().get_mouse_position()
+	var scene_tree_dock := _find_scene_tree_dock()
+	
+	if scene_tree_dock:
+		var rect := scene_tree_dock.get_global_rect()
+		return rect.has_point(mouse_pos)
+	
+	# If we can't find the scene tree dock, assume false (don't cancel)
+	return false
+
+
+# Finds the Scene tree dock control in the editor
+func _find_scene_tree_dock() -> Control:
+	var editor_base := EditorInterface.get_base_control()
+	return _search_control_by_name(editor_base, "Scene")
+
+
+# Recursively searches for a control with a specific name
+func _search_control_by_name(node: Node, control_name: String) -> Control:
+	if node is Control and node.name == control_name:
+		return node as Control
+	
+	for child in node.get_children():
+		var result := _search_control_by_name(child, control_name)
+		if result:
+			return result
+	
+	return null
 
 
 #endregion

--- a/addons/popochiu/editor/canvas_editor_menu/popochiu_canvas_editor_menu.tscn
+++ b/addons/popochiu/editor/canvas_editor_menu/popochiu_canvas_editor_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://wd748u1vdybq"]
+[gd_scene format=3 uid="uid://wd748u1vdybq"]
 
 [ext_resource type="Script" uid="uid://bjpgtct41bl2i" path="res://addons/popochiu/editor/canvas_editor_menu/popochiu_canvas_editor_menu.gd" id="1_vs7c6"]
 [ext_resource type="Texture2D" uid="uid://b3sku5v1n23ni" path="res://addons/popochiu/icons/btn_baseline.svg" id="2_w3cau"]
@@ -9,75 +9,103 @@
 [ext_resource type="Texture2D" uid="uid://d11mg7ftbxvl0" path="res://addons/popochiu/icons/btn_markers.svg" id="6_yea6f"]
 [ext_resource type="Texture2D" uid="uid://dfstqtc5nlapr" path="res://addons/popochiu/icons/btn_obstacle_polygon.svg" id="8_8v2pw"]
 
-[node name="PopochiuCanvasEditorMenu" type="HBoxContainer"]
+[node name="PopochiuCanvasEditorMenu" type="HBoxContainer" unique_id=1273042423]
 visible = false
 offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("1_vs7c6")
 
-[node name="Label" type="Label" parent="."]
+[node name="Label" type="Label" parent="." unique_id=62529825]
 layout_mode = 2
 text = "Popochiu "
 vertical_alignment = 1
 
-[node name="BtnMarkers" type="Button" parent="."]
+[node name="BtnMarkers" type="Button" parent="." unique_id=424778254]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Room Markers"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(0, 1, 1, 1)
+theme_override_colors/icon_pressed_color = Color(0, 0.8, 0.8, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 button_pressed = true
 icon = ExtResource("6_yea6f")
 
-[node name="BtnBaseline" type="Button" parent="."]
+[node name="BtnBaseline" type="Button" parent="." unique_id=917492889]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Baseline"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(0, 1, 1, 1)
+theme_override_colors/icon_pressed_color = Color(0, 0.8, 0.8, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 button_pressed = true
 icon = ExtResource("2_w3cau")
 
-[node name="BtnWalkToPoint" type="Button" parent="."]
+[node name="BtnWalkToPoint" type="Button" parent="." unique_id=1572127953]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Walk-To Point"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(0, 1, 0, 1)
+theme_override_colors/icon_pressed_color = Color(0, 0.8, 0, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 button_pressed = true
 icon = ExtResource("3_ifql1")
 
-[node name="BtnLookAtPoint" type="Button" parent="."]
+[node name="BtnLookAtPoint" type="Button" parent="." unique_id=509955998]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Look-At Point"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(1, 0, 0, 1)
+theme_override_colors/icon_pressed_color = Color(0.8, 0, 0, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 button_pressed = true
 icon = ExtResource("4_bge33")
 
-[node name="BtnDialogPos" type="Button" parent="."]
+[node name="BtnDialogPos" type="Button" parent="." unique_id=76770728]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 tooltip_text = "Dialog Position"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(1, 0, 1, 1)
+theme_override_colors/icon_pressed_color = Color(0.8, 0, 0.8, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 button_pressed = true
 icon = ExtResource("5_803mj")
 
-[node name="BtnInteractionPolygon" type="Button" parent="."]
+[node name="BtnInteractionPolygon" type="Button" parent="." unique_id=577931182]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Interaction Polygon"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(1, 0, 0, 1)
+theme_override_colors/icon_pressed_color = Color(0.8, 0, 0, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 icon = ExtResource("6_6oxl8")
 
-[node name="BtnObstaclePolygon" type="Button" parent="."]
+[node name="BtnObstaclePolygon" type="Button" parent="." unique_id=1893283886]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Obstacle Polygon"
 theme_type_variation = &"FlatButton"
+theme_override_colors/icon_normal_color = Color(1, 0.54901963, 0, 1)
+theme_override_colors/icon_pressed_color = Color(0.8, 0.43921572, 0, 1)
+theme_override_colors/icon_hover_color = Color(1, 1, 1, 1)
+theme_override_colors/icon_hover_pressed_color = Color(1, 1, 1, 1)
 toggle_mode = true
 icon = ExtResource("8_8v2pw")

--- a/addons/popochiu/editor/gizmos/gizmo2d.gd
+++ b/addons/popochiu/editor/gizmos/gizmo2d.gd
@@ -299,7 +299,7 @@ func drag_to(pos: Vector2):
 		_current_position = _target_node.get_viewport_transform().affine_inverse() * current_gizmo_pos
 	else:
 		# For property offsets, calculate distance between gizmo center position in 2D world node coordinates and
-    	# node position, ignoring its transform basis (which holds rotation, skew and scale)
+		# node position, ignoring its transform basis (which holds rotation, skew and scale)
 		_current_position = _target_node.get_viewport_transform().affine_inverse() * current_gizmo_pos - (target_node.get_global_transform().origin)
 
 func release():

--- a/addons/popochiu/editor/gizmos/gizmo_manager_clickable.gd
+++ b/addons/popochiu/editor/gizmos/gizmo_manager_clickable.gd
@@ -16,180 +16,180 @@ var _grabbed_gizmo: Gizmo2D
 
 #region Godot ######################################################################################
 func _init(undo_manager: EditorUndoRedoManager):
-    _undo = undo_manager
-    _gizmos.resize(4)
+	_undo = undo_manager
+	_gizmos.resize(4)
 
 
 #endregion
 
 #region Private #####################################################################################
 func _init_gizmo(gizmo_id: int) -> Gizmo2D:
-    var gizmo: Gizmo2D
-    
-    match gizmo_id:
-        PopochiuGizmoPlugin.WALK_TO_POINT:
-            gizmo = Gizmo2D.new(_target_node, "walk_to_point", "Walk To Point", Gizmo2D.GIZMO_OFFSET)
-        PopochiuGizmoPlugin.LOOK_AT_POINT:
-            gizmo = Gizmo2D.new(_target_node, "look_at_point", "Look At Point", Gizmo2D.GIZMO_OFFSET)
-        PopochiuGizmoPlugin.BASELINE:
-            gizmo = Gizmo2D.new(_target_node, "baseline", "Baseline", Gizmo2D.GIZMO_VOFFSET)
-        PopochiuGizmoPlugin.DIALOG_POS:
-            gizmo = Gizmo2D.new(_target_node, "dialog_pos", "Dialog Position", Gizmo2D.GIZMO_OFFSET)
-    
-    _set_gizmo_theme(gizmo, gizmo_id)
-    _set_gizmo_properties(gizmo)
-    return gizmo
+	var gizmo: Gizmo2D
+	
+	match gizmo_id:
+		PopochiuGizmoPlugin.WALK_TO_POINT:
+			gizmo = Gizmo2D.new(_target_node, "walk_to_point", "Walk To Point", Gizmo2D.GIZMO_OFFSET)
+		PopochiuGizmoPlugin.LOOK_AT_POINT:
+			gizmo = Gizmo2D.new(_target_node, "look_at_point", "Look At Point", Gizmo2D.GIZMO_OFFSET)
+		PopochiuGizmoPlugin.BASELINE:
+			gizmo = Gizmo2D.new(_target_node, "baseline", "Baseline", Gizmo2D.GIZMO_VOFFSET)
+		PopochiuGizmoPlugin.DIALOG_POS:
+			gizmo = Gizmo2D.new(_target_node, "dialog_pos", "Dialog Position", Gizmo2D.GIZMO_OFFSET)
+	
+	_set_gizmo_theme(gizmo, gizmo_id)
+	_set_gizmo_properties(gizmo)
+	return gizmo
 
 
 func _set_gizmo_theme(gizmo: Gizmo2D, gizmo_id: int) -> void:
-    gizmo.set_theme(
-        PopochiuEditorConfig.get_editor_setting(_color_settings[gizmo_id]),
-        PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_HANDLER_SIZE),
-        _font,
-        PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_FONT_SIZE)
-    )
+	gizmo.set_theme(
+		PopochiuEditorConfig.get_editor_setting(_color_settings[gizmo_id]),
+		PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_HANDLER_SIZE),
+		_font,
+		PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_FONT_SIZE)
+	)
 
 
 func _set_gizmo_properties(gizmo: Gizmo2D) -> void:
-    gizmo.show_connector = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_CONNECTORS)
-    gizmo.show_target_name = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_NODE_NAME)
-    gizmo.show_outlines = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_OUTLINE)
-    gizmo.show_position = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_POSITION)
+	gizmo.show_connector = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_CONNECTORS)
+	gizmo.show_target_name = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_NODE_NAME)
+	gizmo.show_outlines = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_OUTLINE)
+	gizmo.show_position = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_POSITION)
 
 
 func _update_properties() -> void:
-    if _grabbed_gizmo and _grabbed_gizmo.target_property:
-        _target_node.set(
-            _grabbed_gizmo.target_property,
-            _grabbed_gizmo.get_position()
-        )
+	if _grabbed_gizmo and _grabbed_gizmo.target_property:
+		_target_node.set(
+			_grabbed_gizmo.target_property,
+			_grabbed_gizmo.get_position()
+		)
 
 
 #endregion
 
 #region Public #####################################################################################
 func initialize_gizmos(font: Font, color_settings: Dictionary) -> void:
-    _font = font
-    _color_settings = color_settings
+	_font = font
+	_color_settings = color_settings
 
-    # Initialize gizmos for PopochiuClickable objects
-    _gizmos[PopochiuGizmoPlugin.WALK_TO_POINT] = _init_gizmo(PopochiuGizmoPlugin.WALK_TO_POINT)
-    _gizmos[PopochiuGizmoPlugin.LOOK_AT_POINT] = _init_gizmo(PopochiuGizmoPlugin.LOOK_AT_POINT)
-    _gizmos[PopochiuGizmoPlugin.BASELINE] = _init_gizmo(PopochiuGizmoPlugin.BASELINE)
-    _gizmos[PopochiuGizmoPlugin.DIALOG_POS] = _init_gizmo(PopochiuGizmoPlugin.DIALOG_POS)
+	# Initialize gizmos for PopochiuClickable objects
+	_gizmos[PopochiuGizmoPlugin.WALK_TO_POINT] = _init_gizmo(PopochiuGizmoPlugin.WALK_TO_POINT)
+	_gizmos[PopochiuGizmoPlugin.LOOK_AT_POINT] = _init_gizmo(PopochiuGizmoPlugin.LOOK_AT_POINT)
+	_gizmos[PopochiuGizmoPlugin.BASELINE] = _init_gizmo(PopochiuGizmoPlugin.BASELINE)
+	_gizmos[PopochiuGizmoPlugin.DIALOG_POS] = _init_gizmo(PopochiuGizmoPlugin.DIALOG_POS)
 
 
 func handle_object(object: Object, edited_root: Node) -> bool:
-    if not object is PopochiuClickable:
-        reset()
-        return false
+	if not object is PopochiuClickable:
+		reset()
+		return false
 
-    _target_node = object
-    _active_gizmos.clear()
+	_target_node = object
+	_active_gizmos.clear()
 
-    # Add the appropriate gizmos for clickable objects
-    if edited_root is PopochiuCharacter:
-        _active_gizmos.append(_gizmos[PopochiuGizmoPlugin.DIALOG_POS])
-    elif edited_root is PopochiuRoom:
-        _active_gizmos.append(_gizmos[PopochiuGizmoPlugin.WALK_TO_POINT])
-        _active_gizmos.append(_gizmos[PopochiuGizmoPlugin.LOOK_AT_POINT])
-        _active_gizmos.append(_gizmos[PopochiuGizmoPlugin.BASELINE])
+	# Add the appropriate gizmos for clickable objects
+	if edited_root is PopochiuCharacter:
+		_active_gizmos.append(_gizmos[PopochiuGizmoPlugin.DIALOG_POS])
+	elif edited_root is PopochiuRoom:
+		_active_gizmos.append(_gizmos[PopochiuGizmoPlugin.WALK_TO_POINT])
+		_active_gizmos.append(_gizmos[PopochiuGizmoPlugin.LOOK_AT_POINT])
+		_active_gizmos.append(_gizmos[PopochiuGizmoPlugin.BASELINE])
 
-    for gizmo in _active_gizmos:
-        gizmo.set_target_node(_target_node)
+	for gizmo in _active_gizmos:
+		gizmo.set_target_node(_target_node)
 
-    return _active_gizmos.size() > 0
+	return _active_gizmos.size() > 0
 
 
 func draw_gizmos(viewport_control: Control) -> void:
-    for gizmo in _active_gizmos:
-        gizmo.draw(viewport_control, _target_node.get(gizmo.target_property))
+	for gizmo in _active_gizmos:
+		gizmo.draw(viewport_control, _target_node.get(gizmo.target_property))
 
 
 func try_grab_gizmo(event: InputEventMouseButton) -> bool:
-    if not _target_node or _active_gizmos.is_empty():
-        return false
+	if not _target_node or _active_gizmos.is_empty():
+		return false
 
-    # Check if the mouse click happened on a gizmo (in reverse order)
-    for i in range(_active_gizmos.size() - 1, -1, -1):
-        if not _active_gizmos[i].has_point(event.position):
-            continue
-        _grabbed_gizmo = _active_gizmos[i]
-        break
+	# Check if the mouse click happened on a gizmo (in reverse order)
+	for i in range(_active_gizmos.size() - 1, -1, -1):
+		if not _active_gizmos[i].has_point(event.position):
+			continue
+		_grabbed_gizmo = _active_gizmos[i]
+		break
 
-    # If user clicked on no gizmos, ignore the event
-    if not _grabbed_gizmo:
-        return false
+	# If user clicked on no gizmos, ignore the event
+	if not _grabbed_gizmo:
+		return false
 
-    # Hold the gizmo with the mouse
-    _grabbed_gizmo.grab(event.position)
-    _undo.create_action("Move clickable gizmo")
-    _undo.add_undo_property(
-        _grabbed_gizmo.target_node,
-        _grabbed_gizmo.target_property,
-        _grabbed_gizmo.target_node.get(_grabbed_gizmo.target_property)
-    )
-    return true
+	# Hold the gizmo with the mouse
+	_grabbed_gizmo.grab(event.position)
+	_undo.create_action("Move clickable gizmo")
+	_undo.add_undo_property(
+		_grabbed_gizmo.target_node,
+		_grabbed_gizmo.target_property,
+		_grabbed_gizmo.target_node.get(_grabbed_gizmo.target_property)
+	)
+	return true
 
 
 func release_gizmo() -> bool:
-    if not _grabbed_gizmo:
-        return false
+	if not _grabbed_gizmo:
+		return false
 
-    _grabbed_gizmo.release()
-    _undo.add_do_property(
-        _grabbed_gizmo.target_node,
-        _grabbed_gizmo.target_property,
-        _grabbed_gizmo.target_node.get(_grabbed_gizmo.target_property)
-    )
-    _undo.commit_action()
-    _grabbed_gizmo = null
-    return true
+	_grabbed_gizmo.release()
+	_undo.add_do_property(
+		_grabbed_gizmo.target_node,
+		_grabbed_gizmo.target_property,
+		_grabbed_gizmo.target_node.get(_grabbed_gizmo.target_property)
+	)
+	_undo.commit_action()
+	_grabbed_gizmo = null
+	return true
 
 
 func drag_gizmo(event: InputEventMouseMotion) -> bool:
-    if not _grabbed_gizmo:
-        return false
+	if not _grabbed_gizmo:
+		return false
 
-    # Drag the gizmo
-    _grabbed_gizmo.drag_to(event.position)
-    _update_properties()
-    return true
+	# Drag the gizmo
+	_grabbed_gizmo.drag_to(event.position)
+	_update_properties()
+	return true
 
 
 func cancel_dragging() -> bool:
-    if not _grabbed_gizmo:
-        return false
-    
-    # Cancel the action
-    _grabbed_gizmo.cancel()
-    _undo.commit_action()
-    _undo.get_history_undo_redo(_undo.get_object_history_id(_grabbed_gizmo.target_node)).undo()
-    _grabbed_gizmo = null
-    return true
+	if not _grabbed_gizmo:
+		return false
+	
+	# Cancel the action
+	_grabbed_gizmo.cancel()
+	_undo.commit_action()
+	_undo.get_history_undo_redo(_undo.get_object_history_id(_grabbed_gizmo.target_node)).undo()
+	_grabbed_gizmo = null
+	return true
 
 
 func has_active_gizmo() -> bool:
-    return _grabbed_gizmo != null
+	return _grabbed_gizmo != null
 
 
 func update_gizmo_settings() -> void:
-    for gizmo_id in _gizmos.size():
-        _set_gizmo_theme(_gizmos[gizmo_id], gizmo_id)
-        _set_gizmo_properties(_gizmos[gizmo_id])
+	for gizmo_id in _gizmos.size():
+		_set_gizmo_theme(_gizmos[gizmo_id], gizmo_id)
+		_set_gizmo_properties(_gizmos[gizmo_id])
 
 
 func set_gizmo_visibility(gizmo_id: int, visible: bool) -> void:
-    if gizmo_id < _gizmos.size():
-        _gizmos[gizmo_id].visible = visible
+	if gizmo_id < _gizmos.size():
+		_gizmos[gizmo_id].visible = visible
 
 
 # Clear all active gizmos and reset internal state.
 # Called when changing scenes or explicitly resetting the manager.
 func reset() -> void:
-    _active_gizmos.clear()
-    _target_node = null
-    _grabbed_gizmo = null
+	_active_gizmos.clear()
+	_target_node = null
+	_grabbed_gizmo = null
 
 
 #endregion

--- a/addons/popochiu/editor/gizmos/gizmo_manager_marker.gd
+++ b/addons/popochiu/editor/gizmos/gizmo_manager_marker.gd
@@ -17,197 +17,197 @@ var _gizmos_visible: bool = true  # Global visibility state
 
 #region Godot ######################################################################################
 func _init(undo_manager: EditorUndoRedoManager):
-    _undo = undo_manager
+	_undo = undo_manager
 
 
 #endregion
 
 #region Private #####################################################################################
 func _create_marker_gizmo(marker: Marker2D) -> Gizmo2D:
-    # Create a gizmo for a specific marker with forced visibility
-    var gizmo = Gizmo2D.new(marker, "position", "", Gizmo2D.GIZMO_POS, Gizmo2D.VISIBILITY_MODE_FORCE_SHOW)
-    _configure_gizmo(gizmo)
-    return gizmo
+	# Create a gizmo for a specific marker with forced visibility
+	var gizmo = Gizmo2D.new(marker, "position", "", Gizmo2D.GIZMO_POS, Gizmo2D.VISIBILITY_MODE_FORCE_SHOW)
+	_configure_gizmo(gizmo)
+	return gizmo
 
 
 func _configure_gizmo(gizmo: Gizmo2D) -> void:
-    # Apply theme settings
-    gizmo.set_theme(
-        PopochiuEditorConfig.get_editor_setting(_color_settings[PopochiuGizmoPlugin.MARKER_POS]),
-        PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_HANDLER_SIZE),
-        _font,
-        PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_FONT_SIZE)
-    )
+	# Apply theme settings
+	gizmo.set_theme(
+		PopochiuEditorConfig.get_editor_setting(_color_settings[PopochiuGizmoPlugin.MARKER_POS]),
+		PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_HANDLER_SIZE),
+		_font,
+		PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_FONT_SIZE)
+	)
 
-    # Apply properties
-    gizmo.show_outlines = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_OUTLINE)
-    gizmo.show_target_name = true  # Always show the marker's name
-    gizmo.show_position = true     # Always show the marker's position
-    gizmo.show_connector = false   # Never show the connector for markers
-    gizmo.visible = _gizmos_visible # Set visibility based on global state
+	# Apply properties
+	gizmo.show_outlines = PopochiuEditorConfig.get_editor_setting(PopochiuEditorConfig.GIZMOS_SHOW_OUTLINE)
+	gizmo.show_target_name = true  # Always show the marker's name
+	gizmo.show_position = true     # Always show the marker's position
+	gizmo.show_connector = false   # Never show the connector for markers
+	gizmo.visible = _gizmos_visible # Set visibility based on global state
 
-    # Additional marker-specific settings could be added here
+	# Additional marker-specific settings could be added here
 
 
 func _scan_for_markers(room: PopochiuRoom) -> void:
-    # Clear existing gizmos
-    _marker_gizmos.clear()
+	# Clear existing gizmos
+	_marker_gizmos.clear()
 
-    # Find the Markers node
-    var markers_container = _find_markers_container(room)
-    if not markers_container:
-        return
+	# Find the Markers node
+	var markers_container = _find_markers_container(room)
+	if not markers_container:
+		return
 
-    # Find all marker nodes under Markers
-    for child in markers_container.get_children():
-        if child is Marker2D:
-            _marker_gizmos[child] = _create_marker_gizmo(child)
+	# Find all marker nodes under Markers
+	for child in markers_container.get_children():
+		if child is Marker2D:
+			_marker_gizmos[child] = _create_marker_gizmo(child)
 
 
 func _find_markers_container(root: Node) -> Node:
-    # Find the "Markers" node in the scene
-    for child in root.get_children():
-        if child.name == "Markers":
-            return child
-    return null
+	# Find the "Markers" node in the scene
+	for child in root.get_children():
+		if child.name == "Markers":
+			return child
+	return null
 
 func _update_properties() -> void:
-    if _grabbed_gizmo and _grabbed_marker:
-        _grabbed_marker.set(
-            _grabbed_gizmo.target_property,
-            _grabbed_gizmo.get_position()
-        )
+	if _grabbed_gizmo and _grabbed_marker:
+		_grabbed_marker.set(
+			_grabbed_gizmo.target_property,
+			_grabbed_gizmo.get_position()
+		)
 
 
 #endregion
 
 #region Public #####################################################################################
 func initialize_gizmos(font: Font, color_settings: Dictionary) -> void:
-    _font = font
-    _color_settings = color_settings
-    _marker_gizmos.clear()
+	_font = font
+	_color_settings = color_settings
+	_marker_gizmos.clear()
 
 
 func handle_object(object: Object, edited_root: Node) -> bool:
-    # If we're not in a room, reset and return false
-    if not edited_root is PopochiuRoom:
-        reset()
-        return false
+	# If we're not in a room, reset and return false
+	if not edited_root is PopochiuRoom:
+		reset()
+		return false
 
-    # Find all markers in the scene
-    _current_room = edited_root
-    _scan_for_markers(edited_root)
-    return _marker_gizmos.size() > 0
+	# Find all markers in the scene
+	_current_room = edited_root
+	_scan_for_markers(edited_root)
+	return _marker_gizmos.size() > 0
 
 
 func draw_gizmos(viewport_control: Control) -> void:
-    # Draw all marker gizmos
-    for marker in _marker_gizmos:
-        # Check if the marker is available.
-        # This avoids errors when the user opens another scene, coming from a room
-        # with markers.
-        if not is_instance_valid(marker) or not marker.is_inside_tree():
-            continue
-        # Draw the gizmo
-        var gizmo = _marker_gizmos[marker]
-        if gizmo.visible:
-            gizmo.draw(viewport_control, marker.get(gizmo.target_property))
+	# Draw all marker gizmos
+	for marker in _marker_gizmos:
+		# Check if the marker is available.
+		# This avoids errors when the user opens another scene, coming from a room
+		# with markers.
+		if not is_instance_valid(marker) or not marker.is_inside_tree():
+			continue
+		# Draw the gizmo
+		var gizmo = _marker_gizmos[marker]
+		if gizmo.visible:
+			gizmo.draw(viewport_control, marker.get(gizmo.target_property))
 
 
 func try_grab_gizmo(event: InputEventMouseButton) -> bool:
-    if _marker_gizmos.is_empty():
-        return false
+	if _marker_gizmos.is_empty():
+		return false
 
-    # Check if the mouse click happened on any marker gizmo
-    for marker in _marker_gizmos:
-        var gizmo = _marker_gizmos[marker]
-        if gizmo.visible and gizmo.has_point(event.position):
-            _grabbed_gizmo = gizmo
-            _grabbed_marker = marker
+	# Check if the mouse click happened on any marker gizmo
+	for marker in _marker_gizmos:
+		var gizmo = _marker_gizmos[marker]
+		if gizmo.visible and gizmo.has_point(event.position):
+			_grabbed_gizmo = gizmo
+			_grabbed_marker = marker
 
-            # Hold the gizmo with the mouse
-            _grabbed_gizmo.grab(event.position)
-            _undo.create_action("Move marker gizmo")
-            _undo.add_undo_property(
-                marker,
-                _grabbed_gizmo.target_property,
-                marker.get(_grabbed_gizmo.target_property)
-            )
-            return true
+			# Hold the gizmo with the mouse
+			_grabbed_gizmo.grab(event.position)
+			_undo.create_action("Move marker gizmo")
+			_undo.add_undo_property(
+				marker,
+				_grabbed_gizmo.target_property,
+				marker.get(_grabbed_gizmo.target_property)
+			)
+			return true
 
-    return false
+	return false
 
 
 func release_gizmo() -> bool:
-    if not _grabbed_gizmo:
-        return false
+	if not _grabbed_gizmo:
+		return false
 
-    _grabbed_gizmo.release()
-    _undo.add_do_property(
-        _grabbed_marker,
-        _grabbed_gizmo.target_property,
-        _grabbed_marker.get(_grabbed_gizmo.target_property)
-    )
-    _undo.commit_action()
-    _grabbed_gizmo = null
-    _grabbed_marker = null
-    return true
+	_grabbed_gizmo.release()
+	_undo.add_do_property(
+		_grabbed_marker,
+		_grabbed_gizmo.target_property,
+		_grabbed_marker.get(_grabbed_gizmo.target_property)
+	)
+	_undo.commit_action()
+	_grabbed_gizmo = null
+	_grabbed_marker = null
+	return true
 
 
 func drag_gizmo(event: InputEventMouseMotion) -> bool:
-    if not _grabbed_gizmo:
-        return false
+	if not _grabbed_gizmo:
+		return false
 
-    # Drag the gizmo
-    _grabbed_gizmo.drag_to(event.position)
-    _update_properties()
-    return true
+	# Drag the gizmo
+	_grabbed_gizmo.drag_to(event.position)
+	_update_properties()
+	return true
 
 
 func cancel_dragging() -> bool:
-    if not _grabbed_gizmo:
-        return false
+	if not _grabbed_gizmo:
+		return false
 
-    # Cancel the action
-    _grabbed_gizmo.cancel()
-    _undo.commit_action()
-    _undo.get_history_undo_redo(_undo.get_object_history_id(_grabbed_marker)).undo()
-    _grabbed_gizmo = null
-    _grabbed_marker = null
-    return true
+	# Cancel the action
+	_grabbed_gizmo.cancel()
+	_undo.commit_action()
+	_undo.get_history_undo_redo(_undo.get_object_history_id(_grabbed_marker)).undo()
+	_grabbed_gizmo = null
+	_grabbed_marker = null
+	return true
 
 
 func has_active_gizmo() -> bool:
-    return _grabbed_gizmo != null
+	return _grabbed_gizmo != null
 
 
 # Update all existing gizmos
 func update_gizmo_settings() -> void:
-    for marker in _marker_gizmos:
-        _configure_gizmo(_marker_gizmos[marker])
+	for marker in _marker_gizmos:
+		_configure_gizmo(_marker_gizmos[marker])
 
 
 # Set visibility for all marker gizmos
 func set_gizmo_visibility(gizmo_id: int, visible: bool) -> void:
-    _gizmos_visible = visible
+	_gizmos_visible = visible
 
-    for marker in _marker_gizmos:
-        _marker_gizmos[marker].visible = visible
+	for marker in _marker_gizmos:
+		_marker_gizmos[marker].visible = visible
 
 
 # Refresh markers when scene changes
 func refresh_markers() -> void:
-    if _current_room:
-        _scan_for_markers(_current_room)
+	if _current_room:
+		_scan_for_markers(_current_room)
 
 
 # Clear all marker gizmos and reset internal state.
 # Called when changing scenes or explicitly resetting the manager.
 func reset() -> void:
-    _marker_gizmos.clear()
-    _current_room = null
-    _grabbed_gizmo = null
-    _grabbed_marker = null
+	_marker_gizmos.clear()
+	_current_room = null
+	_grabbed_gizmo = null
+	_grabbed_marker = null
 
 
 #endregion

--- a/addons/popochiu/editor/gizmos/gizmo_plugin.gd
+++ b/addons/popochiu/editor/gizmos/gizmo_plugin.gd
@@ -4,11 +4,11 @@ extends EditorPlugin
 
 # Gizmo type enums for external visibility mapping
 enum {
-    WALK_TO_POINT,
-    LOOK_AT_POINT,
-    BASELINE,
-    DIALOG_POS,
-    MARKER_POS
+	WALK_TO_POINT,
+	LOOK_AT_POINT,
+	BASELINE,
+	DIALOG_POS,
+	MARKER_POS
 }
 
 # Private vars
@@ -21,162 +21,173 @@ var _marker_manager: GizmoManagerMarker
 var _color_settings: Dictionary = {}
 var _font: Font
 
+
 #region Godot ######################################################################################
-
 func _enter_tree() -> void:
-    # TODO: remove the following 2 lines when the plugin is connected to the appropriate signal
-    # e.g. popochiu_ready
-    PopochiuEditorConfig.initialize_editor_settings()
-    PopochiuConfig.initialize_project_settings()
+	# TODO: remove the following 2 lines when the plugin is connected to the appropriate signal
+	# e.g. popochiu_ready
+	PopochiuEditorConfig.initialize_editor_settings()
+	PopochiuConfig.initialize_project_settings()
 
-    # Read theme settings
-    _init_theme_settings()
+	# Read theme settings
+	_init_theme_settings()
 
-    # Initialization of the plugin
-    _undo = get_undo_redo()
-    
-    # Initialize managers
-    _clickable_manager = GizmoManagerClickable.new(_undo)
-    _marker_manager = GizmoManagerMarker.new(_undo)
-    
-    # Setup gizmos in managers
-    _clickable_manager.initialize_gizmos(_font, _color_settings)
-    _marker_manager.initialize_gizmos(_font, _color_settings)
+	# Initialization of the plugin
+	_undo = get_undo_redo()
+	
+	# Initialize managers
+	_clickable_manager = GizmoManagerClickable.new(_undo)
+	_marker_manager = GizmoManagerMarker.new(_undo)
+	
+	# Setup gizmos in managers
+	_clickable_manager.initialize_gizmos(_font, _color_settings)
+	_marker_manager.initialize_gizmos(_font, _color_settings)
 
-    # Connect signals to update gizmos when editor settings or visibility change
-    EditorInterface.get_editor_settings().settings_changed.connect(_on_gizmo_settings_changed)
-    PopochiuEditorHelper.signal_bus.gizmo_visibility_changed.connect(_on_gizmo_visibility_changed)
+	# Connect signals to update gizmos when editor settings or visibility change
+	EditorInterface.get_editor_settings().settings_changed.connect(_on_gizmo_settings_changed)
+	PopochiuEditorHelper.signal_bus.gizmo_visibility_changed.connect(_on_gizmo_visibility_changed)
 
 #endregion
 
 #region Virtual ####################################################################################
-
 func _edit(object: Object) -> void:
-    # If the object is null or a remote object, this plugin should not kick in
-    if object == null or object.get_class() == "EditorDebuggerRemoteObject":
-        return
+	# If the object is null or a remote object, this plugin should not kick in
+	if object == null or object.get_class() == "EditorDebuggerRemoteObject":
+		return
 
-    # If the user isn't editing a Room or Character scene, no gizmos should be shown
-    if not (
-        PopochiuEditorHelper.is_editing_room() or
-        PopochiuEditorHelper.is_editing_character()
-    ):
-        # Clear all gizmos when not in a relevant scene
-        _marker_manager.reset()
-        _clickable_manager.reset()
-        return
+	# If the user isn't editing a Room or Character scene, no gizmos should be shown
+	if not (
+		PopochiuEditorHelper.is_editing_room() or
+		PopochiuEditorHelper.is_editing_character()
+	):
+		# Clear all gizmos when not in a relevant scene
+		_marker_manager.reset()
+		_clickable_manager.reset()
+		return
 
-    # Track if any managers are handling objects
-    var has_handled_objects = false
-    var edited_root = EditorInterface.get_edited_scene_root()
+	# Track if any managers are handling objects
+	var has_handled_objects = false
+	var edited_root = EditorInterface.get_edited_scene_root()
 
-    # Always call the marker manager with the edited root
-    # This ensures markers are shown in rooms and cleared in other scenes
-    has_handled_objects = _marker_manager.handle_object(edited_root, edited_root) or has_handled_objects
+	# Always call the marker manager with the edited root
+	# This ensures markers are shown in rooms and cleared in other scenes
+	has_handled_objects = (
+		_marker_manager.handle_object(edited_root, edited_root) or has_handled_objects
+	)
 
-    # Handle clickables with the currently selected object
-    has_handled_objects = _clickable_manager.handle_object(object, edited_root) or has_handled_objects
+	# Handle clickables with the currently selected object
+	has_handled_objects = (
+		_clickable_manager.handle_object(object, edited_root) or has_handled_objects
+	)
 
-    # If any manager is handling objects, connect to inspector signal
-    if has_handled_objects:
-        if not EditorInterface.get_inspector().property_edited.is_connected(_on_property_changed):
-            EditorInterface.get_inspector().property_edited.connect(_on_property_changed)
+	# If any manager is handling objects, connect to inspector signal
+	if has_handled_objects:
+		if not EditorInterface.get_inspector().property_edited.is_connected(_on_property_changed):
+			EditorInterface.get_inspector().property_edited.connect(_on_property_changed)
 
-    update_overlays()
+	update_overlays()
 
 
 func _forward_canvas_draw_over_viewport(viewport_control: Control) -> void:
-    # Only draw gizmos in Room or Character scenes.
-    # This is necessary to aviod errors when opening scenes that are not rooms or characters,
-    # coming from a room with markers! Godot calls this method still once before loading the
-    # new scene but it finds no markers to attach to.
-    if not (PopochiuEditorHelper.is_editing_room() or PopochiuEditorHelper.is_editing_character()):
-        return
+	# Only draw gizmos in Room or Character scenes.
+	# This is necessary to aviod errors when opening scenes that are not rooms or characters,
+	# coming from a room with markers! Godot calls this method still once before loading the
+	# new scene but it finds no markers to attach to.
+	if not (PopochiuEditorHelper.is_editing_room() or PopochiuEditorHelper.is_editing_character()):
+		return
 
-    _clickable_manager.draw_gizmos(viewport_control)
-    _marker_manager.draw_gizmos(viewport_control)
+	_clickable_manager.draw_gizmos(viewport_control)
+	_marker_manager.draw_gizmos(viewport_control)
 
 
 func _handles(object: Object) -> bool:
-    var edited_root = EditorInterface.get_edited_scene_root()
-    return \
-        edited_root is PopochiuCharacter or \
-        edited_root is PopochiuRoom or \
-        edited_root is PopochiuCharacter
+	var edited_root = EditorInterface.get_edited_scene_root()
+	return (
+		edited_root is PopochiuCharacter
+		or edited_root is PopochiuRoom
+		or edited_root is PopochiuCharacter
+	)
 
 
 func _forward_canvas_gui_input(event: InputEvent) -> bool:
-    # For left mouse buttons, try to grab or release, depending on state
-    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
-        # Grab
-        if not _clickable_manager.has_active_gizmo() and not _marker_manager.has_active_gizmo() and event.is_pressed():
-            if _clickable_manager.try_grab_gizmo(event) or _marker_manager.try_grab_gizmo(event):
-                update_overlays()
-                return true
-        # Release
-        elif (_clickable_manager.has_active_gizmo() or _marker_manager.has_active_gizmo()) and event.is_released():
-            if _clickable_manager.release_gizmo() or _marker_manager.release_gizmo():
-                update_overlays()
-                return true
+	# For left mouse buttons, try to grab or release, depending on state
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		# Grab
+		if (
+			not _clickable_manager.has_active_gizmo()
+			and not _marker_manager.has_active_gizmo()
+			and event.is_pressed()
+		):
+			if _clickable_manager.try_grab_gizmo(event) or _marker_manager.try_grab_gizmo(event):
+				update_overlays()
+				return true
+		# Release
+		elif (
+			(_clickable_manager.has_active_gizmo() or _marker_manager.has_active_gizmo())
+			and event.is_released()
+		):
+			if _clickable_manager.release_gizmo() or _marker_manager.release_gizmo():
+				update_overlays()
+				return true
 
-    # For mouse movement, drag the grabbed gizmo
-    if event is InputEventMouseMotion:
-        if _clickable_manager.drag_gizmo(event) or _marker_manager.drag_gizmo(event):
-            update_overlays()
-            return true
+	# For mouse movement, drag the grabbed gizmo
+	if event is InputEventMouseMotion:
+		if _clickable_manager.drag_gizmo(event) or _marker_manager.drag_gizmo(event):
+			update_overlays()
+			return true
 
-    # For ESC key or comparable events, cancel the dragging if in place
-    if event.is_action_pressed("ui_cancel"):
-        if _clickable_manager.cancel_dragging() or _marker_manager.cancel_dragging():
-            update_overlays()
-            return true
-    
-    # Nothing to handle outside the cases above
-    return false
+	# For ESC key or comparable events, cancel the dragging if in place
+	if event.is_action_pressed("ui_cancel"):
+		if _clickable_manager.cancel_dragging() or _marker_manager.cancel_dragging():
+			update_overlays()
+			return true
+	
+	# Nothing to handle outside the cases above
+	return false
 
 #endregion
 
 #region Private ####################################################################################
-
 func _init_theme_settings() -> void:
-    # Read color settings (done every time to allow for runtime changes)
-    _color_settings = {
-        WALK_TO_POINT: PopochiuEditorConfig.GIZMOS_WALK_TO_POINT_COLOR,
-        LOOK_AT_POINT: PopochiuEditorConfig.GIZMOS_LOOK_AT_POINT_COLOR,
-        BASELINE: PopochiuEditorConfig.GIZMOS_BASELINE_COLOR,
-        DIALOG_POS: PopochiuEditorConfig.GIZMOS_DIALOG_POS_COLOR,
-        MARKER_POS: PopochiuEditorConfig.GIZMOS_MARKER_POS_COLOR
-    }
-    # Set default font from editor
-    _font = EditorInterface.get_editor_theme().default_font
+	# Read color settings (done every time to allow for runtime changes)
+	_color_settings = {
+		WALK_TO_POINT: PopochiuEditorConfig.GIZMOS_WALK_TO_POINT_COLOR,
+		LOOK_AT_POINT: PopochiuEditorConfig.GIZMOS_LOOK_AT_POINT_COLOR,
+		BASELINE: PopochiuEditorConfig.GIZMOS_BASELINE_COLOR,
+		DIALOG_POS: PopochiuEditorConfig.GIZMOS_DIALOG_POS_COLOR,
+		MARKER_POS: PopochiuEditorConfig.GIZMOS_MARKER_POS_COLOR
+	}
+	# Set default font from editor
+	_font = EditorInterface.get_editor_theme().default_font
 
 
 func _on_property_changed(_property: String):
-    # Update gizmos that are currently visible on the scene
-    # to reflect the new property value
-    update_overlays()
+	# Update gizmos that are currently visible on the scene
+	# to reflect the new property value
+	update_overlays()
 
 
 func _on_gizmo_settings_changed() -> void:
-    # Update theme settings
-    _init_theme_settings()
+	# Update theme settings
+	_init_theme_settings()
 
-    # Update gizmos appearance based on the new settings
-    _clickable_manager.initialize_gizmos(_font, _color_settings)
-    _marker_manager.initialize_gizmos(_font, _color_settings)
-    
-    # Update gizmos in the viewport
-    update_overlays()
+	# Update gizmos appearance based on the new settings
+	_clickable_manager.initialize_gizmos(_font, _color_settings)
+	_marker_manager.initialize_gizmos(_font, _color_settings)
+	
+	# Update gizmos in the viewport
+	update_overlays()
 
 
 func _on_gizmo_visibility_changed(gizmo_id: int, visibility: bool):
-    # The visibility enum values match between plugin and clickable manager
-    if gizmo_id <= DIALOG_POS:
-        _clickable_manager.set_gizmo_visibility(gizmo_id, visibility)
-    # The MARKER_POS enum value is different between the two systems
-    elif gizmo_id == MARKER_POS:
-        _marker_manager.set_gizmo_visibility(0, visibility)
-    
-    update_overlays()
+	# The visibility enum values match between plugin and clickable manager
+	if gizmo_id <= DIALOG_POS:
+		_clickable_manager.set_gizmo_visibility(gizmo_id, visibility)
+	# The MARKER_POS enum value is different between the two systems
+	elif gizmo_id == MARKER_POS:
+		_marker_manager.set_gizmo_visibility(0, visibility)
+	
+	update_overlays()
+
 
 #endregion

--- a/addons/popochiu/editor/helpers/popochiu_signal_bus.gd
+++ b/addons/popochiu/editor/helpers/popochiu_signal_bus.gd
@@ -7,3 +7,5 @@ signal audio_cues_deleted(cue_file_paths: Array)
 signal main_object_added(type: int, name_to_add: String)
 signal gizmo_visibility_changed(gizmo: int, visible: bool)
 signal migrations_done
+signal scene_changed(scene_root: Node)
+signal scene_closed(filepath: String)

--- a/addons/popochiu/editor/main_dock/popochiu_dock.gd
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.gd
@@ -26,13 +26,17 @@ func _ready() -> void:
 	# Hide the GUI tab while we decide how it will work based on devs feedback
 	tab_container.set_tab_hidden(tab_gui.get_index(), true)
 	
-	# Connect to children's signals
+	# Connect to children signals
 	tab_container.tab_changed.connect(_on_tab_changed)
 	btn_setup.pressed.connect(open_setup)
 	btn_docs.pressed.connect(OS.shell_open.bind(PopochiuResources.DOCUMENTATION))
 	
 	# Connect to parent signals
 	get_tree().node_added.connect(_check_node)
+	
+	# Connect to global signals
+	PopochiuEditorHelper.signal_bus.scene_changed.connect(scene_changed)
+	PopochiuEditorHelper.signal_bus.scene_closed.connect(scene_closed)
 
 
 #endregion
@@ -62,6 +66,10 @@ func scene_changed(scene_root: Node) -> void:
 		# Open the Popochiu Main tab if the opened scene in the Editor2D is not a PopochiuRoom nor
 		# the GUI scene
 		tab_container.current_tab = 0
+	
+	# Fix #481: Select the root node of the created scene
+	EditorInterface.get_selection().clear()
+	EditorInterface.get_selection().add_node(scene_root)
 
 
 func scene_closed(filepath: String) -> void:

--- a/addons/popochiu/editor/main_dock/popochiu_dock.tscn
+++ b/addons/popochiu/editor/main_dock/popochiu_dock.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://bardo4kb80rvg"]
+[gd_scene format=3 uid="uid://bardo4kb80rvg"]
 
 [ext_resource type="PackedScene" uid="uid://bynwdds8o3tcx" path="res://addons/popochiu/editor/main_dock/tab_main/tab_main.tscn" id="2_oxyje"]
 [ext_resource type="Script" uid="uid://dxyf5fu3xp3x8" path="res://addons/popochiu/editor/main_dock/popochiu_dock.gd" id="7"]
@@ -6,19 +6,11 @@
 [ext_resource type="PackedScene" uid="uid://q1bjkxavt2ay" path="res://addons/popochiu/editor/main_dock/tab_room/tab_room.tscn" id="12"]
 [ext_resource type="PackedScene" uid="uid://bpj8jlet25coy" path="res://addons/popochiu/editor/main_dock/tab_audio/tab_audio.tscn" id="13"]
 
-[sub_resource type="Image" id="Image_4merx"]
-data = {
-"data": PackedByteArray(255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 42, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 93, 93, 41, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 92, 92, 0, 255, 92, 92, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 93, 93, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
+[sub_resource type="DPITexture" id="DPITexture_4merx"]
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#ff5d5d\" d=\"M2 1v8.586l1.293-1.293a1 1 0 0 1 1.414 0L7 10.587l2.293-2.293a1 1 0 0 1 1.414 0L13 10.586l1-1V6H9V1H2zm8 0v4h4zm-6 9.414-2 2V15h12v-2.586l-.293.293a1 1 0 0 1-1.414 0L10 10.414l-2.293 2.293a1 1 0 0 1-1.414 0L4 10.414z\"/></svg>
+"
 
-[sub_resource type="ImageTexture" id="ImageTexture_nv7qg"]
-image = SubResource("Image_4merx")
-
-[node name="Popochiu" type="Panel"]
+[node name="Popochiu" type="Panel" unique_id=875315221]
 clip_contents = true
 custom_minimum_size = Vector2(340, 0)
 anchors_preset = 15
@@ -28,73 +20,74 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("7")
 
-[node name="MarginContainer" type="MarginContainer" parent="."]
+[node name="MarginContainer" type="MarginContainer" parent="." unique_id=1621288520]
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=684063980]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TabContainer" type="TabContainer" parent="MarginContainer/VBoxContainer"]
+[node name="TabContainer" type="TabContainer" parent="MarginContainer/VBoxContainer" unique_id=713096778]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 current_tab = 0
+tab_3/hidden = true
 
-[node name="Main" parent="MarginContainer/VBoxContainer/TabContainer" instance=ExtResource("2_oxyje")]
+[node name="Main" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=190345305 instance=ExtResource("2_oxyje")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Room" parent="MarginContainer/VBoxContainer/TabContainer" instance=ExtResource("12")]
+[node name="Room" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=1648493662 instance=ExtResource("12")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 focus_mode = 2
 metadata/_tab_index = 1
 
-[node name="Audio" parent="MarginContainer/VBoxContainer/TabContainer" instance=ExtResource("13")]
+[node name="Audio" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=1429483997 instance=ExtResource("13")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 focus_mode = 2
 metadata/_tab_index = 2
 
-[node name="GUI" parent="MarginContainer/VBoxContainer/TabContainer" instance=ExtResource("10_82goo")]
+[node name="GUI" parent="MarginContainer/VBoxContainer/TabContainer" unique_id=1769093385 instance=ExtResource("10_82goo")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 metadata/_tab_index = 3
 
-[node name="FooterPanel" type="PanelContainer" parent="MarginContainer/VBoxContainer"]
+[node name="FooterPanel" type="PanelContainer" parent="MarginContainer/VBoxContainer" unique_id=169724065]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/FooterPanel"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/FooterPanel" unique_id=2025467407]
 layout_mode = 2
 size_flags_vertical = 3
 alignment = 2
 
-[node name="Version" type="Label" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
+[node name="Version" type="Label" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer" unique_id=1666728485]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-text = "v2.0.3"
+text = "v2.1"
 
-[node name="BtnSetup" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
+[node name="BtnSetup" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer" unique_id=1765033783]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Setup"
-icon = SubResource("ImageTexture_nv7qg")
+icon = SubResource("DPITexture_4merx")
 
-[node name="BtnDocs" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer"]
+[node name="BtnDocs" type="Button" parent="MarginContainer/VBoxContainer/FooterPanel/HBoxContainer" unique_id=103207771]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Opens wiki in web browser"
 text = "Documentation"
-icon = SubResource("ImageTexture_nv7qg")
+icon = SubResource("DPITexture_4merx")

--- a/addons/popochiu/editor/main_dock/tab_room/tab_room.tscn
+++ b/addons/popochiu/editor/main_dock/tab_room/tab_room.tscn
@@ -1,26 +1,38 @@
-[gd_scene load_steps=18 format=3 uid="uid://q1bjkxavt2ay"]
+[gd_scene format=3 uid="uid://q1bjkxavt2ay"]
 
 [ext_resource type="Script" uid="uid://dcxh7skiwv6yu" path="res://addons/popochiu/editor/main_dock/tab_room/tab_room.gd" id="1_dnc56"]
 [ext_resource type="PackedScene" uid="uid://b55ialbvpilxv" path="res://addons/popochiu/editor/main_dock/popochiu_group/popochiu_group.tscn" id="2"]
-[ext_resource type="Script" uid="uid://b2gk1jyvqxl06" path="res://addons/popochiu/editor/main_dock/popochiu_filter.gd" id="2_bv3t4"]
+[ext_resource type="Script" uid="uid://cqu68lla27ncc" path="res://addons/popochiu/editor/main_dock/popochiu_filter.gd" id="2_bv3t4"]
 [ext_resource type="Texture2D" uid="uid://bj4bxswex7nsl" path="res://addons/popochiu/icons/prop.png" id="3_rksqc"]
 [ext_resource type="Texture2D" uid="uid://jbdlyvx4gumd" path="res://addons/popochiu/icons/hotspot.png" id="4_6mx6c"]
 [ext_resource type="Texture2D" uid="uid://dvh13sj4uj4b2" path="res://addons/popochiu/icons/walkable_area.png" id="5_j6ot2"]
 [ext_resource type="Texture2D" uid="uid://cosxi1ulfp7rg" path="res://addons/popochiu/icons/region.png" id="6_2h2fq"]
-[ext_resource type="Texture2D" uid="uid://btdsnflrn3j6o" path="res://addons/popochiu/icons/marker.png" id="7_8ygji"]
+[ext_resource type="Texture2D" uid="uid://drktr8ywn0h0" path="res://addons/popochiu/icons/marker.png" id="7_8ygji"]
 [ext_resource type="Texture2D" uid="uid://mir6j58lju3l" path="res://addons/popochiu/icons/character.png" id="9_4yetu"]
 
-[sub_resource type="Image" id="Image_5vmuu"]
-data = {
-"data": PackedByteArray(255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 42, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 93, 93, 41, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 92, 92, 0, 255, 92, 92, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 93, 93, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
+[sub_resource type="DPITexture" id="DPITexture_4merx"]
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#ff5d5d\" d=\"M2 1v8.586l1.293-1.293a1 1 0 0 1 1.414 0L7 10.587l2.293-2.293a1 1 0 0 1 1.414 0L13 10.586l1-1V6H9V1H2zm8 0v4h4zm-6 9.414-2 2V15h12v-2.586l-.293.293a1 1 0 0 1-1.414 0L10 10.414l-2.293 2.293a1 1 0 0 1-1.414 0L4 10.414z\"/></svg>
+"
 
-[sub_resource type="ImageTexture" id="ImageTexture_54j7f"]
-image = SubResource("Image_5vmuu")
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5vmuu"]
+content_margin_left = 8.0
+content_margin_right = 8.0
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.6, 0.6, 0.6, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_54j7f"]
+content_margin_left = 8.0
+content_margin_right = 8.0
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.6, 0.6, 0.6, 1)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_yr4k2"]
 content_margin_left = 8.0
@@ -62,131 +74,111 @@ border_width_right = 2
 border_width_bottom = 2
 border_color = Color(0.6, 0.6, 0.6, 1)
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_44as0"]
-content_margin_left = 8.0
-content_margin_right = 8.0
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.6, 0.6, 0.6, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_doh7h"]
-content_margin_left = 8.0
-content_margin_right = 8.0
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.6, 0.6, 0.6, 1)
-
-[node name="TabRoom" type="VBoxContainer"]
+[node name="TabRoom" type="VBoxContainer" unique_id=2144242830]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1_dnc56")
 
-[node name="PopochiuFilter" type="LineEdit" parent="."]
+[node name="PopochiuFilter" type="LineEdit" parent="." unique_id=1989948859]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 placeholder_text = "Filter Popochiu objects"
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_54j7f")
+right_icon = SubResource("DPITexture_4merx")
 script = ExtResource("2_bv3t4")
 
-[node name="RoomName" type="Button" parent="."]
+[node name="RoomName" type="Button" parent="." unique_id=2145632860]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Room name"
 
-[node name="ToolButtons" type="HBoxContainer" parent="."]
+[node name="ToolButtons" type="HBoxContainer" parent="." unique_id=248797615]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 alignment = 1
 
-[node name="BtnScript" type="Button" parent="ToolButtons"]
+[node name="BtnScript" type="Button" parent="ToolButtons" unique_id=1198829440]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Script"
-icon = SubResource("ImageTexture_54j7f")
+icon = SubResource("DPITexture_4merx")
 
-[node name="BtnResource" type="Button" parent="ToolButtons"]
+[node name="BtnResource" type="Button" parent="ToolButtons" unique_id=699325195]
 unique_name_in_owner = true
 layout_mode = 2
 text = "State"
-icon = SubResource("ImageTexture_54j7f")
+icon = SubResource("DPITexture_4merx")
 
-[node name="BtnResourceScript" type="Button" parent="ToolButtons"]
+[node name="BtnResourceScript" type="Button" parent="ToolButtons" unique_id=452859524]
 unique_name_in_owner = true
 layout_mode = 2
 text = "State"
-icon = SubResource("ImageTexture_54j7f")
+icon = SubResource("DPITexture_4merx")
 
-[node name="RoomScrollContainer" type="ScrollContainer" parent="."]
+[node name="RoomScrollContainer" type="ScrollContainer" parent="." unique_id=1511607740]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="RoomScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="RoomScrollContainer" unique_id=1915755156]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="NoRoomInfo" type="Label" parent="RoomScrollContainer/VBoxContainer"]
+[node name="NoRoomInfo" type="Label" parent="RoomScrollContainer/VBoxContainer" unique_id=1298425333]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(312, 0)
 layout_mode = 2
 text = "Open a room in Main tab to see or create Props, Hotspots, Regions and Points."
 autowrap_mode = 3
 
-[node name="PropsGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="PropsGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=1518040899 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_yr4k2")
+theme_override_styles/panel = SubResource("StyleBoxFlat_5vmuu")
 icon = ExtResource("3_rksqc")
 title = "Props"
 create_text = "Create prop"
 
-[node name="HotspotsGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="HotspotsGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=467682011 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_d8y78")
+theme_override_styles/panel = SubResource("StyleBoxFlat_54j7f")
 icon = ExtResource("4_6mx6c")
 title = "Hotspots"
 create_text = "Create hotspot"
 
-[node name="WalkableAreasGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="WalkableAreasGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=1406337315 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_qmqo4")
+theme_override_styles/panel = SubResource("StyleBoxFlat_yr4k2")
 icon = ExtResource("5_j6ot2")
 title = "Walkable areas"
 create_text = "Create walkable area"
 
-[node name="RegionsGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="RegionsGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=1216351945 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_unj0l")
+theme_override_styles/panel = SubResource("StyleBoxFlat_d8y78")
 icon = ExtResource("6_2h2fq")
 title = "Regions"
 create_text = "Create regions"
 
-[node name="MarkersGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="MarkersGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=902834571 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_44as0")
+theme_override_styles/panel = SubResource("StyleBoxFlat_qmqo4")
 icon = ExtResource("7_8ygji")
 title = "Markers"
 create_text = "Create marker"
 
-[node name="CharactersGroup" parent="RoomScrollContainer/VBoxContainer" instance=ExtResource("2")]
+[node name="CharactersGroup" parent="RoomScrollContainer/VBoxContainer" unique_id=78528682 instance=ExtResource("2")]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_doh7h")
+theme_override_styles/panel = SubResource("StyleBoxFlat_unj0l")
 icon = ExtResource("9_4yetu")
 title = "Characters in room"
 can_create = false

--- a/addons/popochiu/editor/popups/create_object/create_character/create_character.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_character/create_character.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://q0mx8fu63d03"]
+[gd_scene format=3 uid="uid://q0mx8fu63d03"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_dtng2"]
-[ext_resource type="Script" uid="uid://djbywmdgvsccr" path="res://addons/popochiu/editor/popups/create_object/create_character/create_character.gd" id="2_8yo43"]
+[ext_resource type="Script" uid="uid://bwr1ocg4pqd3" path="res://addons/popochiu/editor/popups/create_object/create_character/create_character.gd" id="2_8yo43"]
 
-[node name="CreateCharacterConfirmation" instance=ExtResource("1_dtng2")]
+[node name="CreateCharacterConfirmation" unique_id=878122794 instance=ExtResource("1_dtng2")]
 script = ExtResource("2_8yo43")
 
 [node name="Label" parent="PanelContainer/VBoxContainer/InputContainer" index="0"]
@@ -12,15 +12,15 @@ text = "Character name:"
 [node name="Guide" parent="PanelContainer/VBoxContainer" index="3"]
 text = "Use a descriptive name in PascalCase (e.g. Glottis, MannyCalavera, HectorLeMans)."
 
-[node name="SetAsPCPanel" type="PanelContainer" parent="PanelContainer/VBoxContainer" index="4"]
+[node name="SetAsPCPanel" type="PanelContainer" parent="PanelContainer/VBoxContainer" index="4" unique_id=1165551114]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/SetAsPCPanel" index="0"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/SetAsPCPanel" index="0" unique_id=1811995556]
 layout_mode = 2
 
-[node name="RtlIsPC" type="RichTextLabel" parent="PanelContainer/VBoxContainer/SetAsPCPanel/HBoxContainer" index="0"]
+[node name="RtlIsPC" type="RichTextLabel" parent="PanelContainer/VBoxContainer/SetAsPCPanel/HBoxContainer" index="0" unique_id=632853728]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -31,6 +31,6 @@ text = "You don't have a Player-controlled Character ([b]PC[/b]) yet. Do you wan
 fit_content = true
 scroll_active = false
 
-[node name="BtnIsPC" type="CheckBox" parent="PanelContainer/VBoxContainer/SetAsPCPanel/HBoxContainer" index="1"]
+[node name="BtnIsPC" type="CheckBox" parent="PanelContainer/VBoxContainer/SetAsPCPanel/HBoxContainer" index="1" unique_id=2142942193]
 unique_name_in_owner = true
 layout_mode = 2

--- a/addons/popochiu/editor/popups/create_object/create_dialog/create_dialog.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_dialog/create_dialog.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://dlhcgfucwffgr"]
+[gd_scene format=3 uid="uid://dlhcgfucwffgr"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_i1dna"]
-[ext_resource type="Script" uid="uid://dy5xakbr2kdc8" path="res://addons/popochiu/editor/popups/create_object/create_dialog/create_dialog.gd" id="2_ep8bb"]
+[ext_resource type="Script" uid="uid://kqpjphewhq0m" path="res://addons/popochiu/editor/popups/create_object/create_dialog/create_dialog.gd" id="2_ep8bb"]
 
-[node name="CreateDialogConfirmation" instance=ExtResource("1_i1dna")]
+[node name="CreateDialogConfirmation" unique_id=2095638669 instance=ExtResource("1_i1dna")]
 script = ExtResource("2_ep8bb")
 
 [node name="Label" parent="PanelContainer/VBoxContainer/InputContainer" index="0"]

--- a/addons/popochiu/editor/popups/create_object/create_hotspot/create_hotspot.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_hotspot/create_hotspot.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://b7nvdcut38577"]
+[gd_scene format=3 uid="uid://b7nvdcut38577"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_feyc5"]
-[ext_resource type="Script" uid="uid://7mn1rswgpoyj" path="res://addons/popochiu/editor/popups/create_object/create_hotspot/create_hotspot.gd" id="2_hf5i2"]
+[ext_resource type="Script" uid="uid://c52jb8s6v7oql" path="res://addons/popochiu/editor/popups/create_object/create_hotspot/create_hotspot.gd" id="2_hf5i2"]
 
-[node name="CreateHotspotConfirmation" instance=ExtResource("1_feyc5")]
+[node name="CreateHotspotConfirmation" unique_id=1504862508 instance=ExtResource("1_feyc5")]
 script = ExtResource("2_hf5i2")
 title = "Create PopochiuHotspot"
 

--- a/addons/popochiu/editor/popups/create_object/create_inventory_item/create_inventory_item.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_inventory_item/create_inventory_item.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://dl6pj0tylid8w"]
+[gd_scene format=3 uid="uid://dl6pj0tylid8w"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_rtecw"]
-[ext_resource type="Script" uid="uid://c7muofu88y01q" path="res://addons/popochiu/editor/popups/create_object/create_inventory_item/create_inventory_item.gd" id="2_3sytb"]
+[ext_resource type="Script" uid="uid://d0qlmhic6sm3d" path="res://addons/popochiu/editor/popups/create_object/create_inventory_item/create_inventory_item.gd" id="2_3sytb"]
 
-[node name="CreateInventoryItemConfirmation" instance=ExtResource("1_rtecw")]
+[node name="CreateInventoryItemConfirmation" unique_id=1871040477 instance=ExtResource("1_rtecw")]
 script = ExtResource("2_3sytb")
 title = "Create PopochiuInventoryItem"
 

--- a/addons/popochiu/editor/popups/create_object/create_object.gd
+++ b/addons/popochiu/editor/popups/create_object/create_object.gd
@@ -68,7 +68,11 @@ func create() -> void:
 	var created_object := await _create()
 	if not created_object or not is_instance_valid(created_object):
 		return
-	await PopochiuEditorHelper.filesystem_scanned()
+	
+	# Fix #481: Scan the filesystem directly instead of using the PopochiuEditorHelper function
+	# because it was being cancelled due to a script reload.
+	EditorInterface.get_resource_filesystem().scan.call_deferred()
+	await EditorInterface.get_resource_filesystem().filesystem_changed
 	
 	# Open the scene in the editor and select the file in the FileSystem dock ----------------------
 	if created_object is Node:

--- a/addons/popochiu/editor/popups/create_object/create_prop/create_prop.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_prop/create_prop.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://cpqg77rjfaa0l"]
+[gd_scene format=3 uid="uid://cpqg77rjfaa0l"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_l6xki"]
-[ext_resource type="Script" uid="uid://crlrkb1qsuvic" path="res://addons/popochiu/editor/popups/create_object/create_prop/create_prop.gd" id="2_c5stu"]
+[ext_resource type="Script" uid="uid://c1lm3vfu2f2gc" path="res://addons/popochiu/editor/popups/create_object/create_prop/create_prop.gd" id="2_c5stu"]
 
-[node name="CreatePropConfirmation" instance=ExtResource("1_l6xki")]
+[node name="CreatePropConfirmation" unique_id=432449066 instance=ExtResource("1_l6xki")]
 size_flags_horizontal = 3
 size_flags_vertical = 3
 script = ExtResource("2_c5stu")
@@ -12,14 +12,14 @@ title = "Create PopochiuProp"
 [node name="Label" parent="PanelContainer/VBoxContainer/InputContainer" index="0"]
 text = "Prop name:"
 
-[node name="InteractionContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer" index="1"]
+[node name="InteractionContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer" index="1" unique_id=636431004]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/InteractionContainer" index="0"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/InteractionContainer" index="0" unique_id=120031703]
 layout_mode = 2
 text = "Will this prop have interaction?"
 
-[node name="InteractionCheckbox" type="CheckBox" parent="PanelContainer/VBoxContainer/InteractionContainer" index="1"]
+[node name="InteractionCheckbox" type="CheckBox" parent="PanelContainer/VBoxContainer/InteractionContainer" index="1" unique_id=827010315]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3

--- a/addons/popochiu/editor/popups/create_object/create_region/create_region.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_region/create_region.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://crtkojrvhklpp"]
+[gd_scene format=3 uid="uid://crtkojrvhklpp"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_haco6"]
-[ext_resource type="Script" uid="uid://2d82s1i0qj6p" path="res://addons/popochiu/editor/popups/create_object/create_region/create_region.gd" id="2_ft6um"]
+[ext_resource type="Script" uid="uid://dwpbn1s7yr066" path="res://addons/popochiu/editor/popups/create_object/create_region/create_region.gd" id="2_ft6um"]
 
-[node name="CreateRegionConfirmation" instance=ExtResource("1_haco6")]
+[node name="CreateRegionConfirmation" unique_id=1279476653 instance=ExtResource("1_haco6")]
 script = ExtResource("2_ft6um")
 
 [node name="Label" parent="PanelContainer/VBoxContainer/InputContainer" index="0"]

--- a/addons/popochiu/editor/popups/create_object/create_room_object.gd
+++ b/addons/popochiu/editor/popups/create_object/create_room_object.gd
@@ -27,7 +27,11 @@ func create() -> void:
 	var created_node: Node = await _create()
 	if not created_node or not is_instance_valid(created_node):
 		return
-	await PopochiuEditorHelper.filesystem_scanned()
+	
+	# Fix #481: Scan the filesystem directly instead of using the PopochiuEditorHelper function
+	# because it was being cancelled due to a script reload.
+	EditorInterface.get_resource_filesystem().scan.call_deferred()
+	await EditorInterface.get_resource_filesystem().filesystem_changed
 	
 	# Select the node in the Scene tree and its file in the FileSystem dock ------------------------
 	EditorInterface.edit_node(created_node)

--- a/addons/popochiu/editor/popups/create_object/create_walkable_area/create_walkable_area.tscn
+++ b/addons/popochiu/editor/popups/create_object/create_walkable_area/create_walkable_area.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=3 format=3 uid="uid://ya4nebuu2575"]
+[gd_scene format=3 uid="uid://ya4nebuu2575"]
 
 [ext_resource type="PackedScene" uid="uid://c1pfl2gwjjot5" path="res://addons/popochiu/editor/popups/create_object/create_object.tscn" id="1_4gtmy"]
-[ext_resource type="Script" uid="uid://3qw50bnjw7hh" path="res://addons/popochiu/editor/popups/create_object/create_walkable_area/create_walkable_area.gd" id="2_ey5rs"]
+[ext_resource type="Script" uid="uid://drh1hcqldjjk0" path="res://addons/popochiu/editor/popups/create_object/create_walkable_area/create_walkable_area.gd" id="2_ey5rs"]
 
-[node name="CreateWalkableAreaConfirmation" instance=ExtResource("1_4gtmy")]
+[node name="CreateWalkableAreaConfirmation" unique_id=726139016 instance=ExtResource("1_4gtmy")]
 script = ExtResource("2_ey5rs")
 title = "Create PopochiuWalkableArea"
 

--- a/addons/popochiu/popochiu_plugin.gd
+++ b/addons/popochiu/popochiu_plugin.gd
@@ -176,8 +176,8 @@ func _on_dock_ready() -> void:
 	# Fill the dock with Rooms, Characters, Inventory items, Dialogs and AudioCues
 	dock.grab_focus()
 	
-	scene_changed.connect(dock.scene_changed)
-	scene_closed.connect(dock.scene_closed)
+	scene_changed.connect(_on_scene_changed)
+	scene_closed.connect(_on_scene_closed)
 	
 	if EditorInterface.get_edited_scene_root():
 		dock.scene_changed(EditorInterface.get_edited_scene_root())
@@ -197,6 +197,14 @@ func _on_dock_ready() -> void:
 
 	if not EditorInterface.is_plugin_enabled("popochiu/editor/importers"):
 		EditorInterface.set_plugin_enabled("popochiu/editor/importers", true)
+
+
+func _on_scene_changed(scene_root: Node) -> void:
+	PopochiuEditorHelper.signal_bus.scene_changed.emit(scene_root)
+
+
+func _on_scene_closed(filepath: String) -> void:
+	PopochiuEditorHelper.signal_bus.scene_closed.emit(filepath)
 
 
 #endregion

--- a/project.godot
+++ b/project.godot
@@ -22,14 +22,14 @@ config/windows_native_icon="res://popochiu.ico"
 
 [autoload]
 
-Globals="*uid://3x23xlj4sq3l"
+Globals="*uid://clvdqdj1ydbx"
 Cursor="*uid://c2pqh7ajiuiy0"
 E="*uid://rda8wggldt5o"
-R="*uid://c3jmnc5qhwfa8"
-C="*uid://bann24gq81gl6"
-I="*uid://dvdrt6f5bdf5y"
-D="*uid://dx6ntre8k12k4"
-A="*uid://fd2602n67yny"
+R="*uid://dvqbxoo1d6oqb"
+C="*uid://dycs4s58gcp5k"
+I="*uid://cct7lwe3t451x"
+D="*uid://d13cbtlhv7wn2"
+A="*uid://02ac7qaouswy"
 G="*uid://blk6nfpfiqrd2"
 T="*uid://30lm6k5s368s"
 


### PR DESCRIPTION
- Fix #481 : Scan the filesystem after creating objects with custom logic instead of using `PopochiuEditorHelper.filesystem_scanned()` because it was failing due to a script reload.
- Fix #482 : Exit polygon edition when selecting a node in the _Scene_ dock or when changing to another scene or closing the current one.