### PR TITLE
Closes #432: Provides engine API to override character walk speed

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -106,8 +106,10 @@ const STANDARD_TALK_ANIMATION = "talk"
 ## You can use this to define which [Texture] to use as avatar for the character when it speaks
 ## using a specific emotion.
 @export var avatars := []: set = set_avatars
-## The speed at which the character will move in pixels per frame.
-@export var walk_speed := 200.0
+## The speed at which the character will move in pixels per frame.[br]
+## Values must be strictly greater than [code]0[/code]. Assigning [code]0[/code] or a negative
+## value will be clamped to [code]1.0[/code] and an error will be logged.
+@export var walk_speed := 200.0: set = set_walk_speed
 ## Whether the character can or not move.
 @export var can_move := true
 ## Whether the character ignores or not walkable areas. If [code]true[/code], the character will move
@@ -149,9 +151,12 @@ var anim_suffix := EMPTY_STRING
 var emotion := EMPTY_STRING
 ##
 var scaling_region: Dictionary = {}
-## Stores the default walk speed defined in [member walk_speed]. Used by [PopochiuRoom] when scaling
-## the character if it is inside a [PopochiuRegion] that modifies the scale.
-var default_walk_speed := 0
+## A temporary walk speed override. When strictly greater than [code]0[/code], replaces
+## [member walk_speed] as the base speed for movement, while perspective scaling from
+## [PopochiuRegion]s is still applied on top.[br]
+## Call [method reset_walk_speed] (or set to [code]0.0[/code]) to deactivate the override.[br]
+## Negative values are rejected and clamped to [code]0.0[/code] (no override) with a warning.
+var walk_speed_override: float = 0.0: set = set_walk_speed_override
 ## Stores the default scale. Used by [PopochiuRoom] when scaling the character if it is inside a
 ## [PopochiuRegion] that modifies the scale.
 var default_scale := Vector2.ONE
@@ -171,6 +176,10 @@ var is_visible_in_room: bool: get = get_is_visible_in_room
 ## Returns the current animation being played. Read-only access to [member _current_animation].
 ## This property cannot be set from outside the character implementation.
 var current_animation: String: get = get_current_animation
+## The effective walk speed for the current frame. Combines [member walk_speed] (or
+## [member walk_speed_override] if active) with the perspective scale factor from the current
+## [PopochiuRegion]. Read-only.
+var current_walk_speed: float: get = get_current_walk_speed
 ## Opacity of the character. Range: [code]0.0[/code] (fully transparent) to [code]1.0[/code] (fully opaque).
 ## Setting this value will modulate the alpha channel of the [b]$Sprite2D[/b] child.
 @export_range(0.0, 1.0) var alpha: float = 1.0: set = set_alpha
@@ -223,6 +232,9 @@ var _current_faced_character: PopochiuCharacter = null
 # Tracks the last position where position_updated signal was emitted.
 # Used to throttle signal emissions and only emit when position actually changes.
 var _last_emitted_position: Vector2 = Vector2.INF
+# Perspective scale factor from the current scaling region. Updated by update_scale().
+# 1.0 outside any region.
+var _walk_scale_factor: float = 1.0
 
 @onready var interaction_polygon_node: CollisionPolygon2D = $InteractionPolygon
 @onready var scaling_polygon: CollisionPolygon2D = $ScalingPolygon
@@ -233,7 +245,6 @@ var _last_emitted_position: Vector2 = Vector2.INF
 func _ready():
 	super()
 
-	default_walk_speed = walk_speed
 	default_scale = Vector2(scale)
 
 	if Engine.is_editor_hint():
@@ -301,7 +312,7 @@ func _ready():
 func _physics_process(delta: float) -> void:
 	if _navigation_path.is_empty(): return
 
-	var walk_distance: float = walk_speed * delta
+	var walk_distance: float = current_walk_speed * delta
 	_move_along_path(walk_distance)
 
 
@@ -1159,6 +1170,20 @@ func get_actual_dialog_pos() -> Vector2:
 	return dialog_pos + dialog_pos_offset
 
 
+## Resets the walk speed override to [code]0.0[/code] (inactive), making the character move at
+## its normal [member walk_speed] again.
+func reset_walk_speed() -> void:
+	walk_speed_override = 0.0
+
+
+## Resets the walk speed override to [code]0.0[/code] (inactive), making the character move at
+## its normal [member walk_speed] again.[br]
+##
+## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
+func queue_reset_walk_speed() -> Callable:
+	return func(): reset_walk_speed()
+
+
 ## Resets the dialog position offset to Vector2.ZERO.
 func reset_dialog_pos_offset() -> void:
 	dialog_pos_offset = Vector2.ZERO
@@ -1254,10 +1279,10 @@ func update_scale():
 		scale.y = [
 			[scale_for_position, scaling_region.scale_min].max(), scaling_region.scale_max
 		].min()
