### PR TITLE
Closes #349 by providing stackable inventory items

### DIFF
--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -58,6 +58,10 @@ signal inventory_shown
 ## Emitted when the inventory is requested to hide. [param use_anim] indicates whether the GUI
 ## should use an animation.
 signal inventory_hide_requested(use_anim: bool)
+## Emitted when the quantity of [param item] changes without the item being added to or removed
+## from the inventory (i.e., when stacking or partially removing). [param new_quantity] is the
+## updated count.
+signal item_quantity_updated(item: PopochiuInventoryItem, new_quantity: int)
 
 ## Provides access to the inventory item that is currently selected.
 var active: PopochiuInventoryItem : set = set_active
@@ -91,9 +95,17 @@ func clean_inventory(in_bg := false) -> void:
 		var pii: PopochiuInventoryItem = _item_instances[instance]
 		
 		if not pii.in_inventory: continue
-		if not in_bg: await pii.discard()
 		
-		pii.remove(!in_bg)
+		if in_bg:
+			# refs #349: In background mode, reset quantity_owned directly to avoid signal
+			# emissions and GUI awaits that are not meaningful without a visible inventory.
+			pii.quantity_owned = 0
+		else:
+			# refs #349: Only call discard() here: the old code called both discard() and
+			# remove() separately, which caused item_removed to be emitted twice per item
+			# (once from inside discard() -> remove(), and once from the extra remove() call
+			# after discard()). discard() already calls remove() internally.
+			await pii.discard()
 
 
 ## Shows the inventory for [param time] seconds.
@@ -196,6 +208,13 @@ func is_full() -> bool:
 ## Deselects the [member active] item.
 func deselect_active() -> void:
 	active = null
+
+
+## Returns the number of [param item_name] currently owned by the player.
+## Returns [code]0[/code] if the item is not in the inventory.
+func get_item_quantity(item_name: String) -> int:
+	var i: PopochiuInventoryItem = get_item_instance(item_name)
+	return i.quantity_owned if is_instance_valid(i) else 0
 
 
 #endregion

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -31,14 +31,12 @@ extends Node
 ## ])
 ## [/codeblock]
 
-## Emitted when [param item] is added to the inventory. [param animate] may be used by the GUI
-## to animate the item entering the inventory.
-signal item_added(item: PopochiuInventoryItem, animate: bool)
+## Emitted when [param item] is added to the inventory.
+signal item_added(item: PopochiuInventoryItem)
 ## Emitted when the [param item] has finished entering the inventory (GUI animation completed).
 signal item_add_done(item: PopochiuInventoryItem)
-## Emitted when [param item] is removed from the inventory. [param animate] may be used by the
-## GUI to animate the item leaving the inventory.
-signal item_removed(item: PopochiuInventoryItem, animate: bool)
+## Emitted when [param item] is removed from the inventory.
+signal item_removed(item: PopochiuInventoryItem)
 ## Emitted when the [param item] has finished leaving the inventory (GUI animation completed).
 signal item_remove_done(item: PopochiuInventoryItem)
 ## Emitted when [param item] is replaced in the inventory by [param new_item]. Useful for
@@ -67,6 +65,9 @@ signal item_quantity_updated(item: PopochiuInventoryItem, new_quantity: int)
 var active: PopochiuInventoryItem : set = set_active
 ## Provides access to the inventory item that was clicked.
 var clicked: PopochiuInventoryItem
+## When [code]true[/code], the inventory is being restored from a save file. GUI components
+## should skip entrance/exit animations during restore.
+var is_restoring := false
 # ---- Used for saving/loading the game ------------------------------------------------------------
 ## [Array] containing instances of the currently held [PopochiuInventoryItem]s.
 var items := []
@@ -87,25 +88,21 @@ func _init() -> void:
 
 #region Public #####################################################################################
 ## Removes all items currently in the inventory. If [param in_bg] is [code]true[/code], items are
-## removed in background without calling [method PopochiuInventoryItem.discard].
+## removed silently without GUI lifecycle (useful during scene transitions).
 func clean_inventory(in_bg := false) -> void:
-	items.clear()
-	
-	for instance in _item_instances:
-		var pii: PopochiuInventoryItem = _item_instances[instance]
-		
-		if not pii.in_inventory: continue
-		
-		if in_bg:
-			# refs #349: In background mode, reset quantity_owned directly to avoid signal
-			# emissions and GUI awaits that are not meaningful without a visible inventory.
+	if in_bg:
+		# refs #349: In background mode, reset quantity_owned directly and clear the items list
+		# to avoid signal emissions and GUI awaits.
+		for instance in _item_instances:
+			var pii: PopochiuInventoryItem = _item_instances[instance]
 			pii.quantity_owned = 0
-		else:
-			# refs #349: Only call discard() here: the old code called both discard() and
-			# remove() separately, which caused item_removed to be emitted twice per item
-			# (once from inside discard() -> remove(), and once from the extra remove() call
-			# after discard()). discard() already calls remove() internally.
-			await pii.discard()
+		items.clear()
+	else:
+		# Remove each item through its full GUI lifecycle.
+		for instance in _item_instances:
+			var pii: PopochiuInventoryItem = _item_instances[instance]
+			if pii.in_inventory:
+				await pii.remove()
 
 
 ## Shows the inventory for [param time] seconds.

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -108,7 +108,8 @@ func clean_inventory(in_bg := false) -> void:
 
 
 ## Adds [param quantity] of [param item] to the inventory and waits until any GUI transition has
