### PR TITLE
Add 'hide_in_inventory' property to Inventory items. 

### DIFF
--- a/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
@@ -115,6 +115,9 @@ func _on_gui_unblocked() -> void:
 
 
 func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
+	if item.hide_in_inventory:
+		PopochiuUtils.i.item_add_done.emit(item)
+		return
 	box.add_child(item)
 	
 	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH

--- a/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
@@ -156,6 +156,9 @@ func _on_down_pressed() -> void:
 
 
 func _add_item(item: PopochiuInventoryItem, _animate := true) -> void:
+	if item.hide_in_inventory:
+		PopochiuUtils.i.item_add_done.emit(item)
+		return
 	var slot := box.get_child(PopochiuUtils.i.items.size() - 1)
 	slot.name = "[%s]" % item.script_name
 	slot.add_child(item)

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
@@ -155,6 +155,9 @@ func _on_tween_finished() -> void:
 
 
 func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
+	if item.hide_in_inventory:
+		PopochiuUtils.i.item_add_done.emit(item)
+		return
 	box.add_child(item)
 	
 	item.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -21,8 +21,9 @@ signal unselected
 @export var description := "" : get = get_description
 ## The cursor to use when the mouse hovers the object.
 @export var cursor: CURSOR.Type = CURSOR.Type.USE
-
-
+## Whether this item should be hidden in the inventory GUI. This is useful for virtual items that are not meant to be collected but still need to be 
+## (.e.g. a "Permission" virtual item that a Character gives the player and allows them to access certain areas).
+@export var hide_in_inventory := false
 ## Whether this item is actually inside the inventory GUI.
 var in_inventory := false : set = set_in_inventory
 ## Whether this item has ever been in the inventory. Once true, it stays true.


### PR DESCRIPTION
This allows Inventory items to not be shown in the Inventory GUI, but all other inventory functions remain.

- Adds a "hide_in_inventory" property to Inventory items. 
- Updates the GUI templates' `_add_item` method to skip the process if true.


**Referencing:**
#485 


**Sample Use cases:**

- Avoid wasting screen space with redundant items.     (i.e. Collecting pages for a notebook. )
- Linking props to a "virtual flag".    (i.e. The player uses a axe to remove a door.  The "door" prop can be linked to a hidden "DoorRemoved" item)