-		walk_speed = default_walk_speed / default_scale.x * scale_for_position
+		_walk_scale_factor = scale_for_position / default_scale.x
 	else:
 		scale = default_scale
-		walk_speed = default_walk_speed
+		_walk_scale_factor = 1.0
 
 
 ## Resets the animation prefix.
@@ -1269,6 +1294,30 @@ func reset_animation_prefix() -> void:
 #endregion
 
 #region SetGet #####################################################################################
+func set_walk_speed(value: float) -> void:
+	if value <= 0.0:
+		PopochiuUtils.print_error(
+			"walk_speed must be greater than 0. The value %s is invalid. Clamping to 1.0." % value
+		)
+		walk_speed = 1.0
+	else:
+		walk_speed = value
+
+
+func set_walk_speed_override(value: float) -> void:
+	if value < 0.0:
+		PopochiuUtils.print_warning(
+			"walk_speed_override cannot be negative. Clamping to 0.0 (override inactive)."
+		)
+		walk_speed_override = 0.0
+	else:
+		walk_speed_override = value
+
+
+func get_current_walk_speed() -> float:
+	return (walk_speed_override if walk_speed_override > 0.0 else walk_speed) * _walk_scale_factor
+
+
 func set_alpha(value: float) -> void:
 	alpha = clampf(value, 0.0, 1.0)
 	# Modulate the Sprite2D's alpha to control visibility

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -242,7 +242,7 @@ var _walk_scale_factor: float = 1.0
 
 
 #region Godot ######################################################################################
-func _ready():
+func _ready() -> void:
 	super()
 
 	default_scale = Vector2(scale)
@@ -349,8 +349,8 @@ func _play_idle() -> void:
 ## the base functionality.
 func _play_walk(target_pos: Vector2) -> void:
 	# Set the default parameters for play_animation()
-	var animation_label = walk_animation
-	var animation_fallback = idle_animation
+	var animation_label := walk_animation
+	var animation_fallback := idle_animation
 
 	play_animation(animation_label, animation_fallback)
 