-## finished.
+## finished. Inventory capacity is slot-based: stacked quantities still occupy a single slot and
+## count as [code]1[/code] against the inventory limit.
 func add_item(item: PopochiuInventoryItem, quantity := 1) -> void:
 	if quantity <= 0:
 		PopochiuUtils.print_warning(
@@ -169,13 +170,18 @@ func remove_item(item: PopochiuInventoryItem, quantity: int = 0) -> void:
 
 
 ## Replaces [param item] in the inventory with [param new_item] and waits until the GUI swap has
-## finished.
+## finished. Replacing removes the whole collected quantity of [param item] and adds exactly one
+## quantity of [param new_item].
 func replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	if not _can_replace_item(item, new_item):
+		await get_tree().process_frame
+		return
+
 	_apply_full_removal(item)
 
 	if new_item.quantity_owned == 0:
 		_apply_first_add(new_item, 1)
-	elif new_item.max_quantity > 1 and new_item.quantity_owned < new_item.max_quantity:
+	else:
 		_apply_stack_add(new_item, 1)
 
 	item_replaced.emit(item, new_item)
@@ -303,8 +309,9 @@ func has_item_been_collected(item_name: String) -> bool:
 	return is_instance_valid(i) and i.ever_collected
 
 
-## Returns [code]true[/code] if the inventory has reached the inventory limit
-## configured in the project settings.
+## Returns [code]true[/code] if the inventory has reached the inventory limit configured in the
+## project settings. The limit counts occupied slots, not total owned quantity, so a stacked item
+## still occupies a single slot and counts as [code]1[/code].
 func is_full() -> bool:
 	return (
 		PopochiuUtils.e.settings.inventory_limit > 0
@@ -350,6 +357,41 @@ func _get_addable_quantity(
 		)
 
 	return actual
+
+
+func _can_replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> bool:
+	var item_name := item.script_name if is_instance_valid(item) else "<invalid item>"
+	var new_item_name := new_item.script_name if is_instance_valid(new_item) else "<invalid item>"
+
+	if not is_instance_valid(item) or item.quantity_owned <= 0:
+		PopochiuUtils.print_warning(
+			"Couldn't replace %s. Item is not in the inventory." % item_name
+		)
+		return false
+
+	if not is_instance_valid(new_item):
+		PopochiuUtils.print_warning(
+			"Couldn't replace %s. Replacement item is invalid." % item_name
+		)
+		return false
+
+	if item == new_item:
+		PopochiuUtils.print_warning(
+			"Couldn't replace %s with itself." % item_name
+		)
+		return false
+
+	if new_item.quantity_owned == 0:
+		return true
+
+	if new_item.max_quantity > 1 and new_item.quantity_owned < new_item.max_quantity:
+		return true
+
+	PopochiuUtils.print_warning(
+		"Couldn't replace %s with %s. Replacement item can't receive one more unit."
+		% [item_name, new_item_name]
+	)
+	return false
 
 
 func _register_item(item: PopochiuInventoryItem) -> void:

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -87,30 +87,34 @@ func _init() -> void:
 #endregion
 
 #region Public #####################################################################################
-## Removes all items currently in the inventory. If [param in_bg] is [code]true[/code], items are
-## removed silently without GUI lifecycle (useful during scene transitions).
-func clean_inventory(in_bg := false) -> void:
-	if in_bg:
-		# refs #349: In background mode, reset quantity_owned directly and clear the items list
-		# to avoid signal emissions and GUI awaits.
-		for instance in _item_instances:
-			var pii: PopochiuInventoryItem = _item_instances[instance]
-			pii.quantity_owned = 0
-		items.clear()
-		set_active_item(null)
-		clicked = null
-	else:
-		# Remove each item through its full GUI lifecycle.
-		for instance in _item_instances:
-			var pii: PopochiuInventoryItem = _item_instances[instance]
-			if pii.in_inventory:
-				await pii.remove()
+## Removes all items currently in the inventory. When items are ## removed the GUI lifecycle
+## gets triggered once for each item, so the GUI may play animations if necessary.
+func clean_inventory() -> void:
+	# Remove each item through its full GUI lifecycle.
+	for instance in _item_instances:
+		var pii: PopochiuInventoryItem = _item_instances[instance]
+		if pii.in_inventory:
+			await pii.remove()
+
+
+## Removes all items currently in the inventory without triggering GUI lifecycle
+## (useful during scene transitions).
+func clean_inventory_bg() -> void:
+	# refs #349: In background mode, reset quantity_owned directly and clear the items list
+	# to avoid signal emissions and GUI awaits.
+	for instance in _item_instances:
+		var pii: PopochiuInventoryItem = _item_instances[instance]
+		pii.quantity_owned = 0
+	items.clear()
+	set_active_item(null)
+	clicked = null
 
 
 ## Adds [param quantity] of [param item] to the inventory and waits until any GUI transition has
 ## finished. Inventory capacity is slot-based: stacked quantities still occupy a single slot and
 ## count as [code]1[/code] against the inventory limit.
 func add_item(item: PopochiuInventoryItem, quantity := 1) -> void:
+	# Stop on negative or null quantities.
 	if quantity <= 0:
 		PopochiuUtils.print_warning(
 			"Couldn't add %d of %s. Quantity must be greater than 0."
@@ -119,31 +123,46 @@ func add_item(item: PopochiuInventoryItem, quantity := 1) -> void:
 		await get_tree().process_frame
 		return
 
+	# If character doesn't own the item yet...
 	if item.quantity_owned == 0:
+		# Stop if the inventory is full.
 		if is_full():
-			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % item.script_name)
+			PopochiuUtils.print_warning("Couldn't add %s. Inventory is full." % item.script_name)
 			await get_tree().process_frame
 			return
 
+		# Calculate the addable quantity for the first collection of this item.
 		var actual := _get_addable_quantity(item, quantity, item.max_quantity)
-		if actual <= 0:
-			await get_tree().process_frame
-			return
-
+		# Add the item to the inventory for the first time, and we're done!
 		_apply_first_add(item, actual)
 		item_added.emit(item)
 		await item_add_done
 		return
 
+	# If we are here, we have at least one item in the inventory.
+	# Stop if we can have only one (or less for good measure, but the value is forced by
+	# a setter, so it should never be possible).
 	if item.max_quantity <= 1:
+		PopochiuUtils.print_warning(
+			"Couldn't add %s. It is already in the inventory."
+			% item.script_name
+		)
 		await get_tree().process_frame
 		return
 
 	var actual := _get_addable_quantity(item, quantity, item.max_quantity - item.quantity_owned)
-	if actual > 0:
-		_apply_stack_add(item, actual)
+	# Stop if there is no room left for this item.
+	if actual <= 0:
+		PopochiuUtils.print_warning(
+			"Couldn't add %s. Max quantity exceeded."
+			% item.script_name
+		)
+		await get_tree().process_frame
+		return
 
-	await get_tree().process_frame
+	# We're at the end, add the items and we're done.
+	_apply_stack_add(item, actual)
+
 
 
 ## Removes [param quantity] of [param item] from the inventory and waits until any GUI transition
@@ -403,13 +422,13 @@ func _apply_first_add(item: PopochiuInventoryItem, quantity: int) -> void:
 	_register_item(item)
 	item.quantity_owned = quantity
 	item.ever_collected = true
-	item._on_added_to_inventory()
+	item._on_added_to_inventory() # Call to Virtual, not Private
 
 
 func _apply_stack_add(item: PopochiuInventoryItem, quantity: int) -> void:
 	var old_qty := item.quantity_owned
 	item.quantity_owned += quantity
-	item._on_quantity_changed(old_qty, item.quantity_owned)
+	item._on_quantity_changed(old_qty, item.quantity_owned)  # Call to Virtual, not Private
 	item_quantity_updated.emit(item, item.quantity_owned)
 
 
@@ -422,7 +441,7 @@ func _apply_full_removal(item: PopochiuInventoryItem) -> void:
 func _apply_partial_removal(item: PopochiuInventoryItem, quantity: int) -> void:
 	var old_qty := item.quantity_owned
 	item.quantity_owned -= quantity
-	item._on_quantity_changed(old_qty, item.quantity_owned)
+	item._on_quantity_changed(old_qty, item.quantity_owned) # Call to Virtual, not Private
 	item_quantity_updated.emit(item, item.quantity_owned)
 
 

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -97,12 +97,122 @@ func clean_inventory(in_bg := false) -> void:
 			var pii: PopochiuInventoryItem = _item_instances[instance]
 			pii.quantity_owned = 0
 		items.clear()
+		set_active_item(null)
+		clicked = null
 	else:
 		# Remove each item through its full GUI lifecycle.
 		for instance in _item_instances:
 			var pii: PopochiuInventoryItem = _item_instances[instance]
 			if pii.in_inventory:
 				await pii.remove()
+
+
+## Adds [param quantity] of [param item] to the inventory and waits until any GUI transition has
+## finished.
+func add_item(item: PopochiuInventoryItem, quantity := 1) -> void:
+	if quantity <= 0:
+		PopochiuUtils.print_warning(
+			"Couldn't add %d of %s. Quantity must be greater than 0."
+			% [quantity, item.script_name]
+		)
+		await get_tree().process_frame
+		return
+
+	if item.quantity_owned == 0:
+		if is_full():
+			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % item.script_name)
+			await get_tree().process_frame
+			return
+
+		var actual := _get_addable_quantity(item, quantity, item.max_quantity)
+		if actual <= 0:
+			await get_tree().process_frame
+			return
+
+		_apply_first_add(item, actual)
+		item_added.emit(item)
+		await item_add_done
+		return
+
+	if item.max_quantity <= 1:
+		await get_tree().process_frame
+		return
+
+	var actual := _get_addable_quantity(item, quantity, item.max_quantity - item.quantity_owned)
+	if actual > 0:
+		_apply_stack_add(item, actual)
+
+	await get_tree().process_frame
+
+
+## Removes [param quantity] of [param item] from the inventory and waits until any GUI transition
+## has finished. Use [code]0[/code] to remove the full stack.
+func remove_item(item: PopochiuInventoryItem, quantity: int = 0) -> void:
+	if quantity < 0:
+		PopochiuUtils.print_warning(
+			"Couldn't remove %d of %s. Quantity must be 0 or greater."
+			% [quantity, item.script_name]
+		)
+		await get_tree().process_frame
+		return
+
+	var qty_to_remove := quantity if quantity > 0 else item.quantity_owned
+	if qty_to_remove >= item.quantity_owned:
+		_apply_full_removal(item)
+		item_removed.emit(item)
+		await item_remove_done
+		return
+
+	_apply_partial_removal(item, qty_to_remove)
+
+	await get_tree().process_frame
+
+
+## Replaces [param item] in the inventory with [param new_item] and waits until the GUI swap has
+## finished.
+func replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	_apply_full_removal(item)
+
+	if new_item.quantity_owned == 0:
+		_apply_first_add(new_item, 1)
+	elif new_item.max_quantity > 1 and new_item.quantity_owned < new_item.max_quantity:
+		_apply_stack_add(new_item, 1)
+
+	item_replaced.emit(item, new_item)
+	await item_replace_done
+
+
+## Registers an inventory item that is already present in a GUI scene without running the full
+## add-item flow.
+func register_existing_item(item: PopochiuInventoryItem) -> void:
+	if not is_instance_valid(item):
+		return
+
+	if item.quantity_owned == 0:
+		_apply_first_add(item, 1)
+		return
+
+	item.ever_collected = true
+	_register_item(item)
+
+
+## Applies the deprecated [member PopochiuInventoryItem.in_inventory] setter semantics without
+## emitting inventory signals or awaiting GUI transitions. Use [method add_item] and
+## [method remove_item] for normal gameplay flow.
+func set_item_in_inventory_silently(item: PopochiuInventoryItem, value: bool) -> void:
+	if not is_instance_valid(item):
+		return
+
+	if value:
+		if item.quantity_owned == 0:
+			_apply_first_add(item, 1)
+			return
+
+		item.ever_collected = true
+		_register_item(item)
+		return
+
+	_apply_full_removal(item)
 
 
 ## Shows the inventory for [param time] seconds.
@@ -224,6 +334,54 @@ func set_active(value: PopochiuInventoryItem) -> void:
 	active = value
 	
 	item_selected.emit(active)
+
+
+#endregion
+
+#region Private ####################################################################################
+func _get_addable_quantity(
+	item: PopochiuInventoryItem, requested: int, available_limit: int
+) -> int:
+	var actual := mini(requested, available_limit)
+	if actual < requested:
+		PopochiuUtils.print_warning(
+			"Couldn't add all %d of %s. Capped at max_quantity of %d."
+			% [requested, item.script_name, item.max_quantity]
+		)
+
+	return actual
+
+
+func _register_item(item: PopochiuInventoryItem) -> void:
+	if not items.has(item.script_name):
+		items.append(item.script_name)
+
+
+func _apply_first_add(item: PopochiuInventoryItem, quantity: int) -> void:
+	_register_item(item)
+	item.quantity_owned = quantity
+	item.ever_collected = true
+	item._on_added_to_inventory()
+
+
+func _apply_stack_add(item: PopochiuInventoryItem, quantity: int) -> void:
+	var old_qty := item.quantity_owned
+	item.quantity_owned += quantity
+	item._on_quantity_changed(old_qty, item.quantity_owned)
+	item_quantity_updated.emit(item, item.quantity_owned)
+
+
+func _apply_full_removal(item: PopochiuInventoryItem) -> void:
+	item.quantity_owned = 0
+	items.erase(item.script_name)
+	set_active_item(null)
+
+
+func _apply_partial_removal(item: PopochiuInventoryItem, quantity: int) -> void:
+	var old_qty := item.quantity_owned
+	item.quantity_owned -= quantity
+	item._on_quantity_changed(old_qty, item.quantity_owned)
+	item_quantity_updated.emit(item, item.quantity_owned)
 
 
 #endregion

--- a/addons/popochiu/engine/interfaces/i_inventory.gd
+++ b/addons/popochiu/engine/interfaces/i_inventory.gd
@@ -161,6 +161,7 @@ func add_item(item: PopochiuInventoryItem, quantity := 1) -> void:
 		return
 
 	# We're at the end, add the items and we're done.
+	# Exceeding quantity is signaled by _apply_stack_add().
 	_apply_stack_add(item, actual)
 
 
@@ -224,7 +225,7 @@ func register_existing_item(item: PopochiuInventoryItem) -> void:
 ## Applies the deprecated [member PopochiuInventoryItem.in_inventory] setter semantics without
 ## emitting inventory signals or awaiting GUI transitions. Use [method add_item] and
 ## [method remove_item] for normal gameplay flow.
-func set_item_in_inventory_silently(item: PopochiuInventoryItem, value: bool) -> void:
+func set_item_in_inventory_bg(item: PopochiuInventoryItem, value: bool) -> void:
 	if not is_instance_valid(item):
 		return
 

--- a/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
@@ -115,7 +115,7 @@ func _on_gui_unblocked() -> void:
 		show()
 
 
-func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
+func _add_item(item: PopochiuInventoryItem) -> void:
 	box.add_child(item)
 	
 	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
@@ -123,7 +123,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	
 	item.selected.connect(_change_cursor)
 	
-	if not always_visible and animate:
+	if not always_visible and not PopochiuUtils.i.is_restoring:
 		# Show the inventory for a while and hide after a couple of seconds so players can see the
 		# item being added to the inventory
 		set_process_input(false)
@@ -144,7 +144,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
+func _remove_item(item: PopochiuInventoryItem) -> void:
 	item.selected.disconnect(_change_cursor)
 	box.remove_child(item)
 	
@@ -152,7 +152,7 @@ func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
 		PopochiuUtils.cursor.show_cursor()
 		PopochiuUtils.g.show_hover_text()
 		
-		if animate:
+		if not PopochiuUtils.i.is_restoring:
 			_close()
 			await get_tree().create_timer(1.0).timeout
 	

--- a/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_bar/inventory_bar.gd
@@ -26,17 +26,15 @@ func _ready():
 	# Connect to singletons signals
 	PopochiuUtils.g.blocked.connect(_on_gui_blocked)
 	PopochiuUtils.g.unblocked.connect(_on_gui_unblocked)
-	PopochiuUtils.i.item_added.connect(_add_item)
-	PopochiuUtils.i.item_removed.connect(_remove_item)
-	PopochiuUtils.i.item_replaced.connect(_replace_item)
 	PopochiuUtils.i.inventory_show_requested.connect(_show_and_hide)
 	PopochiuUtils.i.inventory_hide_requested.connect(_close)
 	
 	# Check if there are already items in the inventory (set manually in the scene)
 	for ii in box.get_children():
 		if ii is PopochiuInventoryItem:
-			ii.in_inventory = true
-			ii.selected.connect(_change_cursor)
+			PopochiuUtils.i.register_existing_item(ii)
+			if not ii.selected.is_connected(_change_cursor):
+				ii.selected.connect(_change_cursor)
 	
 	set_process_input(not always_visible)
 
@@ -115,13 +113,14 @@ func _on_gui_unblocked() -> void:
 		show()
 
 
-func _add_item(item: PopochiuInventoryItem) -> void:
+func show_item(item: PopochiuInventoryItem) -> void:
 	box.add_child(item)
 	
 	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
 	item.custom_minimum_size.y = box.size.y
 	
-	item.selected.connect(_change_cursor)
+	if not item.selected.is_connected(_change_cursor):
+		item.selected.connect(_change_cursor)
 	
 	if not always_visible and not PopochiuUtils.i.is_restoring:
 		# Show the inventory for a while and hide after a couple of seconds so players can see the
@@ -140,12 +139,11 @@ func _add_item(item: PopochiuInventoryItem) -> void:
 		set_process_input(true)
 	else:
 		await get_tree().process_frame
-	
-	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem) -> void:
-	item.selected.disconnect(_change_cursor)
+func hide_item(item: PopochiuInventoryItem) -> void:
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	box.remove_child(item)
 	
 	if not always_visible:
@@ -157,15 +155,15 @@ func _remove_item(item: PopochiuInventoryItem) -> void:
 			await get_tree().create_timer(1.0).timeout
 	
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_remove_done.emit(item)
 
 
-func _replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+func swap_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	item.replace_by(new_item)
+	if not new_item.selected.is_connected(_change_cursor):
+		new_item.selected.connect(_change_cursor)
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_replace_done.emit()
 
 
 func _show_and_hide(time := 1.0) -> void:

--- a/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
@@ -156,7 +156,7 @@ func _on_down_pressed() -> void:
 	_check_scroll_buttons()
 
 
-func _add_item(item: PopochiuInventoryItem, _animate := true) -> void:
+func _add_item(item: PopochiuInventoryItem) -> void:
 	var slot := box.get_child(PopochiuUtils.i.items.size() - 1)
 	slot.name = "[%s]" % item.script_name
 	slot.add_child(item)
@@ -180,7 +180,7 @@ func _add_item(item: PopochiuInventoryItem, _animate := true) -> void:
 	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem, _animate := true) -> void:
+func _remove_item(item: PopochiuInventoryItem) -> void:
 	item.selected.disconnect(_change_cursor)
 	
 	box.get_meta(item.script_name).remove_child(item)

--- a/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
+++ b/addons/popochiu/engine/objects/gui/components/inventory_grid/inventory_grid.gd
@@ -46,11 +46,6 @@ func _ready():
 	down.pressed.connect(_on_down_pressed)
 	scroll_container.get_v_scroll_bar().value_changed.connect(_on_scroll)
 	
-	# Connect to singletons signals
-	PopochiuUtils.i.item_added.connect(_add_item)
-	PopochiuUtils.i.item_removed.connect(_remove_item)
-	PopochiuUtils.i.item_replaced.connect(_replace_item)
-	
 	_check_scroll_buttons()
 
 
@@ -140,7 +135,7 @@ func _check_starting_items() -> void:
 		if (slot.get_child_count() > 0
 		and slot.get_child(0) is PopochiuInventoryItem
 		):
-			PopochiuUtils.i.items.append(slot.get_child(0).script_name)
+			PopochiuUtils.i.register_existing_item(slot.get_child(0))
 			slot.name = slot.get_child(0).script_name
 		else:
 			slot.name = EMPTY_SLOT
@@ -156,7 +151,7 @@ func _on_down_pressed() -> void:
 	_check_scroll_buttons()
 
 
-func _add_item(item: PopochiuInventoryItem) -> void:
+func show_item(item: PopochiuInventoryItem) -> void:
 	var slot := box.get_child(PopochiuUtils.i.items.size() - 1)
 	slot.name = "[%s]" % item.script_name
 	slot.add_child(item)
@@ -170,18 +165,18 @@ func _add_item(item: PopochiuInventoryItem) -> void:
 	
 	box.set_meta(item.script_name, slot)
 	
-	item.selected.connect(_change_cursor)
+	if not item.selected.is_connected(_change_cursor):
+		item.selected.connect(_change_cursor)
 	_check_scroll_buttons()
 	
 	# Common call to all inventories. Should be in the class from where inventory panels will
 	# inherit from
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem) -> void:
-	item.selected.disconnect(_change_cursor)
+func hide_item(item: PopochiuInventoryItem) -> void:
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	
 	box.get_meta(item.script_name).remove_child(item)
 	box.get_meta(item.script_name).name = EMPTY_SLOT
@@ -189,22 +184,23 @@ func _remove_item(item: PopochiuInventoryItem) -> void:
 	_check_scroll_buttons()
 	
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_remove_done.emit(item)
 
 
-func _replace_item(
+func swap_item(
 	item: PopochiuInventoryItem, new_item: PopochiuInventoryItem
 ) -> void:
+	var slot: Control = box.get_meta(item.script_name)
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	item.replace_by(new_item)
 	box.remove_meta(item.script_name)
-	box.set_meta(new_item.script_name, new_item.get_parent())
+	box.set_meta(new_item.script_name, slot)
+	if not new_item.selected.is_connected(_change_cursor):
+		new_item.selected.connect(_change_cursor)
 	
 	_check_scroll_buttons()
 	
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_replace_done.emit()
 
 
 func _change_cursor(item: PopochiuInventoryItem) -> void:

--- a/addons/popochiu/engine/objects/gui/popochiu_gui.gd
+++ b/addons/popochiu/engine/objects/gui/popochiu_gui.gd
@@ -43,6 +43,9 @@ func _ready():
 	PopochiuUtils.d.dialog_started.connect(_on_dialog_started)
 	PopochiuUtils.g.dialog_options_shown.connect(_on_dialog_options_shown)
 	PopochiuUtils.d.dialog_finished.connect(_on_dialog_finished)
+	PopochiuUtils.i.item_added.connect(_on_inventory_item_added)
+	PopochiuUtils.i.item_removed.connect(_on_inventory_item_removed)
+	PopochiuUtils.i.item_replaced.connect(_on_inventory_item_replaced)
 	PopochiuUtils.i.item_selected.connect(_on_inventory_item_selected)
 	PopochiuUtils.e.game_saved.connect(_on_game_saved)
 	PopochiuUtils.e.game_loaded.connect(_on_game_loaded)
@@ -147,6 +150,30 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	pass
 
 
+## Called when [param item] is added to the inventory.[br]
+## This hook is awaited by the base GUI routing layer, which emits
+## [signal PopochiuIInventory.item_add_done] automatically after the hook returns. Overrides must
+## not emit the signal or call [method G.block].
+func _on_item_added(item: PopochiuInventoryItem) -> void:
+	pass
+
+
+## Called when [param item] is removed from the inventory.[br]
+## This hook is awaited by the base GUI routing layer, which emits
+## [signal PopochiuIInventory.item_remove_done] automatically after the hook returns. Overrides
+## must not emit the signal or call [method G.block].
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
+	pass
+
+
+## Called when [param item] is replaced in the inventory by [param new_item].[br]
+## This hook is awaited by the base GUI routing layer, which emits
+## [signal PopochiuIInventory.item_replace_done] automatically after the hook returns. Overrides
+## must not emit the signal or call [method G.block].
+func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	pass
+
+
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText
 ## component.
 func _on_game_saved() -> void:
@@ -197,6 +224,33 @@ func on_shown() -> void:
 #endregion
 
 #region Private ####################################################################################
+## Routes [signal PopochiuIInventory.item_added] through the GUI hook surface and guarantees the
+## completion handshake.
+func _on_inventory_item_added(item: PopochiuInventoryItem) -> void:
+	PopochiuUtils.g.block()
+	await _on_item_added(item)
+	PopochiuUtils.i.item_add_done.emit(item)
+	PopochiuUtils.g.unblock(true)
+
+
+## Routes [signal PopochiuIInventory.item_removed] through the GUI hook surface and guarantees the
+## completion handshake.
+func _on_inventory_item_removed(item: PopochiuInventoryItem) -> void:
+	PopochiuUtils.g.block()
+	await _on_item_removed(item)
+	PopochiuUtils.i.item_remove_done.emit(item)
+	PopochiuUtils.g.unblock()
+
+
+## Routes [signal PopochiuIInventory.item_replaced] through the GUI hook surface and guarantees
+## the completion handshake.
+func _on_inventory_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	PopochiuUtils.g.block()
+	await _on_item_replaced(item, new_item)
+	PopochiuUtils.i.item_replace_done.emit()
+	PopochiuUtils.g.unblock()
+
+
 func _adjust_nodes_text(nodes_array: Array) -> void:
 	for node: Node in nodes_array:
 		_adjust_nodes_text(node.get_children())

--- a/addons/popochiu/engine/objects/gui/popochiu_gui.gd
+++ b/addons/popochiu/engine/objects/gui/popochiu_gui.gd
@@ -154,7 +154,7 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 ## This hook is awaited by the base GUI routing layer, which emits
 ## [signal PopochiuIInventory.item_add_done] automatically after the hook returns. Overrides must
 ## not emit the signal or call [method G.block].
-func _on_item_added(item: PopochiuInventoryItem) -> void:
+func _on_item_added(_item: PopochiuInventoryItem) -> void:
 	pass
 
 

--- a/addons/popochiu/engine/objects/gui/popochiu_gui.gd
+++ b/addons/popochiu/engine/objects/gui/popochiu_gui.gd
@@ -162,7 +162,7 @@ func _on_item_added(_item: PopochiuInventoryItem) -> void:
 ## This hook is awaited by the base GUI routing layer, which emits
 ## [signal PopochiuIInventory.item_remove_done] automatically after the hook returns. Overrides
 ## must not emit the signal or call [method G.block].
-func _on_item_removed(item: PopochiuInventoryItem) -> void:
+func _on_item_removed(_item: PopochiuInventoryItem) -> void:
 	pass
 
 
@@ -170,7 +170,7 @@ func _on_item_removed(item: PopochiuInventoryItem) -> void:
 ## This hook is awaited by the base GUI routing layer, which emits
 ## [signal PopochiuIInventory.item_replace_done] automatically after the hook returns. Overrides
 ## must not emit the signal or call [method G.block].
-func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+func _on_item_replaced(_item: PopochiuInventoryItem, _new_item: PopochiuInventoryItem) -> void:
 	pass
 
 

--- a/addons/popochiu/engine/objects/gui/resources/base_gui_theme.tres
+++ b/addons/popochiu/engine/objects/gui/resources/base_gui_theme.tres
@@ -3,7 +3,7 @@
 [ext_resource type="Texture2D" uid="uid://pl1ch71kfj72" path="res://addons/popochiu/engine/objects/gui/resources/images/check_button_checked.png" id="2_ldprq"]
 [ext_resource type="Texture2D" uid="uid://dukr75slqli45" path="res://addons/popochiu/engine/objects/gui/resources/images/check_button_unchecked.png" id="3_3rprc"]
 [ext_resource type="Texture2D" uid="uid://cqxqfxobqltga" path="res://addons/popochiu/engine/objects/gui/resources/images/grabber.png" id="4_4x0ix"]
-[ext_resource type="Texture2D" uid="uid://bbl1rk1aqbhp" path="res://addons/popochiu/engine/objects/gui/resources/images/radio_button.png" id="5_c6xq1"]
+[ext_resource type="Texture2D" uid="uid://dnjlxttdpub4q" path="res://addons/popochiu/engine/objects/gui/resources/images/radio_button.png" id="5_c6xq1"]
 [ext_resource type="Texture2D" uid="uid://d1ywqbehmtuv" path="res://addons/popochiu/engine/objects/gui/resources/images/down_arrow.png" id="5_jwcnu"]
 [ext_resource type="FontFile" uid="uid://dm6h44ck2nm2b" path="res://addons/popochiu/engine/objects/gui/fonts/minecraftia-regular.ttf" id="6_gx6k1"]
 

--- a/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
@@ -16,6 +16,7 @@ var _return_to_walk_to := false
 ## Used to access the [b]9VerbPanel[/b] component (the one at the bottom containing the verbs,
 ## the inventory, and the button to open the [b]9VerbSettingsPopup[/b].
 @onready var _9_verb_panel: Control = %"9VerbPanel"
+@onready var _inventory_grid: PopochiuInventoryGrid = _9_verb_panel.get_node("%9VerbInventoryGrid")
 @onready var hover_text_cursor: Control = %HoverTextCursor
 ## Used to access the [b]9VerbSettingsPopup[/b] node.
 @onready var settings_popup: Control = %"9VerbSettingsPopup"
@@ -194,6 +195,18 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 		PopochiuUtils.g.show_hover_text()
 	else:
 		_show_command_on(item.description)
+
+
+func _on_item_added(item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.show_item(item)
+
+
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.hide_item(item)
+
+
+func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.swap_item(item, new_item)
 
 
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText

--- a/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb/9_verb_gui.gd
@@ -16,7 +16,7 @@ var _return_to_walk_to := false
 ## Used to access the [b]9VerbPanel[/b] component (the one at the bottom containing the verbs,
 ## the inventory, and the button to open the [b]9VerbSettingsPopup[/b].
 @onready var _9_verb_panel: Control = %"9VerbPanel"
-@onready var _inventory_grid: PopochiuInventoryGrid = _9_verb_panel.get_node("%9VerbInventoryGrid")
+@onready var _inventory_grid: Control = %"9VerbInventoryGrid"
 @onready var hover_text_cursor: Control = %HoverTextCursor
 ## Used to access the [b]9VerbSettingsPopup[/b] node.
 @onready var settings_popup: Control = %"9VerbSettingsPopup"

--- a/addons/popochiu/engine/objects/gui/templates/9_verb/components/9_verb_panel/9_verb_panel.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb/components/9_verb_panel/9_verb_panel.tscn
@@ -172,6 +172,7 @@ script = ExtResource("5_bpewk")
 command = 9
 
 [node name="9VerbInventoryGrid" parent="PanelContainer/VBoxContainer/Verbs&InventoryContainer/HBoxContainer" instance=ExtResource("6_r1cmu")]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 1
 theme = null

--- a/addons/popochiu/engine/objects/gui/templates/9_verb_high_res/components/9_verb_panel_high_res/9_verb_panel_high_res.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/9_verb_high_res/components/9_verb_panel_high_res/9_verb_panel_high_res.tscn
@@ -183,5 +183,6 @@ text = "Use"
 script = ExtResource("7_16jef")
 command = 9
 
-[node name="9VerbInventoryGridHighRes" parent="PanelContainer/VBoxContainer/Verbs&InventoryContainer/HBoxContainer" instance=ExtResource("7_xc4x6")]
+[node name="9VerbInventoryGrid" parent="PanelContainer/VBoxContainer/Verbs&InventoryContainer/HBoxContainer" instance=ExtResource("7_xc4x6")]
+unique_name_in_owner = true
 layout_mode = 2

--- a/addons/popochiu/engine/objects/gui/templates/sierra/components/sierra_inventory_popup/sierra_inventory_popup.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/sierra/components/sierra_inventory_popup/sierra_inventory_popup.tscn
@@ -130,6 +130,7 @@ texture_pressed = ExtResource("4_vd0bg")
 texture_hover = ExtResource("4_vd0bg")
 
 [node name="SierraInventoryGrid" parent="Overlay/PanelContainer/VBoxContainer" instance=ExtResource("5_i15hx")]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="FooterContainer" type="HBoxContainer" parent="Overlay/PanelContainer/VBoxContainer"]

--- a/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
@@ -11,9 +11,7 @@ extends PopochiuGraphicInterface
 @onready var sierra_bar: Control = %SierraBar
 @onready var sierra_menu: Control = %SierraMenu
 @onready var sierra_inventory_popup: Control = %SierraInventoryPopup
-@onready var _inventory_grid: PopochiuInventoryGrid = sierra_inventory_popup.get_node(
-	"%SierraInventoryGrid"
-)
+@onready var _inventory_grid: Control = %SierraInventoryGrid
 @onready var sierra_settings_popup: Control = %SierraSettingsPopup
 @onready var sierra_sound_popup: Control = %SierraSoundPopup
 @onready var text_settings_popup: Control = %TextSettingsPopup

--- a/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd
@@ -11,6 +11,9 @@ extends PopochiuGraphicInterface
 @onready var sierra_bar: Control = %SierraBar
 @onready var sierra_menu: Control = %SierraMenu
 @onready var sierra_inventory_popup: Control = %SierraInventoryPopup
+@onready var _inventory_grid: PopochiuInventoryGrid = sierra_inventory_popup.get_node(
+	"%SierraInventoryGrid"
+)
 @onready var sierra_settings_popup: Control = %SierraSettingsPopup
 @onready var sierra_sound_popup: Control = %SierraSoundPopup
 @onready var text_settings_popup: Control = %TextSettingsPopup
@@ -131,6 +134,18 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	else:
 		PopochiuUtils.cursor.remove_secondary_cursor_texture()
 		PopochiuUtils.cursor.show_cursor()
+
+
+func _on_item_added(item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.show_item(item)
+
+
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.hide_item(item)
+
+
+func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	await _inventory_grid.swap_item(item, new_item)
 
 
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText

--- a/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://6ucg5xkcreh5"]
+[gd_scene format=3 uid="uid://6ucg5xkcreh5"]
 
 [ext_resource type="Theme" uid="uid://dpequqav4rjaf" path="res://addons/popochiu/engine/objects/gui/resources/base_gui_theme.tres" id="1_3jlpr"]
 [ext_resource type="Script" uid="uid://byhjwrxhgl1e5" path="res://addons/popochiu/engine/objects/gui/templates/sierra/sierra_gui.gd" id="1_40nsv"]
@@ -102,7 +102,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="SierraGUI" type="Control"]
+[node name="SierraGUI" type="Control" unique_id=351786394]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -113,32 +113,32 @@ mouse_filter = 2
 theme = ExtResource("1_3jlpr")
 script = ExtResource("1_40nsv")
 
-[node name="Cursor" type="AnimatedSprite2D" parent="."]
+[node name="Cursor" type="AnimatedSprite2D" parent="." unique_id=590174916]
 texture_filter = 1
 sprite_frames = SubResource("SpriteFrames_eo6w8")
 animation = &"gui"
 offset = Vector2(16, 16)
 
-[node name="SierraBar" parent="." instance=ExtResource("4_hjdb7")]
+[node name="SierraBar" parent="." unique_id=848903437 instance=ExtResource("4_hjdb7")]
 unique_name_in_owner = true
 layout_mode = 1
 
-[node name="SierraMenu" parent="." instance=ExtResource("5_ffq7i")]
+[node name="SierraMenu" parent="." unique_id=1620720244 instance=ExtResource("5_ffq7i")]
 unique_name_in_owner = true
 layout_mode = 1
 
-[node name="DialogPortrait" parent="." instance=ExtResource("5_nehoj")]
+[node name="DialogPortrait" parent="." unique_id=29231156 instance=ExtResource("5_nehoj")]
 layout_mode = 1
 
-[node name="DialogMenu" parent="." instance=ExtResource("14_3gq4k")]
+[node name="DialogMenu" parent="." unique_id=1746743535 instance=ExtResource("14_3gq4k")]
 visible = false
 layout_mode = 1
 
-[node name="SystemText" parent="." instance=ExtResource("18_x7swu")]
+[node name="SystemText" parent="." unique_id=668555024 instance=ExtResource("18_x7swu")]
 z_index = 1
 layout_mode = 1
 
-[node name="Popups" type="Control" parent="."]
+[node name="Popups" type="Control" parent="." unique_id=1019152404]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -147,32 +147,32 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="SierraInventoryPopup" parent="Popups" instance=ExtResource("15_2hyjp")]
+[node name="SierraInventoryPopup" parent="Popups" unique_id=1689771734 instance=ExtResource("15_2hyjp")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
 
-[node name="SierraSettingsPopup" parent="Popups" instance=ExtResource("18_sv4ik")]
+[node name="SierraSettingsPopup" parent="Popups" unique_id=727950063 instance=ExtResource("18_sv4ik")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
 
-[node name="SierraSoundPopup" parent="Popups" instance=ExtResource("19_3kc82")]
+[node name="SierraSoundPopup" parent="Popups" unique_id=1945395933 instance=ExtResource("19_3kc82")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
 
-[node name="TextSettingsPopup" parent="Popups" instance=ExtResource("20_anvsw")]
+[node name="TextSettingsPopup" parent="Popups" unique_id=40081456 instance=ExtResource("20_anvsw")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
 
-[node name="SaveAndLoadPopup" parent="Popups" instance=ExtResource("21_1xmwq")]
+[node name="SaveAndLoadPopup" parent="Popups" unique_id=39274138 instance=ExtResource("21_1xmwq")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1
 
-[node name="QuitPopup" parent="Popups" instance=ExtResource("24_50bps")]
+[node name="QuitPopup" parent="Popups" unique_id=2106186567 instance=ExtResource("24_50bps")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1

--- a/addons/popochiu/engine/objects/gui/templates/sierra_high_res/components/sierra_inventory_popup_high_res/sierra_inventory_popup_high_res.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/sierra_high_res/components/sierra_inventory_popup_high_res/sierra_inventory_popup_high_res.tscn
@@ -125,7 +125,8 @@ theme_override_constants/margin_bottom = 12
 layout_mode = 2
 theme_override_constants/separation = 12
 
-[node name="SierraInventoryGridHighRes" parent="Overlay/PanelContainer/VBoxContainer/MarginContainer/VBoxContainer" instance=ExtResource("5_s3yhq")]
+[node name="SierraInventoryGrid" parent="Overlay/PanelContainer/VBoxContainer/MarginContainer/VBoxContainer" instance=ExtResource("5_s3yhq")]
+unique_name_in_owner = true
 layout_mode = 2
 
 [node name="FooterContainer" type="HBoxContainer" parent="Overlay/PanelContainer/VBoxContainer/MarginContainer/VBoxContainer"]

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
@@ -155,7 +155,7 @@ func _on_tween_finished() -> void:
 	_is_hidden = panel_container.position.y == hidden_y
 
 
-func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
+func _add_item(item: PopochiuInventoryItem) -> void:
 	box.add_child(item)
 	
 	item.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
@@ -164,7 +164,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	
 	item.selected.connect(_change_cursor)
 	
-	if not always_visible and animate:
+	if not always_visible and not PopochiuUtils.i.is_restoring:
 		# Show the inventory for a while and hide after a couple of seconds so players can see the
 		# item being added to the inventory
 		set_process_input(false)
@@ -185,7 +185,7 @@ func _add_item(item: PopochiuInventoryItem, animate := true) -> void:
 	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
+func _remove_item(item: PopochiuInventoryItem) -> void:
 	item.selected.disconnect(_change_cursor)
 	box.remove_child(item)
 	
@@ -193,7 +193,7 @@ func _remove_item(item: PopochiuInventoryItem, animate := true) -> void:
 		PopochiuUtils.cursor.show_cursor()
 		PopochiuUtils.g.show_hover_text()
 		
-		if animate:
+		if not PopochiuUtils.i.is_restoring:
 			_close()
 			await get_tree().create_timer(1.0).timeout
 	

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.gd
@@ -34,9 +34,6 @@ func _ready():
 	settings_btn.mouse_exited.connect(_on_settings_mouse_exited)
 	
 	# Connect to singletons signals
-	PopochiuUtils.i.item_added.connect(_add_item)
-	PopochiuUtils.i.item_removed.connect(_remove_item)
-	PopochiuUtils.i.item_replaced.connect(_replace_item)
 	PopochiuUtils.i.inventory_show_requested.connect(_show_and_hide)
 	PopochiuUtils.i.inventory_hide_requested.connect(_close)
 	PopochiuUtils.g.blocked.connect(_on_gui_blocked)
@@ -44,7 +41,8 @@ func _ready():
 	
 	# Check if there are already items in the inventory (set manually in the scene)
 	for ii in box.get_children():
-		ii.in_inventory = ii is PopochiuInventoryItem
+		if ii is PopochiuInventoryItem:
+			PopochiuUtils.i.register_existing_item(ii)
 	
 	set_process_input(not always_visible)
 
@@ -155,14 +153,15 @@ func _on_tween_finished() -> void:
 	_is_hidden = panel_container.position.y == hidden_y
 
 
-func _add_item(item: PopochiuInventoryItem) -> void:
+func show_item(item: PopochiuInventoryItem) -> void:
 	box.add_child(item)
 	
 	item.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 	item.size_flags_vertical = Control.SIZE_FILL
 	item.expand_mode = TextureRect.EXPAND_FIT_WIDTH
 	
-	item.selected.connect(_change_cursor)
+	if not item.selected.is_connected(_change_cursor):
+		item.selected.connect(_change_cursor)
 	
 	if not always_visible and not PopochiuUtils.i.is_restoring:
 		# Show the inventory for a while and hide after a couple of seconds so players can see the
@@ -181,12 +180,11 @@ func _add_item(item: PopochiuInventoryItem) -> void:
 		set_process_input(true)
 	else:
 		await get_tree().process_frame
-	
-	PopochiuUtils.i.item_add_done.emit(item)
 
 
-func _remove_item(item: PopochiuInventoryItem) -> void:
-	item.selected.disconnect(_change_cursor)
+func hide_item(item: PopochiuInventoryItem) -> void:
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	box.remove_child(item)
 	
 	if not always_visible:
@@ -198,19 +196,19 @@ func _remove_item(item: PopochiuInventoryItem) -> void:
 			await get_tree().create_timer(1.0).timeout
 	
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_remove_done.emit(item)
 
 
 func _change_cursor(item: PopochiuInventoryItem) -> void:
 	PopochiuUtils.i.set_active_item(item)
 
 
-func _replace_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+func swap_item(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	if item.selected.is_connected(_change_cursor):
+		item.selected.disconnect(_change_cursor)
 	item.replace_by(new_item)
+	if not new_item.selected.is_connected(_change_cursor):
+		new_item.selected.connect(_change_cursor)
 	await get_tree().process_frame
-	
-	PopochiuUtils.i.item_replace_done.emit()
 
 
 func _show_and_hide(time := 1.0) -> void:

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/components/simple_click_bar/simple_click_bar.tscn
@@ -20,6 +20,7 @@ atlas = SubResource("CompressedTexture2D_fxk42")
 region = Rect2(0, 24, 24, 24)
 
 [node name="SimpleClickBar" type="Control" groups=["popochiu_gui_component"]]
+unique_name_in_owner = true
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_gui.gd
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click/simple_click_gui.gd
@@ -7,6 +7,8 @@ extends PopochiuGraphicInterface
 ## inventory bar is in the top left corner of the screen, and the settings bar is in the top right
 ## corner of the screen.
 
+@onready var _simple_click_bar: Control = %SimpleClickBar
+
 
 #region Godot ######################################################################################
 func _ready() -> void:
@@ -165,6 +167,18 @@ func _on_inventory_item_selected(item: PopochiuInventoryItem) -> void:
 	else:
 		PopochiuUtils.cursor.remove_secondary_cursor_texture()
 		PopochiuUtils.cursor.show_cursor()
+
+
+func _on_item_added(item: PopochiuInventoryItem) -> void:
+	await _simple_click_bar.show_item(item)
+
+
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
+	await _simple_click_bar.hide_item(item)
+
+
+func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	await _simple_click_bar.swap_item(item, new_item)
 
 
 ## Called when the game is saved. By default, it shows [code]Game saved[/code] in the SystemText

--- a/addons/popochiu/engine/objects/gui/templates/simple_click_high_res/components/simple_click_bar_high_res/simple_click_bar_high_res.tscn
+++ b/addons/popochiu/engine/objects/gui/templates/simple_click_high_res/components/simple_click_bar_high_res/simple_click_bar_high_res.tscn
@@ -16,7 +16,8 @@ region = Rect2(0, 40, 40, 40)
 atlas = ExtResource("3_lewa0")
 region = Rect2(0, 40, 40, 40)
 
-[node name="SimpleClickBarHighRes" type="Control" groups=["popochiu_gui_component"]]
+[node name="SimpleClickBar" type="Control" groups=["popochiu_gui_component"]]
+unique_name_in_owner = true
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -22,10 +22,26 @@ signal unselected
 @export var description := "" : get = get_description
 ## The cursor to use when the mouse hovers the object.
 @export var cursor: CURSOR.Type = CURSOR.Type.USE
+## The maximum number of this item the player can own at one time.[br]
+## Defaults to [code]1[/code], which preserves the legacy single-item behaviour.
+## Cannot be set below [code]1[/code]: a value of zero or less would make the item permanently
+## un-addable and break the first-add vs. stacking logic inside [method add].
+@export var max_quantity := 1 : set = set_max_quantity
 
 
-## Whether this item is actually inside the inventory GUI.
-var in_inventory := false : set = set_in_inventory
+## The number of this item the player currently owns. Use this property to check ownership and
+## stack sizes.
+var quantity_owned := 0
+# @deprecated: Use [member quantity_owned] instead. Kept for backward compatibility
+#
+## Reading returns [code]true[/code] if [member quantity_owned] is greater than [code]0[/code].[br]
+## Setting [code]true[/code] ensures [member quantity_owned] is at least [code]1[/code].[br]
+## Setting [code]false[/code] sets [member quantity_owned] to [code]0[/code].[br]
+## [b]Warning:[/b] Unlike [method add] and [method remove], this setter does not emit inventory
+## signals and does not update the inventory GUI. Use [method add] and [method remove] instead.
+var in_inventory: bool :
+	get: return quantity_owned > 0
+	set(value): _set_in_inventory(value)
 ## Whether this item has ever been in the inventory. Once true, it stays true.
 var ever_collected := false : set = set_ever_collected
 ## Stores the last [enum MouseButton] pressed on this object.
@@ -82,11 +98,19 @@ func _on_discard() -> void:
 	pass
 
 
+## Called when [member quantity_owned] changes due to stacking or partial removal — i.e., when
+## the item slot stays in the inventory but the count changes.[br]
+## Override this to react to quantity changes (e.g. play a different sound for 1 vs. many coins).
+func _on_quantity_changed(_old_qty: int, _new_qty: int) -> void:
+	pass
+
+
 #endregion
 
 #region Public #####################################################################################
-## Adds this item to the inventory. If [param animate] is [code]true[/code], the inventory GUI
-## shows an animation (implementation depends on the GUI).
+## Adds [param quantity] of this item to the inventory. If [param animate] is [code]true[/code],
+## the inventory GUI shows an animation for the first add only; subsequent stack additions do not
+## animate. [param quantity] defaults to [code]1[/code].
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 ##
@@ -99,12 +123,13 @@ func _on_discard() -> void:
 ##         I.Key.queue_add()
 ##     ])
 ## [/codeblock]
-func queue_add(animate := true) -> Callable:
-	return func (): await add(animate)
+func queue_add(quantity := 1, animate := true) -> Callable:
+	return func (): await add(quantity, animate)
 
 
-## Adds this item to the inventory. If [param animate] is [code]true[/code], the inventory GUI
-## shows an animation (implementation depends on the GUI).
+## Adds [param quantity] of this item to the inventory. [param quantity] defaults to [code]1[/code].
+## If [param animate] is [code]true[/code], the inventory GUI shows an animation (only on the first
+## add; subsequent stack additions only emit [signal PopochiuIInventory.item_quantity_updated]).
 ##
 ## Example:
 ## [codeblock]
@@ -112,50 +137,89 @@ func queue_add(animate := true) -> Callable:
 ##     await C.walk_to_clicked()
 ##     await C.player.say("I'm gonna take this with me")
 ##     await I.Key.add()
+##     # Add three coins at once:
+##     await I.Coin.add(3)
 ## [/codeblock]
-func add(animate := true) -> void:
-	if PopochiuUtils.i.is_full():
-		PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
+func add(quantity := 1, animate := true) -> void:
+	if quantity_owned == 0:
+		# --- First add: create the inventory slot and run the full GUI lifecycle ---
+		if PopochiuUtils.i.is_full():
+			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
+			
+			await get_tree().process_frame
+			return
+		
+		PopochiuUtils.g.block()
+		
+		PopochiuUtils.i.items.append(script_name)
+		
+		PopochiuUtils.i.item_added.emit(self, animate)
+		# Assign quantity_owned directly — do NOT go through the in_inventory setter here.
+		# add() is the lifecycle owner for first-add: it has already handled g.block(),
+		# item_added, and the await sequence below. Going through the setter would call
+		# _on_added_to_inventory() a second time and cannot represent a quantity > 1.
+		# Clamp to max_quantity even on first add: the caller may request more than allowed.
+		var clamped_qty := mini(quantity, max_quantity)
+		if clamped_qty < quantity:
+			PopochiuUtils.print_warning(
+				"Couldn't add all %d of %s. Capped at max_quantity of %d."
+				% [quantity, script_name, max_quantity]
+			)
+		quantity_owned = clamped_qty
+		ever_collected = true
+		_on_added_to_inventory()
+
+		await PopochiuUtils.i.item_add_done
+
+		PopochiuUtils.g.unblock(true)
+		return
+	
+	if max_quantity > 1:
+		# --- Stack add: increase quantity without touching the inventory slot ---
+		var clamped_qty := mini(quantity, max_quantity - quantity_owned)
+		
+		if clamped_qty < quantity:
+			PopochiuUtils.print_warning(
+				"Couldn't add all %d of %s. Capped at max_quantity of %d."
+				% [quantity, script_name, max_quantity]
+			)
+		
+		if clamped_qty > 0:
+			var old_qty := quantity_owned
+			quantity_owned += clamped_qty
+			_on_quantity_changed(old_qty, quantity_owned)
+			PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
 		
 		await get_tree().process_frame
 		return
 	
-	if not in_inventory:
-		PopochiuUtils.g.block()
-
-		PopochiuUtils.i.items.append(script_name)
-		
-		PopochiuUtils.i.item_added.emit(self, animate)
-		in_inventory = true
-		ever_collected = true
-		
-		await PopochiuUtils.i.item_add_done
-
-		PopochiuUtils.g.unblock(true)
-
-		return
-	
+	# --- Silent no-op for max_quantity == 1 ---
+	# Back-compat guarantee: games with max_quantity = 1 (the default) often call add() from
+	# multiple code paths and expect redundant calls on an already-held item to silently do nothing.
 	await get_tree().process_frame
 
 
-## Adds this item to the inventory and makes it the active item (cursor shows the item's texture).
-## Pass [param animate] as [code]false[/code] to skip the inventory GUI animation.
+## Adds [param quantity] of this item to the inventory and makes it the active item (cursor shows
+## the item's texture). Pass [param animate] as [code]false[/code] to skip the inventory GUI
+## animation.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_add_as_active(animate := true) -> Callable:
-	return func (): await add_as_active(animate)
+func queue_add_as_active(quantity := 1, animate := true) -> Callable:
+	return func (): await add_as_active(quantity, animate)
 
 
-## Adds this item to the inventory and makes it the active item (cursor shows the item's texture).
-## Pass [param animate] as [code]false[/code] to skip the inventory GUI animation.
-func add_as_active(animate := true) -> void:
-	await add(animate)
+## Adds [param quantity] of this item to the inventory and makes it the active item (cursor shows
+## the item's texture). Pass [param animate] as [code]false[/code] to skip the inventory GUI
+## animation.
+func add_as_active(quantity := 1, animate := true) -> void:
+	await add(quantity, animate)
 	
 	PopochiuUtils.i.set_active_item(self)
 
 
-## Removes the item from the inventory (instance is kept in memory). Pass [param animate] as
-## [code]true[/code] to animate the removal in the inventory GUI.
+## Removes [param quantity] of this item from the inventory (instance is kept in memory).
+## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the full stack.
+## Pass [param animate] as [code]true[/code] to animate the removal in the inventory GUI.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 ##
@@ -168,12 +232,13 @@ func add_as_active(animate := true) -> void:
 ##             I.ToyCar.queue_remove()
 ##         ])
 ## [/codeblock]
-func queue_remove(animate := false) -> Callable:
-	return func (): await remove(animate)
+func queue_remove(quantity: int = 0, animate := false) -> Callable:
+	return func (): await remove(quantity, animate)
 
 
-## Removes the item from the inventory (instance is kept in memory). Pass [param animate] as
-## [code]true[/code] to animate the removal in the inventory GUI.
+## Removes [param quantity] of this item from the inventory (instance is kept in memory).
+## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the full stack.
+## Pass [param animate] as [code]true[/code] to animate the removal in the inventory GUI.
 ##
 ## Example:
 ## [codeblock]
@@ -182,8 +247,24 @@ func queue_remove(animate := false) -> Callable:
 ##         await C.player.say("Here is your toy car")
 ##         await I.ToyCar.remove()
 ## [/codeblock]
-func remove(animate := false) -> void:
-	in_inventory = false
+func remove(quantity: int = 0, animate := false) -> void:
+	var qty_to_remove := quantity if quantity > 0 else quantity_owned
+	
+	if quantity_owned - qty_to_remove > 0:
+		# --- Partial removal: reduce quantity without removing the inventory slot ---
+		var old_qty := quantity_owned
+		quantity_owned -= qty_to_remove
+		_on_quantity_changed(old_qty, quantity_owned)
+		PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
+		
+		await get_tree().process_frame
+		return
+	
+	# --- Full removal: tear down the inventory slot and run the full GUI lifecycle ---
+	# Assign quantity_owned directly — do NOT go through the in_inventory setter here.
+	# remove() is the lifecycle owner for full removal: it must control signal sequencing and
+	# handle g.unblock(). The setter does not emit item_removed or call g.unblock().
+	quantity_owned = 0
 	
 	PopochiuUtils.i.items.erase(script_name)
 	PopochiuUtils.i.set_active_item(null)
@@ -224,12 +305,18 @@ func queue_replace(new_item: PopochiuInventoryItem) -> Callable:
 ##         await replace(I.RopeWithHook)
 ## [/codeblock]
 func replace(new_item: PopochiuInventoryItem) -> void:
-	in_inventory = false
+	# Assign quantity_owned directly on both items; do NOT call add(), remove(), or go through
+	# the in_inventory setter. replace() orchestrates its own atomic GUI flow (item_replaced ->
+	# await item_replace_done -> g.unblock()) in a single sequence. Routing through add() would
+	# trigger a second g.block(), item_added signal, and await item_add_done, corrupting that
+	# sequence. The setter would call _on_added_to_inventory() on new_item before the GUI
+	# replacement animation is complete.
+	quantity_owned = 0
 	
 	PopochiuUtils.i.items.erase(script_name)
 	PopochiuUtils.i.set_active_item(null)
 	PopochiuUtils.i.items.append(new_item.script_name)
-	new_item.in_inventory = true
+	new_item.quantity_owned = 1
 	
 	PopochiuUtils.i.item_replaced.emit(self, new_item)
 	
@@ -255,10 +342,13 @@ func queue_discard(animate := false) -> Callable:
 func discard(animate := false) -> void:
 	_on_discard()
 	
-	PopochiuUtils.i.items.erase(script_name)
+	# refs #349: The manual items.erase() that was here has been removed. It was a latent bug:
+	# remove() already erases this item from items[] as part of its own lifecycle, so the
+	# double-erase was causing item_removed to be emitted before the GUI animation had a
+	# chance to complete. This is a more robust fix than the original workaround.
 	PopochiuUtils.i.item_discarded.emit(self)
 	
-	await remove(animate)
+	await remove(0, animate)
 
 
 ## Makes this item the current active item (the cursor will look like the item's texture).
@@ -347,10 +437,10 @@ func count_invoked(command: int) -> int:
 #endregion
 
 #region SetGet #####################################################################################
-func set_in_inventory(value: bool) -> void:
-	in_inventory = value
-	
-	if in_inventory: _on_added_to_inventory()
+func set_max_quantity(value: int) -> void:
+	# Clamp to a minimum of 1: a value below 1 would make the item permanently un-addable
+	# and break the first-add vs. stacking logic inside add().
+	max_quantity = max(1, value)
 
 
 func set_ever_collected(value: bool) -> void:
@@ -372,6 +462,20 @@ func get_description() -> String:
 #endregion
 
 #region Private ####################################################################################
+# This setter MUST NOT call add() or any other public method. GUI components
+# inventory_bar.gd and simple_click_bar.gd both assign in_inventory = true during scene
+# _ready() to re-register items that were placed in the scene manually. Those calls expect
+# zero side-effects: no g.block(), no item_added signal, no await item_add_done. Routing
+# through add() here would corrupt GUI state during initialisation.
+func _set_in_inventory(value: bool) -> void:
+	if value:
+		if quantity_owned == 0:
+			quantity_owned = 1
+			_on_added_to_inventory()
+	else:
+		quantity_owned = 0
+
+
 # Increments the usage count for the specified command
 func _increment_command_count(command_id: int) -> void:
 	_command_usage_count.get_or_add(command_id, 0)

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -108,9 +108,9 @@ func _on_quantity_changed(_old_qty: int, _new_qty: int) -> void:
 #endregion
 
 #region Public #####################################################################################
-## Adds [param quantity] of this item to the inventory. If [param animate] is [code]true[/code],
-## the inventory GUI shows an animation for the first add only; subsequent stack additions do not
-## animate. [param quantity] defaults to [code]1[/code].
+## Adds [param quantity] of this item to the inventory. [param quantity] defaults to [code]1[/code].
+## On first add, the GUI shows an entrance animation; subsequent stack additions only emit
+## [signal PopochiuIInventory.item_quantity_updated].
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 ##
@@ -123,13 +123,13 @@ func _on_quantity_changed(_old_qty: int, _new_qty: int) -> void:
 ##         I.Key.queue_add()
 ##     ])
 ## [/codeblock]
-func queue_add(quantity := 1, animate := true) -> Callable:
-	return func (): await add(quantity, animate)
+func queue_add(quantity := 1) -> Callable:
+	return func (): await add(quantity)
 
 
 ## Adds [param quantity] of this item to the inventory. [param quantity] defaults to [code]1[/code].
-## If [param animate] is [code]true[/code], the inventory GUI shows an animation (only on the first
-## add; subsequent stack additions only emit [signal PopochiuIInventory.item_quantity_updated]).
+## On first add, the GUI shows an entrance animation; subsequent stack additions only emit
+## [signal PopochiuIInventory.item_quantity_updated].
 ##
 ## Example:
 ## [codeblock]
@@ -140,86 +140,38 @@ func queue_add(quantity := 1, animate := true) -> Callable:
 ##     # Add three coins at once:
 ##     await I.Coin.add(3)
 ## [/codeblock]
-func add(quantity := 1, animate := true) -> void:
-	if quantity_owned == 0:
-		# --- First add: create the inventory slot and run the full GUI lifecycle ---
-		if PopochiuUtils.i.is_full():
-			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
-			
-			await get_tree().process_frame
-			return
-		
+func add(quantity := 1) -> void:
+	var is_first_add := _do_add(quantity)
+	
+	if is_first_add:
 		PopochiuUtils.g.block()
-		
-		PopochiuUtils.i.items.append(script_name)
-		
-		PopochiuUtils.i.item_added.emit(self, animate)
-		# Assign quantity_owned directly — do NOT go through the in_inventory setter here.
-		# add() is the lifecycle owner for first-add: it has already handled g.block(),
-		# item_added, and the await sequence below. Going through the setter would call
-		# _on_added_to_inventory() a second time and cannot represent a quantity > 1.
-		# Clamp to max_quantity even on first add: the caller may request more than allowed.
-		var clamped_qty := mini(quantity, max_quantity)
-		if clamped_qty < quantity:
-			PopochiuUtils.print_warning(
-				"Couldn't add all %d of %s. Capped at max_quantity of %d."
-				% [quantity, script_name, max_quantity]
-			)
-		quantity_owned = clamped_qty
-		ever_collected = true
-		_on_added_to_inventory()
-
+		PopochiuUtils.i.item_added.emit(self)
 		await PopochiuUtils.i.item_add_done
-
 		PopochiuUtils.g.unblock(true)
 		return
 	
-	if max_quantity > 1:
-		# --- Stack add: increase quantity without touching the inventory slot ---
-		var clamped_qty := mini(quantity, max_quantity - quantity_owned)
-		
-		if clamped_qty < quantity:
-			PopochiuUtils.print_warning(
-				"Couldn't add all %d of %s. Capped at max_quantity of %d."
-				% [quantity, script_name, max_quantity]
-			)
-		
-		if clamped_qty > 0:
-			var old_qty := quantity_owned
-			quantity_owned += clamped_qty
-			_on_quantity_changed(old_qty, quantity_owned)
-			PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
-		
-		await get_tree().process_frame
-		return
-	
-	# --- Silent no-op for max_quantity == 1 ---
-	# Back-compat guarantee: games with max_quantity = 1 (the default) often call add() from
-	# multiple code paths and expect redundant calls on an already-held item to silently do nothing.
 	await get_tree().process_frame
 
 
 ## Adds [param quantity] of this item to the inventory and makes it the active item (cursor shows
-## the item's texture). Pass [param animate] as [code]false[/code] to skip the inventory GUI
-## animation.
+## the item's texture).
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_add_as_active(quantity := 1, animate := true) -> Callable:
-	return func (): await add_as_active(quantity, animate)
+func queue_add_as_active(quantity := 1) -> Callable:
+	return func (): await add_as_active(quantity)
 
 
 ## Adds [param quantity] of this item to the inventory and makes it the active item (cursor shows
-## the item's texture). Pass [param animate] as [code]false[/code] to skip the inventory GUI
-## animation.
-func add_as_active(quantity := 1, animate := true) -> void:
-	await add(quantity, animate)
+## the item's texture).
+func add_as_active(quantity := 1) -> void:
+	await add(quantity)
 	
 	PopochiuUtils.i.set_active_item(self)
 
 
 ## Removes [param quantity] of this item from the inventory (instance is kept in memory).
-## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the full stack.
-## Pass [param animate] as [code]true[/code] to animate the removal in the inventory GUI.
+## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the
+## full stack.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 ##
@@ -232,13 +184,13 @@ func add_as_active(quantity := 1, animate := true) -> void:
 ##             I.ToyCar.queue_remove()
 ##         ])
 ## [/codeblock]
-func queue_remove(quantity: int = 0, animate := false) -> Callable:
-	return func (): await remove(quantity, animate)
+func queue_remove(quantity: int = 0) -> Callable:
+	return func (): await remove(quantity)
 
 
 ## Removes [param quantity] of this item from the inventory (instance is kept in memory).
-## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the full stack.
-## Pass [param animate] as [code]true[/code] to animate the removal in the inventory GUI.
+## Call without params or pass [param quantity] as [code]0[/code] (the default) to remove the
+## full stack.
 ##
 ## Example:
 ## [codeblock]
@@ -247,33 +199,16 @@ func queue_remove(quantity: int = 0, animate := false) -> Callable:
 ##         await C.player.say("Here is your toy car")
 ##         await I.ToyCar.remove()
 ## [/codeblock]
-func remove(quantity: int = 0, animate := false) -> void:
-	var qty_to_remove := quantity if quantity > 0 else quantity_owned
+func remove(quantity: int = 0) -> void:
+	var is_full_removal := _do_remove(quantity)
 	
-	if quantity_owned - qty_to_remove > 0:
-		# --- Partial removal: reduce quantity without removing the inventory slot ---
-		var old_qty := quantity_owned
-		quantity_owned -= qty_to_remove
-		_on_quantity_changed(old_qty, quantity_owned)
-		PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
-		
-		await get_tree().process_frame
+	if is_full_removal:
+		PopochiuUtils.i.item_removed.emit(self)
+		await PopochiuUtils.i.item_remove_done
+		PopochiuUtils.g.unblock()
 		return
 	
-	# --- Full removal: tear down the inventory slot and run the full GUI lifecycle ---
-	# Assign quantity_owned directly — do NOT go through the in_inventory setter here.
-	# remove() is the lifecycle owner for full removal: it must control signal sequencing and
-	# handle g.unblock(). The setter does not emit item_removed or call g.unblock().
-	quantity_owned = 0
-	
-	PopochiuUtils.i.items.erase(script_name)
-	PopochiuUtils.i.set_active_item(null)
-	# TODO: Maybe this signal should be triggered once the await has finished
-	PopochiuUtils.i.item_removed.emit(self, animate)
-	
-	await PopochiuUtils.i.item_remove_done
-	
-	PopochiuUtils.g.unblock()
+	await get_tree().process_frame
 
 
 ## Replaces this inventory item with [param new_item]. Useful when combining items.
@@ -305,18 +240,11 @@ func queue_replace(new_item: PopochiuInventoryItem) -> Callable:
 ##         await replace(I.RopeWithHook)
 ## [/codeblock]
 func replace(new_item: PopochiuInventoryItem) -> void:
-	# Assign quantity_owned directly on both items; do NOT call add(), remove(), or go through
-	# the in_inventory setter. replace() orchestrates its own atomic GUI flow (item_replaced ->
-	# await item_replace_done -> g.unblock()) in a single sequence. Routing through add() would
-	# trigger a second g.block(), item_added signal, and await item_add_done, corrupting that
-	# sequence. The setter would call _on_added_to_inventory() on new_item before the GUI
-	# replacement animation is complete.
-	quantity_owned = 0
-	
-	PopochiuUtils.i.items.erase(script_name)
-	PopochiuUtils.i.set_active_item(null)
-	PopochiuUtils.i.items.append(new_item.script_name)
-	new_item.quantity_owned = 1
+	# Use the synchronous data helpers so replace() can orchestrate its own single GUI flow
+	# (item_replaced -> await item_replace_done -> g.unblock()) without triggering the separate
+	# block/signal/await sequences that the public add()/remove() methods would.
+	_do_remove(0)
+	new_item._do_add(1)
 	
 	PopochiuUtils.i.item_replaced.emit(self, new_item)
 	
@@ -327,28 +255,28 @@ func replace(new_item: PopochiuInventoryItem) -> void:
 	PopochiuUtils.g.unblock()
 
 
-# NOTE: Maybe this is not necessary since we can have the same with [method queue_remove].
-## Removes the item from the inventory without destroying the instance. Pass [param animate] as
-## [code]true[/code] to animate the removal in the inventory GUI.
+# @deprecated Available in 2.1 - Will be removed in 2.1.
+#
+## Use [method queue_remove] instead.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
-func queue_discard(animate := false) -> Callable:
-	return func (): await discard(animate)
+func queue_discard(quantity: int = 0) -> Callable:
+	return func (): await discard(quantity)
 
 
-# NOTE: Maybe this is not necessary since we can have the same with [method remove].
-## Removes the item from the inventory without destroying the instance. Pass [param animate] as
-## [code]true[/code] to animate the removal in the inventory GUI.
-func discard(animate := false) -> void:
+# @deprecated Available in 2.1 - Will be removed in 2.2.
+#
+## Use [method remove] instead. Calls [method _on_discard] and emits
+## [signal PopochiuIInventory.item_discarded] before delegating to [method remove].
+func discard(quantity: int = 0) -> void:
+	PopochiuUtils.print_warning(
+		"discard() is deprecated and will be removed in Popochiu 2.3."
+		+ " Use remove() instead."
+	)
 	_on_discard()
-	
-	# refs #349: The manual items.erase() that was here has been removed. It was a latent bug:
-	# remove() already erases this item from items[] as part of its own lifecycle, so the
-	# double-erase was causing item_removed to be emitted before the GUI animation had a
-	# chance to complete. This is a more robust fix than the original workaround.
 	PopochiuUtils.i.item_discarded.emit(self)
 	
-	await remove(0, animate)
+	await remove(quantity)
 
 
 ## Makes this item the current active item (the cursor will look like the item's texture).
@@ -462,11 +390,11 @@ func get_description() -> String:
 #endregion
 
 #region Private ####################################################################################
-# This setter MUST NOT call add() or any other public method. GUI components
-# inventory_bar.gd and simple_click_bar.gd both assign in_inventory = true during scene
+# Minimal setter for GUI scene initialisation. Does NOT call _do_add()/_do_remove() because
+# GUI components inventory_bar.gd and simple_click_bar.gd both assign in_inventory = true during scene
 # _ready() to re-register items that were placed in the scene manually. Those calls expect
-# zero side-effects: no g.block(), no item_added signal, no await item_add_done. Routing
-# through add() here would corrupt GUI state during initialisation.
+# zero side-effects: no g.block(), no item_added signal, no await item_add_done.
+# Also, scene-placed items must skip the is_full() check and items[] registration. 
 func _set_in_inventory(value: bool) -> void:
 	if value:
 		if quantity_owned == 0:
@@ -474,6 +402,67 @@ func _set_in_inventory(value: bool) -> void:
 			_on_added_to_inventory()
 	else:
 		quantity_owned = 0
+
+
+# Returns the number of items that can actually be added, clamping to max_quantity and logging
+# a warning if the requested amount was reduced.
+func _clamp_add_quantity(requested: int) -> int:
+	var actual := mini(requested, max_quantity - quantity_owned)
+	if actual < requested:
+		PopochiuUtils.print_warning(
+			"Couldn't add all %d of %s. Capped at max_quantity of %d."
+			% [requested, script_name, max_quantity]
+		)
+	return actual
+
+
+# Synchronous data mutation for adding items. Returns true if this was a first-add (a new
+# inventory slot was created), false for a stack-add or silent no-op.
+func _do_add(quantity: int) -> bool:
+	if quantity_owned == 0:
+		if PopochiuUtils.i.is_full():
+			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
+			return false
+		
+		var actual := _clamp_add_quantity(quantity)
+		PopochiuUtils.i.items.append(script_name)
+		quantity_owned = actual
+		ever_collected = true
+		_on_added_to_inventory()
+		return true
+	
+	if max_quantity > 1:
+		var actual := _clamp_add_quantity(quantity)
+		if actual > 0:
+			var old_qty := quantity_owned
+			quantity_owned += actual
+			_on_quantity_changed(old_qty, quantity_owned)
+			PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
+		return false
+	
+	# Silent no-op for max_quantity == 1: back-compat guarantee for games that call add()
+	# from multiple code paths on an already-held item.
+	return false
+
+
+# Synchronous data mutation for removing items. Returns true if the item was fully removed
+# from its inventory slot, false for a partial removal or no-op.
+func _do_remove(quantity: int) -> bool:
+	var qty_to_remove := quantity if quantity > 0 else quantity_owned
+	
+	if qty_to_remove >= quantity_owned:
+		# Full removal
+		quantity_owned = 0
+		PopochiuUtils.i.items.erase(script_name)
+		PopochiuUtils.i.set_active_item(null)
+		return true
+	
+	# Partial removal
+	var old_qty := quantity_owned
+	quantity_owned -= qty_to_remove
+	_on_quantity_changed(old_qty, quantity_owned)
+	PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
+	return false
 
 
 # Increments the usage count for the specified command

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -141,16 +141,7 @@ func queue_add(quantity := 1) -> Callable:
 ##     await I.Coin.add(3)
 ## [/codeblock]
 func add(quantity := 1) -> void:
-	var is_first_add := _do_add(quantity)
-	
-	if is_first_add:
-		PopochiuUtils.g.block()
-		PopochiuUtils.i.item_added.emit(self)
-		await PopochiuUtils.i.item_add_done
-		PopochiuUtils.g.unblock(true)
-		return
-	
-	await get_tree().process_frame
+	await PopochiuUtils.i.add_item(self, quantity)
 
 
 ## Adds [param quantity] of this item to the inventory and makes it the active item (cursor shows
@@ -200,15 +191,7 @@ func queue_remove(quantity: int = 0) -> Callable:
 ##         await I.ToyCar.remove()
 ## [/codeblock]
 func remove(quantity: int = 0) -> void:
-	var is_full_removal := _do_remove(quantity)
-	
-	if is_full_removal:
-		PopochiuUtils.i.item_removed.emit(self)
-		await PopochiuUtils.i.item_remove_done
-		PopochiuUtils.g.unblock()
-		return
-	
-	await get_tree().process_frame
+	await PopochiuUtils.i.remove_item(self, quantity)
 
 
 ## Replaces this inventory item with [param new_item]. Useful when combining items.
@@ -240,22 +223,10 @@ func queue_replace(new_item: PopochiuInventoryItem) -> Callable:
 ##         await replace(I.RopeWithHook)
 ## [/codeblock]
 func replace(new_item: PopochiuInventoryItem) -> void:
-	# Use the synchronous data helpers so replace() can orchestrate its own single GUI flow
-	# (item_replaced -> await item_replace_done -> g.unblock()) without triggering the separate
-	# block/signal/await sequences that the public add()/remove() methods would.
-	_do_remove(0)
-	new_item._do_add(1)
-	
-	PopochiuUtils.i.item_replaced.emit(self, new_item)
-	
-	await PopochiuUtils.i.item_replace_done
-	
-	# NOTE: Inventory items should not be in charge of handling the GUI unblock. This should be
-	# 		done by the GUI itself.
-	PopochiuUtils.g.unblock()
+	await PopochiuUtils.i.replace_item(self, new_item)
 
 
-# @deprecated Available in 2.1 - Will be removed in 2.1.
+# @deprecated Available in 2.1 - Will be removed in 2.2.
 #
 ## Use [method queue_remove] instead.
 ##
@@ -270,7 +241,7 @@ func queue_discard(quantity: int = 0) -> Callable:
 ## [signal PopochiuIInventory.item_discarded] before delegating to [method remove].
 func discard(quantity: int = 0) -> void:
 	PopochiuUtils.print_warning(
-		"discard() is deprecated and will be removed in Popochiu 2.3."
+		"discard() is deprecated and will be removed in Popochiu 2.2."
 		+ " Use remove() instead."
 	)
 	_on_discard()
@@ -390,79 +361,15 @@ func get_description() -> String:
 #endregion
 
 #region Private ####################################################################################
-# Minimal setter for GUI scene initialisation. Does NOT call _do_add()/_do_remove() because
-# GUI components inventory_bar.gd and simple_click_bar.gd both assign in_inventory = true during scene
-# _ready() to re-register items that were placed in the scene manually. Those calls expect
-# zero side-effects: no g.block(), no item_added signal, no await item_add_done.
-# Also, scene-placed items must skip the is_full() check and items[] registration. 
+# Deprecated compatibility setter. This keeps the old silent state-toggling semantics, but new
+# code should use add()/remove() for gameplay flows or PopochiuIInventory.register_existing_item()
+# for GUI bootstrap registration.
 func _set_in_inventory(value: bool) -> void:
-	if value:
-		if quantity_owned == 0:
-			quantity_owned = 1
-			_on_added_to_inventory()
-	else:
-		quantity_owned = 0
-
-
-# Returns the number of items that can actually be added, clamping to max_quantity and logging
-# a warning if the requested amount was reduced.
-func _clamp_add_quantity(requested: int) -> int:
-	var actual := mini(requested, max_quantity - quantity_owned)
-	if actual < requested:
-		PopochiuUtils.print_warning(
-			"Couldn't add all %d of %s. Capped at max_quantity of %d."
-			% [requested, script_name, max_quantity]
-		)
-	return actual
-
-
-# Synchronous data mutation for adding items. Returns true if this was a first-add (a new
-# inventory slot was created), false for a stack-add or silent no-op.
-func _do_add(quantity: int) -> bool:
-	if quantity_owned == 0:
-		if PopochiuUtils.i.is_full():
-			PopochiuUtils.print_error("Couldn't add %s. Inventory is full." % script_name)
-			return false
-		
-		var actual := _clamp_add_quantity(quantity)
-		PopochiuUtils.i.items.append(script_name)
-		quantity_owned = actual
-		ever_collected = true
-		_on_added_to_inventory()
-		return true
-	
-	if max_quantity > 1:
-		var actual := _clamp_add_quantity(quantity)
-		if actual > 0:
-			var old_qty := quantity_owned
-			quantity_owned += actual
-			_on_quantity_changed(old_qty, quantity_owned)
-			PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
-		return false
-	
-	# Silent no-op for max_quantity == 1: back-compat guarantee for games that call add()
-	# from multiple code paths on an already-held item.
-	return false
-
-
-# Synchronous data mutation for removing items. Returns true if the item was fully removed
-# from its inventory slot, false for a partial removal or no-op.
-func _do_remove(quantity: int) -> bool:
-	var qty_to_remove := quantity if quantity > 0 else quantity_owned
-	
-	if qty_to_remove >= quantity_owned:
-		# Full removal
-		quantity_owned = 0
-		PopochiuUtils.i.items.erase(script_name)
-		PopochiuUtils.i.set_active_item(null)
-		return true
-	
-	# Partial removal
-	var old_qty := quantity_owned
-	quantity_owned -= qty_to_remove
-	_on_quantity_changed(old_qty, quantity_owned)
-	PopochiuUtils.i.item_quantity_updated.emit(self, quantity_owned)
-	return false
+	PopochiuUtils.print_warning(
+		"Direct assignment to in_inventory is deprecated and only performs a silent state"
+		+ " change. Use add()/remove() for normal inventory flow."
+	)
+	PopochiuUtils.i.set_item_in_inventory_silently(self, value)
 
 
 # Increments the usage count for the specified command

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -41,7 +41,7 @@ var quantity_owned := 0
 ## signals and does not update the inventory GUI. Use [method add] and [method remove] instead.
 var in_inventory: bool :
 	get: return quantity_owned > 0
-	set = set_in_inventory
+	set(value): set_in_inventory(value)
 ## Whether this item has ever been in the inventory. Once true, it stays true.
 var ever_collected := false : set = set_ever_collected
 ## Stores the last [enum MouseButton] pressed on this object.

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -194,7 +194,9 @@ func remove(quantity: int = 0) -> void:
 	await PopochiuUtils.i.remove_item(self, quantity)
 
 
-## Replaces this inventory item with [param new_item]. Useful when combining items.
+## Replaces this inventory item with [param new_item]. Useful when combining items. Replacing
+## removes the whole collected quantity of this item and adds exactly one quantity of
+## [param new_item].
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]
 ##
@@ -212,7 +214,9 @@ func queue_replace(new_item: PopochiuInventoryItem) -> Callable:
 	return func (): await replace(new_item)
 
 
-## Replaces this inventory item with [param new_item]. Useful when combining items.
+## Replaces this inventory item with [param new_item]. Useful when combining items. Replacing
+## removes the whole collected quantity of this item and adds exactly one quantity of
+## [param new_item].
 ##
 ## Example:
 ## [codeblock]

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -41,7 +41,7 @@ var quantity_owned := 0
 ## signals and does not update the inventory GUI. Use [method add] and [method remove] instead.
 var in_inventory: bool :
 	get: return quantity_owned > 0
-	set(value): _set_in_inventory(value)
+	set = set_in_inventory
 ## Whether this item has ever been in the inventory. Once true, it stays true.
 var ever_collected := false : set = set_ever_collected
 ## Stores the last [enum MouseButton] pressed on this object.
@@ -368,7 +368,7 @@ func get_description() -> String:
 # Deprecated compatibility setter. This keeps the old silent state-toggling semantics, but new
 # code should use add()/remove() for gameplay flows or PopochiuIInventory.register_existing_item()
 # for GUI bootstrap registration.
-func _set_in_inventory(value: bool) -> void:
+func set_in_inventory(value: bool) -> void:
 	PopochiuUtils.print_warning(
 		"Direct assignment to in_inventory is deprecated and only performs a silent state"
 		+ " change. Use add()/remove() for normal inventory flow."

--- a/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
+++ b/addons/popochiu/engine/objects/inventory_item/popochiu_inventory_item.gd
@@ -373,7 +373,7 @@ func set_in_inventory(value: bool) -> void:
 		"Direct assignment to in_inventory is deprecated and only performs a silent state"
 		+ " change. Use add()/remove() for normal inventory flow."
 	)
-	PopochiuUtils.i.set_item_in_inventory_silently(self, value)
+	PopochiuUtils.i.set_item_in_inventory_bg(self, value)
 
 
 # Increments the usage count for the specified command

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -444,12 +444,12 @@ func get_current_animation_position() -> float:
 #endregion
 
 #region Private ####################################################################################
-func _on_item_added(item: PopochiuInventoryItem, _animate: bool) -> void:
+func _on_item_added(item: PopochiuInventoryItem) -> void:
 	if item.script_name == link_to_item:
 		disable()
 
 
-func _on_item_removed(item: PopochiuInventoryItem, _animate: bool) -> void:
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
 	if item.script_name == link_to_item:
 		_on_linked_item_removed()
 		linked_item_removed.emit(self)

--- a/addons/popochiu/engine/others/popochiu_save_load.gd
+++ b/addons/popochiu/engine/others/popochiu_save_load.gd
@@ -128,6 +128,7 @@ func load_game(slot := 1) -> Dictionary:
 	
 	# Load inventory items — supports both the legacy format (Array of String) and the current
 	# format (Array of Dictionary with "name" and "qty" keys, introduced in refs #349).
+	PopochiuUtils.i.is_restoring = true
 	for entry in loaded_data.player.inventory:
 		var item_name: String
 		var qty := 1
@@ -140,7 +141,8 @@ func load_game(slot := 1) -> Dictionary:
 			qty = entry.get("qty", 1)
 		
 		if not item_name.is_empty():
-			PopochiuUtils.i.get_item_instance(item_name).add(qty, false)
+			PopochiuUtils.i.get_item_instance(item_name).add(qty)
+	PopochiuUtils.i.is_restoring = false
 	
 	# Load main object states
 	for type in ["rooms", "characters", "inventory_items", "dialogs"]:

--- a/addons/popochiu/engine/others/popochiu_save_load.gd
+++ b/addons/popochiu/engine/others/popochiu_save_load.gd
@@ -64,7 +64,7 @@ func save_game(slot := 1, description := "") -> bool:
 		description = description,
 		player = {
 			room = PopochiuUtils.r.current.script_name,
-			inventory = PopochiuUtils.i.items,
+			inventory = _build_inventory_save_data(),
 		},
 		rooms = {}, # Stores the state of each PopochiuRoomData
 		characters = {}, # Stores the state of each PopochiuCharacterData
@@ -126,9 +126,21 @@ func load_game(slot := 1) -> Dictionary:
 	test_json_conv.parse(content)
 	var loaded_data: Dictionary = test_json_conv.data
 	
-	# Load inventory items
-	for item in loaded_data.player.inventory:
-		PopochiuUtils.i.get_item_instance(item).add(false)
+	# Load inventory items — supports both the legacy format (Array of String) and the current
+	# format (Array of Dictionary with "name" and "qty" keys, introduced in refs #349).
+	for entry in loaded_data.player.inventory:
+		var item_name: String
+		var qty := 1
+		
+		if entry is String:
+			# refs #349: Legacy save format — plain string item name, assume quantity of 1.
+			item_name = entry
+		else:
+			item_name = entry.get("name", "")
+			qty = entry.get("qty", 1)
+		
+		if not item_name.is_empty():
+			PopochiuUtils.i.get_item_instance(item_name).add(qty, false)
 	
 	# Load main object states
 	for type in ["rooms", "characters", "inventory_items", "dialogs"]:
@@ -227,6 +239,21 @@ func _load_dialog_options(
 			
 			if loaded_options[opt.id].has(prop.name):
 				opt[prop.name] = loaded_options[opt.id][prop.name]
+
+
+# Builds the inventory array for the save file. Each element is a Dictionary with the item's
+# script_name and current quantity. Introduced in refs #349 (quantity support).
+# TODO: Remove this after a few versions and save only the inventory items with quantity > 0,
+# to avoid saving unnecessary data.
+func _build_inventory_save_data() -> Array:
+	var result := []
+	for item_name: String in PopochiuUtils.i.items:
+		var item := PopochiuUtils.i.get_item_instance(item_name)
+		result.append({
+			"name": item_name,
+			"qty": item.quantity_owned if is_instance_valid(item) else 1,
+		})
+	return result
 
 
 #endregion

--- a/addons/popochiu/engine/others/popochiu_save_load.gd
+++ b/addons/popochiu/engine/others/popochiu_save_load.gd
@@ -125,23 +125,16 @@ func load_game(slot := 1) -> Dictionary:
 	var test_json_conv = JSON.new()
 	test_json_conv.parse(content)
 	var loaded_data: Dictionary = test_json_conv.data
+	var player_data = loaded_data.get("player", {})
+	var inventory_entries = []
+	if player_data is Dictionary:
+		inventory_entries = player_data.get("inventory", [])
 	
 	# Load inventory items — supports both the legacy format (Array of String) and the current
 	# format (Array of Dictionary with "name" and "qty" keys, introduced in refs #349).
 	PopochiuUtils.i.is_restoring = true
-	for entry in loaded_data.player.inventory:
-		var item_name: String
-		var qty := 1
-		
-		if entry is String:
-			# refs #349: Legacy save format — plain string item name, assume quantity of 1.
-			item_name = entry
-		else:
-			item_name = entry.get("name", "")
-			qty = entry.get("qty", 1)
-		
-		if not item_name.is_empty():
-			PopochiuUtils.i.get_item_instance(item_name).add(qty)
+	for entry in inventory_entries:
+		_restore_inventory_entry(entry)
 	PopochiuUtils.i.is_restoring = false
 	
 	# Load main object states
@@ -241,6 +234,50 @@ func _load_dialog_options(
 			
 			if loaded_options[opt.id].has(prop.name):
 				opt[prop.name] = loaded_options[opt.id][prop.name]
+
+
+func _restore_inventory_entry(entry) -> void:
+	var item_name := ""
+	var qty := 1
+
+	if entry is String:
+		# refs #349: Legacy save format — plain string item name, assume quantity of 1.
+		item_name = entry
+	elif entry is Dictionary:
+		item_name = entry.get("name", "")
+		qty = entry.get("qty", 1)
+	else:
+		PopochiuUtils.print_warning(
+			"Skipping malformed inventory entry while loading a save file."
+		)
+		return
+
+	if item_name.is_empty():
+		PopochiuUtils.print_warning(
+			"Skipping inventory entry with an empty item name while loading a save file."
+		)
+		return
+
+	if typeof(qty) != TYPE_INT:
+		PopochiuUtils.print_warning(
+			"Skipping inventory entry for %s. Quantity must be an integer." % item_name
+		)
+		return
+
+	if qty <= 0:
+		PopochiuUtils.print_warning(
+			"Skipping inventory entry for %s. Quantity must be greater than 0." % item_name
+		)
+		return
+
+	var item := PopochiuUtils.i.get_item_instance(item_name)
+	if not is_instance_valid(item):
+		PopochiuUtils.print_warning(
+			"Skipping inventory entry for %s. Item could not be instantiated." % item_name
+		)
+		return
+
+	item.add(qty)
 
 
 # Builds the inventory array for the save file. Each element is a Dictionary with the item's

--- a/addons/popochiu/engine/templates/gui/gui_template.gd
+++ b/addons/popochiu/engine/templates/gui/gui_template.gd
@@ -55,6 +55,24 @@ func _on_mouse_exited_inventory_item(inventory_item: PopochiuInventoryItem) -> v
 	super(inventory_item)
 
 
+# Called when an `inventory_item` is added to the inventory.
+# `super()` delegates to the active GUI template component and waits for its transition.
+func _on_item_added(item: PopochiuInventoryItem) -> void:
+	await super(item)
+
+
+# Called when an `inventory_item` is removed from the inventory.
+# `super()` delegates to the active GUI template component and waits for its transition.
+func _on_item_removed(item: PopochiuInventoryItem) -> void:
+	await super(item)
+
+
+# Called when an inventory `item` is replaced by `new_item`.
+# `super()` delegates to the active GUI template component and waits for its transition.
+func _on_item_replaced(item: PopochiuInventoryItem, new_item: PopochiuInventoryItem) -> void:
+	await super(item, new_item)
+
+
 # Called when a dialog line is spoken by a `PopochiuCharacter` (i.e. when
 # `PopochiuCharacter.say()` is called).
 func _on_dialog_line_started() -> void:

--- a/addons/popochiu/migration/migrations/popochiu_migration_13.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_13.gd
@@ -1,0 +1,99 @@
+@tool
+class_name PopochiuMigration13
+extends PopochiuMigration
+
+const VERSION = 13
+const DESCRIPTION = "Update inventory item method signatures for quantity support (refs #349)"
+const STEPS = [
+	"Update add() calls: move animate to second argument position",
+	"Update remove() calls: move animate to second argument position",
+	"Update add_as_active() calls: move animate to second argument position",
+	"Update queue_add() calls: move animate to second argument position",
+	"Update queue_remove() calls: move animate to second argument position",
+	"Update queue_add_as_active() calls: move animate to second argument position",
+	"Replace deprecated in_inventory = true/false assignments with method calls",
+]
+
+
+#region Virtual ####################################################################################
+func _do_migration() -> bool:
+	return await PopochiuMigrationHelper.execute_migration_steps(
+		self,
+		[
+			_update_add_calls,
+			_update_remove_calls,
+			_update_add_as_active_calls,
+			_update_queue_add_calls,
+			_update_queue_remove_calls,
+			_update_queue_add_as_active_calls,
+			_replace_in_inventory_assignments,
+		]
+	)
+
+
+#endregion
+
+#region Private ####################################################################################
+## Update .add(false) and .add(true) calls: the animate argument has moved from first to second
+## position since quantity is now the first parameter. Bare .add() calls need no change.
+func _update_add_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".add(false)", to = ".add(1, false)"},
+		{from = ".add(true)", to = ".add(1, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Update .remove(false) and .remove(true) calls: the animate argument has moved from first to
+## second position since quantity is now the first parameter. Bare .remove() calls need no change.
+func _update_remove_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".remove(false)", to = ".remove(0, false)"},
+		{from = ".remove(true)", to = ".remove(0, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Update .add_as_active() calls: animate moves from first to second position.
+func _update_add_as_active_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".add_as_active(false)", to = ".add_as_active(1, false)"},
+		{from = ".add_as_active(true)", to = ".add_as_active(1, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Update .queue_add() calls: animate moves from first to second position.
+func _update_queue_add_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".queue_add(false)", to = ".queue_add(1, false)"},
+		{from = ".queue_add(true)", to = ".queue_add(1, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Update .queue_remove() calls: animate moves from first to second position.
+func _update_queue_remove_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".queue_remove(false)", to = ".queue_remove(0, false)"},
+		{from = ".queue_remove(true)", to = ".queue_remove(0, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Update .queue_add_as_active() calls: animate moves from first to second position.
+func _update_queue_add_as_active_calls() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = ".queue_add_as_active(false)", to = ".queue_add_as_active(1, false)"},
+		{from = ".queue_add_as_active(true)", to = ".queue_add_as_active(1, true)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+## Replace the deprecated in_inventory assignments with the proper method calls.
+## in_inventory = true  → await add(1, false)  (background add, matching old direct-assign behaviour)
+## in_inventory = false → await remove(0, false) (background full removal, matching old behaviour)
+## Note: the replacements use await because add() and remove() are coroutines. If the calling
+## function is not already async, Godot will issue a warning, but the call will still work.
+func _replace_in_inventory_assignments() -> Completion:
+	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
+		{from = "in_inventory = true", to = "await add(1, false)"},
+		{from = "in_inventory = false", to = "await remove(0, false)"},
+	], ["autoloads"]) else Completion.IGNORED
+
+
+#endregion

--- a/addons/popochiu/migration/migrations/popochiu_migration_13.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_13.gd
@@ -5,12 +5,11 @@ extends PopochiuMigration
 const VERSION = 13
 const DESCRIPTION = "Update inventory item method signatures for quantity support (refs #349)"
 const STEPS = [
-	"Update add() calls: move animate to second argument position",
-	"Update remove() calls: move animate to second argument position",
-	"Update add_as_active() calls: move animate to second argument position",
-	"Update queue_add() calls: move animate to second argument position",
-	"Update queue_remove() calls: move animate to second argument position",
-	"Update queue_add_as_active() calls: move animate to second argument position",
+	"Strip animate param from add()/add_as_active() calls",
+	"Strip animate param from remove() calls",
+	"Strip animate param from queue_add()/queue_add_as_active() calls",
+	"Strip animate param from queue_remove() calls",
+	"Strip animate param from discard()/queue_discard() calls",
 	"Replace deprecated in_inventory = true/false assignments with method calls",
 ]
 
@@ -20,12 +19,11 @@ func _do_migration() -> bool:
 	return await PopochiuMigrationHelper.execute_migration_steps(
 		self,
 		[
-			_update_add_calls,
-			_update_remove_calls,
-			_update_add_as_active_calls,
-			_update_queue_add_calls,
-			_update_queue_remove_calls,
-			_update_queue_add_as_active_calls,
+			_strip_animate_from_add_calls,
+			_strip_animate_from_remove_calls,
+			_strip_animate_from_queue_add_calls,
+			_strip_animate_from_queue_remove_calls,
+			_strip_animate_from_discard_calls,
 			_replace_in_inventory_assignments,
 		]
 	)
@@ -34,65 +32,62 @@ func _do_migration() -> bool:
 #endregion
 
 #region Private ####################################################################################
-## Update .add(false) and .add(true) calls: the animate argument has moved from first to second
-## position since quantity is now the first parameter. Bare .add() calls need no change.
-func _update_add_calls() -> Completion:
+## Strip the boolean animate param from .add() and .add_as_active() calls. The animate param has
+## been removed: GUI components now check PopochiuIInventory.is_restoring instead.
+func _strip_animate_from_add_calls() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".add(false)", to = ".add(1, false)"},
-		{from = ".add(true)", to = ".add(1, true)"},
+		{from = ".add(false)", to = ".add()"},
+		{from = ".add(true)", to = ".add()"},
+		{from = ".add_as_active(false)", to = ".add_as_active()"},
+		{from = ".add_as_active(true)", to = ".add_as_active()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 
-## Update .remove(false) and .remove(true) calls: the animate argument has moved from first to
-## second position since quantity is now the first parameter. Bare .remove() calls need no change.
-func _update_remove_calls() -> Completion:
+## Strip the boolean animate param from .remove() calls.
+func _strip_animate_from_remove_calls() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".remove(false)", to = ".remove(0, false)"},
-		{from = ".remove(true)", to = ".remove(0, true)"},
+		{from = ".remove(false)", to = ".remove()"},
+		{from = ".remove(true)", to = ".remove()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 
-## Update .add_as_active() calls: animate moves from first to second position.
-func _update_add_as_active_calls() -> Completion:
+## Strip the boolean animate param from .queue_add() and .queue_add_as_active() calls.
+func _strip_animate_from_queue_add_calls() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".add_as_active(false)", to = ".add_as_active(1, false)"},
-		{from = ".add_as_active(true)", to = ".add_as_active(1, true)"},
+		{from = ".queue_add(false)", to = ".queue_add()"},
+		{from = ".queue_add(true)", to = ".queue_add()"},
+		{from = ".queue_add_as_active(false)", to = ".queue_add_as_active()"},
+		{from = ".queue_add_as_active(true)", to = ".queue_add_as_active()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 
-## Update .queue_add() calls: animate moves from first to second position.
-func _update_queue_add_calls() -> Completion:
+## Strip the boolean animate param from .queue_remove() calls.
+func _strip_animate_from_queue_remove_calls() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".queue_add(false)", to = ".queue_add(1, false)"},
-		{from = ".queue_add(true)", to = ".queue_add(1, true)"},
+		{from = ".queue_remove(false)", to = ".queue_remove()"},
+		{from = ".queue_remove(true)", to = ".queue_remove()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 
-## Update .queue_remove() calls: animate moves from first to second position.
-func _update_queue_remove_calls() -> Completion:
+## Strip the boolean animate param from .discard() and .queue_discard() calls.
+func _strip_animate_from_discard_calls() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".queue_remove(false)", to = ".queue_remove(0, false)"},
-		{from = ".queue_remove(true)", to = ".queue_remove(0, true)"},
-	], ["autoloads"]) else Completion.IGNORED
-
-
-## Update .queue_add_as_active() calls: animate moves from first to second position.
-func _update_queue_add_as_active_calls() -> Completion:
-	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = ".queue_add_as_active(false)", to = ".queue_add_as_active(1, false)"},
-		{from = ".queue_add_as_active(true)", to = ".queue_add_as_active(1, true)"},
+		{from = ".discard(false)", to = ".discard()"},
+		{from = ".discard(true)", to = ".discard()"},
+		{from = ".queue_discard(false)", to = ".queue_discard()"},
+		{from = ".queue_discard(true)", to = ".queue_discard()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 
 ## Replace the deprecated in_inventory assignments with the proper method calls.
-## in_inventory = true  → await add(1, false)  (background add, matching old direct-assign behaviour)
-## in_inventory = false → await remove(0, false) (background full removal, matching old behaviour)
+## in_inventory = true  → await add()  (background add, matching old direct-assign behaviour)
+## in_inventory = false → await remove() (background full removal, matching old behaviour)
 ## Note: the replacements use await because add() and remove() are coroutines. If the calling
 ## function is not already async, Godot will issue a warning, but the call will still work.
 func _replace_in_inventory_assignments() -> Completion:
 	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = "in_inventory = true", to = "await add(1, false)"},
-		{from = "in_inventory = false", to = "await remove(0, false)"},
+		{from = "in_inventory = true", to = "await add()"},
+		{from = "in_inventory = false", to = "await remove()"},
 	], ["autoloads"]) else Completion.IGNORED
 
 