@@ -878,7 +878,7 @@ func queue_play_animation(
 
 ## Plays the [param animation_label] animation, falling back to [param animation_fallback]
 ## if not found.
-func play_animation(animation_label: String, animation_fallback := ""):
+func play_animation(animation_label: String, animation_fallback := "") -> void:
 	# Use idle_animation as default fallback if none provided
 	if animation_fallback.is_empty():
 		animation_fallback = idle_animation
@@ -920,12 +920,12 @@ func play_animation(animation_label: String, animation_fallback := ""):
 ## Stops the current looping animation (except idle) after its current loop finishes.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_stop_animation():
+func queue_stop_animation() -> Callable:
 	return func(): await stop_animation()
 
 
 ## Stops the current looping animation (except idle) after its current loop finishes.
-func stop_animation():
+func stop_animation() -> void:
 	# If the animation is not looping or is an idle one, do nothing
 	if (
 		animation_player.get_animation(
@@ -949,36 +949,36 @@ func stop_animation():
 ## Immediately stops the current animation and switches to idle.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_halt_animation():
+func queue_halt_animation() -> Callable:
 	return func(): halt_animation()
 
 
 ## Immediately stops the current animation and switches to idle.
-func halt_animation():
+func halt_animation() -> void:
 	_play_idle()
 
 
 ## Pauses the current animation.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_pause_animation():
+func queue_pause_animation() -> Callable:
 	return func(): pause_animation()
 
 
 ## Pauses the current animation.
-func pause_animation():
+func pause_animation() -> void:
 	animation_player.pause()
 
 
 ## Resumes the paused animation.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_resume_animation():
+func queue_resume_animation() -> Callable:
 	return func(): resume_animation()
 
 
 ## Resumes the paused animation.
-func resume_animation():
+func resume_animation() -> void:
 	animation_player.play()
 
 
@@ -1084,7 +1084,7 @@ func fade_to(
 
 ## Makes the character look in the direction of [param destination]. The result is one of the values
 ## defined by [enum Looking].
-func face_direction(destination: Vector2):
+func face_direction(destination: Vector2) -> void:
 	# Determine the direction the character is facing.
 	# We cannot use the face_* functions because they reset the state to IDLE.
 	# Get the angle of the vector from the origin to the destination as a number between
@@ -1314,6 +1314,8 @@ func set_walk_speed_override(value: float) -> void:
 		walk_speed_override = value
 
 
+## Returns the effective walk speed for the current frame, combining [member walk_speed]
+## (or [member walk_speed_override] if active) with the current perspective scale factor.
 func get_current_walk_speed() -> float:
 	return (walk_speed_override if walk_speed_override > 0.0 else walk_speed) * _walk_scale_factor
 
@@ -1575,7 +1577,7 @@ func _get_vo_cue(emotion := EMPTY_STRING) -> String:
 	return EMPTY_STRING
 
 
-func _get_valid_oriented_animation(animation_label):
+func _get_valid_oriented_animation(animation_label: String) -> String:
 	# Generate prioritized list of animation names to try
 	var prioritized_names = _get_prioritized_animation_names(animation_label)
 

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -132,10 +132,15 @@ func _check_scaling(
 		return
 	
 	var character: PopochiuCharacter = area
-	# Track character entry/exit across all shapes
+	# Track character entry/exit (via the ScalingPolygon shape specifically).
+	# We do NOT check for all shapes here because since the guard above already confirmed the
+	# ScalingPolygon is the shape that fired, its exit is the definitive signal to stop scaling.
+	# WORKAROUND for #505 waiting for a proper solution:
+	# Removed the check for all shapes (with get_overlapping_areas) or some characters
+	# would not reset the character's scale and cause it to be stuck with the wrong one.
 	if entered:
 		_active_characters[character.script_name] = area
-	elif not character in get_overlapping_areas():
+	else:
 		_active_characters.erase(character.script_name)
 		_remove_character_scaling_region(character)
 		return

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -13,17 +13,17 @@ extends Area2D
 ## Can be used to show the name of the area to players.
 @export var description := ""
 ## Whether the region is or not enabled.
-@export var enabled := true : set = _set_enabled
+@export var enabled := true: set = _set_enabled
 ## The [Color] to apply to the character that enters this region.
 @export var tint := Color.WHITE
 ## Whether the region will scale the character while it moves through it.
-@export var scaling :bool = false
+@export var scaling: bool = false
 ## The scale to apply to the character inside the region when it moves to the top ([code]y[/code])
 ## of it.
-@export var scale_top :float = 1.0
+@export var scale_top: float = 1.0
 ## The scale to apply to the character inside the region when it moves to the bottom
 ## ([code]y[/code]) of it.
-@export var scale_bottom :float = 1.0
+@export var scale_bottom: float = 1.0
 ## Stores the vertices to assign to the [b]InteractionPolygon[/b] child during runtime. This is used
 ## by [PopochiuRoom] to store the info in its [code].tscn[/code].
 @export var interaction_polygon := PackedVector2Array()
@@ -123,7 +123,7 @@ func _check_area(area: Area2D, entered: bool) -> void:
 
 func _check_scaling(
 	area_rid: RID, area: Area2D, area_shape_index: int, local_shape_index: int, entered: bool
-):
+) -> void:
 	if not is_instance_valid(area) or not (
 		area is PopochiuCharacter
 		and area.get("scaling_polygon")
@@ -151,7 +151,7 @@ func _check_scaling(
 
 
 func _update_character_scaling_region(chr: PopochiuCharacter) -> void:
-	var polygon_y_array := []
+	var polygon_y_array: Array[float] = []
 	for x: Vector2 in interaction_polygon_node.get_polygon():
 		polygon_y_array.append(x.y)
 	


### PR DESCRIPTION
Working on that I found some weak spots in the implementation and decided to harden it a bit. One is #505 for which I provided a fix in a specific commit. The other is part of the changes and I'll describe it below.

### Problem

`walk_speed` was playing two roles at once: inspector-configured baseline *and* runtime-scaled effective speed. `update_scale()` was overwriting it every frame whenever a character moved through a scaling region, making it impossible to safely read or override the speed from game scripts. Any value set at runtime would be silently stomped.

### Solution

I separated the concerns cleanly:

- **`walk_speed`** is now a pure inspector property holding the developer's intended baseline. The engine never writes to it at runtime.
- **`_walk_scale_factor`** (private) stores the current perspective scale multiplier, updated by `update_scale()` when the character is inside a `PopochiuRegion`. Defaults to `1.0`.
- **`walk_speed_override`** (public) is a temporary, script-driven speed adjustment. When active (> 0), it replaces `walk_speed` as the base, while `_walk_scale_factor` is still applied on top,  so the override respects game-world perspective.
- **`current_walk_speed`** (public, read-only computed property) is the single source of truth for effective movement speed: `(walk_speed_override if active else walk_speed) * _walk_scale_factor`.
- **`default_walk_speed`** is removed. It was only needed to undo the mutation of `walk_speed`, which no longer happens.

Both `walk_speed` and `walk_speed_override` validate their input: non-positive `walk_speed` is clamped to `1.0` with an error; negative `walk_speed_override` is clamped to `0.0` with a warning.

### Breaking change

`default_walk_speed` is removed. Any game script reading it should be updated to read `walk_speed` directly.

### New public API

- `walk_speed_override: float`: set to override movement speed temporarily; `0.0` = inactive
- `current_walk_speed: float`: read-only; the actual speed used each frame
- `reset_walk_speed()`: convenience method to clear the override (`walk_speed_override = 0.0`)
- `queue_reset_walk_speed()`: queue-chain variant