--- a/addons/popochiu/migration/migrations/popochiu_migration_13.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_13.gd
@@ -10,7 +10,7 @@ const STEPS = [
 	"Strip animate param from queue_add()/queue_add_as_active() calls",
 	"Strip animate param from queue_remove() calls",
 	"Strip animate param from discard()/queue_discard() calls",
-	"Replace deprecated in_inventory = true/false assignments with method calls",
+	"Warn about deprecated in_inventory = true/false assignments that need manual migration",
 ]
 
 
@@ -24,7 +24,7 @@ func _do_migration() -> bool:
 			_strip_animate_from_queue_add_calls,
 			_strip_animate_from_queue_remove_calls,
 			_strip_animate_from_discard_calls,
-			_replace_in_inventory_assignments,
+			_warn_about_in_inventory_assignments,
 		]
 	)
 
@@ -79,16 +79,41 @@ func _strip_animate_from_discard_calls() -> Completion:
 	], ["autoloads"]) else Completion.IGNORED
 
 
-## Replace the deprecated in_inventory assignments with the proper method calls.
-## in_inventory = true  → await add()  (background add, matching old direct-assign behaviour)
-## in_inventory = false → await remove() (background full removal, matching old behaviour)
-## Note: the replacements use await because add() and remove() are coroutines. If the calling
-## function is not already async, Godot will issue a warning, but the call will still work.
-func _replace_in_inventory_assignments() -> Completion:
-	return Completion.DONE if PopochiuMigrationHelper.replace_in_scripts([
-		{from = "in_inventory = true", to = "await add()"},
-		{from = "in_inventory = false", to = "await remove()"},
-	], ["autoloads"]) else Completion.IGNORED
+## Warn about deprecated direct in_inventory assignments.
+## Direct assignment now emits a runtime deprecation warning but still performs a silent state
+## change. Rewriting it automatically to add()/remove() would change GUI timing and side effects,
+## so this migration only reports the files that need manual review.
+func _warn_about_in_inventory_assignments() -> Completion:
+	var script_paths: Array = PopochiuMigrationHelper.get_absolute_file_paths_for_file_extensions(
+		PopochiuResources.GAME_PATH,
+		["gd"],
+		["autoloads"]
+	)
+	var matching_files: Array[String] = []
+
+	for file_path: String in script_paths:
+		if (
+			PopochiuMigrationHelper.is_text_in_file("in_inventory = true", file_path)
+			or PopochiuMigrationHelper.is_text_in_file("in_inventory = false", file_path)
+		):
+			matching_files.append(file_path)
+
+	if matching_files.is_empty():
+		return Completion.IGNORED
+
+	var files_list := ""
+	for file_path: String in matching_files:
+		files_list += "\n- %s" % file_path
+
+	PopochiuUtils.print_warning(
+		"Migration %d: Found deprecated in_inventory assignments that require manual review.%s\n"
+		+ "Direct assignment still works as a silent state change, while add()/remove() now run "
+		+ "the full inventory GUI lifecycle. Replace each usage intentionally based on the "
+		+ "desired behaviour."
+		% [VERSION, files_list]
+	)
+
+	return Completion.DONE
 
 
 #endregion

--- a/addons/popochiu/migration/migrations/popochiu_migration_13.gd.uid
+++ b/addons/popochiu/migration/migrations/popochiu_migration_13.gd.uid
@@ -1,0 +1,1 @@
+uid://fhue3gvg54l0

--- a/addons/popochiu/migration/migrations/popochiu_migration_14.gd
+++ b/addons/popochiu/migration/migrations/popochiu_migration_14.gd
@@ -1,0 +1,138 @@
+@tool
+class_name PopochiuMigration14
+extends PopochiuMigration
+
+const VERSION = 14
+const DESCRIPTION = "Normalize GUI inventory component unique names"
+const STEPS = [
+	"Normalize copied GUI inventory component node names and unique-name flags",
+]
+const COMPONENT_SCENES := [
+	{
+		path = "res://game/gui/components/9_verb_panel/9_verb_panel.tscn",
+		current_name = "9VerbInventoryGrid",
+		target_name = "9VerbInventoryGrid",
+	},
+	{
+		path = "res://game/gui/components/9_verb_panel_high_res/9_verb_panel_high_res.tscn",
+		current_name = "9VerbInventoryGridHighRes",
+		target_name = "9VerbInventoryGrid",
+	},
+	{
+		path = "res://game/gui/components/sierra_inventory_popup/sierra_inventory_popup.tscn",
+		current_name = "SierraInventoryGrid",
+		target_name = "SierraInventoryGrid",
+	},
+	{
+		path = "res://game/gui/components/sierra_inventory_popup_high_res/sierra_inventory_popup_high_res.tscn",
+		current_name = "SierraInventoryGridHighRes",
+		target_name = "SierraInventoryGrid",
+	},
+	{
+		path = "res://game/gui/components/simple_click_bar/simple_click_bar.tscn",
+		current_name = "SimpleClickBar",
+		target_name = "SimpleClickBar",
+	},
+	{
+		path = "res://game/gui/components/simple_click_bar_high_res/simple_click_bar_high_res.tscn",
+		current_name = "SimpleClickBarHighRes",
+		target_name = "SimpleClickBar",
+	},
+]
+
+
+#region Virtual ####################################################################################
+func _is_migration_needed() -> bool:
+	for scene_data: Dictionary in COMPONENT_SCENES:
+		var node := _get_inventory_component_node(scene_data.path, scene_data.current_name, scene_data.target_name)
+		if not is_instance_valid(node):
+			continue
+
+		if node.name != scene_data.target_name or not node.unique_name_in_owner:
+			return true
+
+	return false
+
+
+func _do_migration() -> bool:
+	return await PopochiuMigrationHelper.execute_migration_steps(
+		self,
+		[_normalize_inventory_component_unique_names]
+	)
+
+
+#endregion
+
+#region Private ####################################################################################
+func _normalize_inventory_component_unique_names() -> Completion:
+	var updated_any := false
+
+	for scene_data: Dictionary in COMPONENT_SCENES:
+		if not FileAccess.file_exists(scene_data.path):
+			continue
+
+		var packed_scene := ResourceLoader.load(
+			scene_data.path, "", ResourceLoader.CACHE_MODE_IGNORE
+		) as PackedScene
+		if not packed_scene:
+			PopochiuUtils.print_error(
+				"Migration %d: Couldn't load GUI component scene %s" % [VERSION, scene_data.path]
+			)
+			return Completion.FAILED
+
+		var scene := packed_scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
+		var node := _find_inventory_component_node(
+			scene, scene_data.current_name, scene_data.target_name
+		)
+		if not is_instance_valid(node):
+			continue
+
+		var changed := false
+		if node.name != scene_data.target_name:
+			node.name = scene_data.target_name
+			changed = true
+
+		if not node.unique_name_in_owner:
+			node.unique_name_in_owner = true
+			changed = true
+
+		if not changed:
+			continue
+
+		if PopochiuEditorHelper.pack_scene(scene, scene_data.path) != OK:
+			PopochiuUtils.print_error(
+				"Migration %d: Couldn't update GUI component scene %s" % [VERSION, scene_data.path]
+			)
+			return Completion.FAILED
+
+		updated_any = true
+
+	return Completion.DONE if updated_any else Completion.IGNORED
+
+
+func _get_inventory_component_node(
+	scene_path: String, current_name: String, target_name: String
+) -> Node:
+	if not FileAccess.file_exists(scene_path):
+		return null
+
+	var packed_scene := ResourceLoader.load(scene_path, "", ResourceLoader.CACHE_MODE_IGNORE) as PackedScene
+	if not packed_scene:
+		return null
+
+	var scene := packed_scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
+	return _find_inventory_component_node(scene, current_name, target_name)
+
+
+func _find_inventory_component_node(scene: Node, current_name: String, target_name: String) -> Node:
+	if scene.name == current_name or scene.name == target_name:
+		return scene
+
+	var node := scene.find_child(target_name, true, false)
+	if is_instance_valid(node):
+		return node
+
+	return scene.find_child(current_name, true, false)
+
+
+#endregion

--- a/addons/popochiu/migration/migrations/popochiu_migration_14.gd.uid
+++ b/addons/popochiu/migration/migrations/popochiu_migration_14.gd.uid
@@ -1,0 +1,1 @@
+uid://dx48athcs5lfg

--- a/docs/src/the-engine-handbook/scripting-principles.md
+++ b/docs/src/the-engine-handbook/scripting-principles.md
@@ -473,7 +473,7 @@ func _on_any_character_spoke(character: PopochiuCharacter, message: String) -> v
 # React when an item is added to the inventory
 I.item_added.connect(_on_item_collected)
 
-func _on_item_collected(item: PopochiuInventoryItem, _animate: bool) -> void:
+func _on_item_collected(item: PopochiuInventoryItem) -> void:
     if item == I.GoldenKey:
         await C.player.say("This could open something important...")
 ```


### PR DESCRIPTION
This PR reworks how "adding to the inventory" works under the hood in a way that allows addition of single quantity items, but also supports "quantity" for items in a specific inventory slots.

For the most part, this is about engine and game devs API, with nothing about visual clues: no counters, no single/multiple items dedicated icons for the inventory items, etc, so it's candidate for some future improvements, but at least, it allows devs to support this much wanted feature out of the box.
Visual clues may be managed with some non-obstrusive strategies in the custom GUI, at the moment.

**IMPORTANT NOTE:** the last commit in this PR introduces an API change by removing the "animate" params from add/remove/replace calls, in a first attempt to solve a strong coupling problem I have found in the Engine/GUI relationship design (see #510). A migration is there to address this, too.

That commit also contains some overall refactoring (my bad, it's a bit too much of a commit) so I can either split the breaking change out of it or we can accept it and go on with a cleaner interface for now.