### PR TITLE
refs #521: Implement blocking regions

### DIFF
--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -51,6 +51,9 @@ signal obstacle_state_changed(character: PopochiuCharacter)
 ## Emitted during movement when the character's position changes.
 ## Only emitted while the character is moving and the position has actually changed from the last emission.
 signal position_updated(character: PopochiuCharacter, current_position: Vector2)
+## Emitted when this character's movement is interrupted because it tried to enter a
+## [PopochiuRegion] with [member PopochiuRegion.walkable] set to [code]false[/code].
+signal blocked_by_region(region: PopochiuRegion)
 
 
 ## Empty string constant to perform type checks (String is not nullable in GDScript. See #381, #382).
@@ -118,6 +121,9 @@ const STANDARD_TALK_ANIMATION = "talk"
 ## Whether the character ignores or not obstacles in walkable areas. If [code]true[/code], the character will
 ## move within a walkable area, ignoring obstacle polygons that might block the path.
 @export var ignore_obstacles := false
+## Whether the character can walk through [PopochiuRegion]s with [member PopochiuRegion.walkable]
+## set to [code]false[/code]. When [code]true[/code], blocking regions will not interrupt movement.
+@export var ignore_blocking_regions := false
 ## Whether the character ignores scale changes applied by [PopochiuRegion]s.
 ## When [code]true[/code], the character will not be scaled when entering or moving through a region
 ## that has scaling enabled.
@@ -279,6 +285,11 @@ func _ready() -> void:
 	# Connect movement signals to virtual methods
 	movement_started.connect(_on_movement_started)
 	movement_ended.connect(_on_movement_ended)
+	
+	# #521: Detect entry into blocking regions through bidirectional Area2D overlap signals.
+	# Both the region and the character independently receive area_entered for the same overlap,
+	# so the character can manage its own blocking reaction without the region calling into it.
+	area_entered.connect(_on_entered_area_check_blocking)
 
 	# Connect to own movement signals to handle navigation internally
 	if not started_walk_to.is_connected(_update_navigation_path):
@@ -391,6 +402,14 @@ func _on_movement_started() -> void:
 ## Called when the character stops moving. Override to add custom behavior such as
 ## triggering events or updating game state.
 func _on_movement_ended() -> void:
+	pass
+
+
+## Called when this character's movement is interrupted because it tried to enter a
+## [PopochiuRegion] with [member PopochiuRegion.walkable] set to [code]false[/code].[br]
+## Override in the character's game script to react to the event (e.g. play a sound, show a
+## message). [param region] is the [PopochiuRegion] that blocked the character.
+func _on_blocked_by_region(_region: PopochiuRegion) -> void:
 	pass
 
 
@@ -1552,6 +1571,21 @@ func stop_following_character() -> void:
 #endregion
 
 #region Private ####################################################################################
+# #521: Handler for the character's own area_entered signal.
+# Area2D overlap detection is bidirectional, so when a character enters a region, both nodes
+# receive area_entered independently. This lets the character manage its own blocking reaction
+# without the region needing to call any method on the character.
+func _on_entered_area_check_blocking(area: Area2D) -> void:
+	if not (area is PopochiuRegion):
+		return
+	var region := area as PopochiuRegion
+	if region.walkable or ignore_blocking_regions:
+		return
+	stop_walking()
+	blocked_by_region.emit(region)
+	_on_blocked_by_region(region)
+
+
 # Resolves a character parameter to a PopochiuCharacter instance.
 # [param character] can be a PopochiuCharacter, a String (script_name), or null.
 # [param fallback_script_name] is used when [param character] is null or empty.

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -64,6 +64,10 @@ const STANDARD_IDLE_ANIMATION = "idle"
 const STANDARD_WALK_ANIMATION = "walk"
 ## Standard talk animation name.
 const STANDARD_TALK_ANIMATION = "talk"
+## Distance in pixels to pull back from a blocking region boundary when trimming the navigation
+## path. Prevents boundary-precision issues with Geometry2D.is_point_in_polygon() on subsequent
+## clicks. See #521.
+const BLOCKING_REGION_PULLBACK = 2.0
 
 
 ## The [Color] in which the dialogue lines of the character are rendered.
@@ -1836,7 +1840,7 @@ func _update_navigation_path(character: PopochiuCharacter, start_position: Vecto
 	# state from a previous blocked walk, then set to the region that caused trimming (if any).
 	_pending_blocking_region = null
 	if not ignore_blocking_regions:
-		_pending_blocking_region = _trim_path_at_blocking_regions(start_position)
+		_pending_blocking_region = _trim_path_to_first_blocking_region(start_position)
 
 	# Now the _navigation_path will at least have another point at index 0.
 	# Starting the physics processing will make _physics_process()
@@ -1846,11 +1850,11 @@ func _update_navigation_path(character: PopochiuCharacter, start_position: Vecto
 
 # Character navigation system.
 #
-# Checks every segment of _navigation_path against all non-walkable, enabled regions in the
-# scene. If a segment would enter a blocking region for the first time (start outside, end
-# inside), the path is trimmed to the intersection point on the region's polygon edge.
-# Returns the blocking region, or null if no trimming was needed.
-func _trim_path_at_blocking_regions(start_position: Vector2) -> PopochiuRegion:
+# Trims _navigation_path at the nearest point where it would cross a non-walkable region
+# boundary. Iterates path segments in order, and for each segment finds the closest
+# intersection across ALL blocking regions (not just the first one found in tree order).
+# Returns the blocking region that caused the trim, or null if no trimming was needed.
+func _trim_path_to_first_blocking_region(start_position: Vector2) -> PopochiuRegion:
 	var blocking_regions: Array = get_tree().get_nodes_in_group("regions").filter(
 		func(r: Node) -> bool: return r is PopochiuRegion and not r.walkable and r.enabled
 	)
@@ -1861,6 +1865,11 @@ func _trim_path_at_blocking_regions(start_position: Vector2) -> PopochiuRegion:
 	for i in range(n):
 		var seg_start := start_position if i == 0 else _navigation_path[i - 1]
 		var seg_end := _navigation_path[i]
+
+		# Find the nearest hit across all blocking regions for this segment.
+		var nearest_hit := Vector2.INF
+		var nearest_t := INF
+		var blocking_region: PopochiuRegion = null
 
 		for region in blocking_regions:
 			var polygon: PackedVector2Array = region.get_global_polygon()
@@ -1875,14 +1884,21 @@ func _trim_path_at_blocking_regions(start_position: Vector2) -> PopochiuRegion:
 			var hit := _first_entry_intersection(seg_start, seg_end, polygon)
 			if hit == Vector2.INF:
 				continue
-			# Trim: discard waypoints from i onward and replace with the stop point.
-			# Pull back 2px from the boundary so the character stops clearly outside the
+			var t := seg_start.distance_to(hit)
+			if t < nearest_t:
+				nearest_t = t
+				nearest_hit = hit
+				blocking_region = region
+
+		# If any region blocked this segment, trim the path here.
+		if blocking_region:
+			# Pull back from the boundary so the character stops clearly outside the
 			# region. Without this, a subsequent path starting from exactly on the edge
 			# causes is_point_in_polygon() to be unreliable and the trim to be skipped.
-			var stop := hit - (hit - seg_start).normalized() * 2.0
+			var stop := nearest_hit - (nearest_hit - seg_start).normalized() * BLOCKING_REGION_PULLBACK
 			_navigation_path.resize(i)
 			_navigation_path.append(stop)
-			return region
+			return blocking_region
 
 	return null
 

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -254,6 +254,9 @@ var _last_emitted_position: Vector2 = Vector2.INF
 # Perspective scale factor from the current scaling region. Updated by update_scale().
 # 1.0 outside any region.
 var _walk_scale_factor: float = 1.0
+# The non-walkable region that caused path trimming on the current walk. Set by
+# _trim_path_at_blocking_regions() and cleared after signals are emitted at movement end.
+var _pending_blocking_region: PopochiuRegion = null
 
 @onready var interaction_polygon_node: CollisionPolygon2D = $InteractionPolygon
 @onready var scaling_polygon: CollisionPolygon2D = $ScalingPolygon
@@ -286,10 +289,9 @@ func _ready() -> void:
 	movement_started.connect(_on_movement_started)
 	movement_ended.connect(_on_movement_ended)
 	
-	# #521: Detect entry into blocking regions through bidirectional Area2D overlap signals.
-	# Both the region and the character independently receive area_entered for the same overlap,
-	# so the character can manage its own blocking reaction without the region calling into it.
-	area_entered.connect(_on_entered_area_check_blocking)
+	# #521: Route the blocked_by_region signal to the virtual override so game scripts
+	# can react without manually connecting in every character script.
+	blocked_by_region.connect(_on_blocked_by_region)
 
 	# Connect to own movement signals to handle navigation internally
 	if not started_walk_to.is_connected(_update_navigation_path):
@@ -1571,21 +1573,6 @@ func stop_following_character() -> void:
 #endregion
 
 #region Private ####################################################################################
-# #521: Handler for the character's own area_entered signal.
-# Area2D overlap detection is bidirectional, so when a character enters a region, both nodes
-# receive area_entered independently. This lets the character manage its own blocking reaction
-# without the region needing to call any method on the character.
-func _on_entered_area_check_blocking(area: Area2D) -> void:
-	if not (area is PopochiuRegion):
-		return
-	var region := area as PopochiuRegion
-	if region.walkable or ignore_blocking_regions:
-		return
-	stop_walking()
-	blocked_by_region.emit(region)
-	_on_blocked_by_region(region)
-
-
 # Resolves a character parameter to a PopochiuCharacter instance.
 # [param character] can be a PopochiuCharacter, a String (script_name), or null.
 # [param fallback_script_name] is used when [param character] is null or empty.
@@ -1796,6 +1783,13 @@ func _move_along_path(walk_distance: float):
 	update_scale()
 	_clear_navigation_path()
 
+	# #521: If the path was trimmed at a blocking region boundary, notify game scripts now
+	# that movement has fully stopped. Clearing before emitting prevents re-entrancy issues.
+	if _pending_blocking_region != null:
+		var region := _pending_blocking_region
+		_pending_blocking_region = null
+		blocked_by_region.emit(region)
+
 	# Apply facing behavior after movement completes.
 	# This handles the case where a character is both following one character
 	# and facing another (e.g., bodyguard following the player but always facing threats).
@@ -1837,10 +1831,87 @@ func _update_navigation_path(character: PopochiuCharacter, start_position: Vecto
 	# Let's remove the first point of the path since it is the character's current position.
 	_navigation_path.remove_at(0)
 
+	# #521: Trim the path before movement starts so the character never visually enters
+	# a non-walkable region. _pending_blocking_region is cleared first to discard any stale
+	# state from a previous blocked walk, then set to the region that caused trimming (if any).
+	_pending_blocking_region = null
+	if not ignore_blocking_regions:
+		_pending_blocking_region = _trim_path_at_blocking_regions(start_position)
+
 	# Now the _navigation_path will at least have another point at index 0.
 	# Starting the physics processing will make _physics_process()
 	# move the character along the path.
 	set_physics_process(true)
+
+
+# Character navigation system.
+#
+# Checks every segment of _navigation_path against all non-walkable, enabled regions in the
+# scene. If a segment would enter a blocking region for the first time (start outside, end
+# inside), the path is trimmed to the intersection point on the region's polygon edge.
+# Returns the blocking region, or null if no trimming was needed.
+func _trim_path_at_blocking_regions(start_position: Vector2) -> PopochiuRegion:
+	var blocking_regions: Array = get_tree().get_nodes_in_group("regions").filter(
+		func(r: Node) -> bool: return r is PopochiuRegion and not r.walkable and r.enabled
+	)
+	if blocking_regions.is_empty():
+		return null
+
+	var n := _navigation_path.size()
+	for i in range(n):
+		var seg_start := start_position if i == 0 else _navigation_path[i - 1]
+		var seg_end := _navigation_path[i]
+
+		for region in blocking_regions:
+			var polygon: PackedVector2Array = region.get_global_polygon()
+			if polygon.is_empty():
+				continue
+			# Character is already inside this region: allow exiting.
+			if Geometry2D.is_point_in_polygon(seg_start, polygon):
+				continue
+			# Find the nearest polygon edge intersection along this segment.
+			# This handles both entry (seg_end inside) and transit (seg_end outside but
+			# the segment still crosses a polygon edge) cases.
+			var hit := _first_entry_intersection(seg_start, seg_end, polygon)
+			if hit == Vector2.INF:
+				continue
+			# Trim: discard waypoints from i onward and replace with the stop point.
+			# Pull back 2px from the boundary so the character stops clearly outside the
+			# region. Without this, a subsequent path starting from exactly on the edge
+			# causes is_point_in_polygon() to be unreliable and the trim to be skipped.
+			var stop := hit - (hit - seg_start).normalized() * 2.0
+			_navigation_path.resize(i)
+			_navigation_path.append(stop)
+			return region
+
+	return null
+
+
+# Returns the point where segment (p1→p2) first crosses a polygon edge, i.e., the nearest
+# intersection when approaching from outside. Returns Vector2.INF if there is no intersection.
+func _first_entry_intersection(
+	p1: Vector2, p2: Vector2, polygon: PackedVector2Array
+) -> Vector2:
+	var seg_len := p1.distance_to(p2)
+	if seg_len < 0.001:
+		return Vector2.INF
+
+	var best_t := INF
+	var best_hit := Vector2.INF
+	var count := polygon.size()
+
+	for i in range(count):
+		var edge_a := polygon[i]
+		var edge_b := polygon[(i + 1) % count]
+		var hit = Geometry2D.segment_intersects_segment(p1, p2, edge_a, edge_b)
+		if hit == null:
+			continue
+		var t := p1.distance_to(hit) / seg_len
+		if t < best_t:
+			best_t = t
+			best_hit = hit
+
+	return best_hit
 
 
 # Character navigation system.

--- a/addons/popochiu/engine/objects/character/popochiu_character.gd
+++ b/addons/popochiu/engine/objects/character/popochiu_character.gd
@@ -1903,11 +1903,9 @@ func _trim_path_to_first_blocking_region(start_position: Vector2) -> PopochiuReg
 	return null
 
 
-# Returns the point where segment (p1→p2) first crosses a polygon edge, i.e., the nearest
+# Returns the point where segment (p1->p2) first crosses a polygon edge, i.e., the nearest
 # intersection when approaching from outside. Returns Vector2.INF if there is no intersection.
-func _first_entry_intersection(
-	p1: Vector2, p2: Vector2, polygon: PackedVector2Array
-) -> Vector2:
+func _first_entry_intersection(p1: Vector2, p2: Vector2, polygon: PackedVector2Array) -> Vector2:
 	var seg_len := p1.distance_to(p2)
 	if seg_len < 0.001:
 		return Vector2.INF

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -8,12 +8,21 @@ extends Area2D
 ## Regions can apply visual effects such as tinting characters or scaling them based on vertical
 ## position (useful for simulating depth in walkable areas).
 
+## Emitted when a [param character] tries to enter this region while [member walkable] is
+## [code]false[/code] and the character does not ignore blocking regions.
+## Connect to this signal in the region's game script to react to the blocking event.
+signal character_blocked(character: PopochiuCharacter)
+
 ## The identifier of the object used in scripts.
 @export var script_name := ""
 ## Can be used to show the name of the area to players.
 @export var description := ""
 ## Whether the region is or not enabled.
 @export var enabled := true: set = _set_enabled
+## Whether characters can walk through this region. When [code]false[/code], characters whose
+## [member PopochiuCharacter.ignore_blocking_regions] is also [code]false[/code] will have their
+## movement interrupted upon entering. The region's state is saved as part of the room save data.
+@export var walkable := true
 ## The [Color] to apply to the character that enters this region.
 @export var tint := Color.WHITE
 ## Whether the region will scale the character while it moves through it.
@@ -151,6 +160,12 @@ func _check_area(area: Area2D, entered: bool) -> void:
 	if not area is PopochiuCharacter: return
 	
 	if entered:
+		# #521: If the region is not walkable and the character doesn't opt out, emit the blocking
+		# signal and suppress _on_character_entered() so tinting/custom enter logic don't fire.
+		# The character stops itself independently via its own area_entered handler.
+		if not walkable and not (area as PopochiuCharacter).ignore_blocking_regions:
+			character_blocked.emit(area as PopochiuCharacter)
+			return
 		_on_character_entered(area)
 	else:
 		_on_character_exited(area)

--- a/addons/popochiu/engine/objects/region/popochiu_region.gd
+++ b/addons/popochiu/engine/objects/region/popochiu_region.gd
@@ -143,6 +143,12 @@ func get_markers() -> Array[Marker2D]:
 	return markers
 
 
+## Returns the vertices of this region's polygon in global (world) coordinates.
+## Used by path-trimming in [PopochiuCharacter] to check segment intersections.
+func get_global_polygon() -> PackedVector2Array:
+	return _get_global_polygon()
+
+
 #endregion
 
 #region SetGet #####################################################################################

--- a/addons/popochiu/engine/templates/character_template.gd
+++ b/addons/popochiu/engine/templates/character_template.gd
@@ -106,6 +106,13 @@ func _on_movement_ended() -> void:
 	pass
 
 
+# Called when this character's movement is blocked by a region with walkable = false.
+# Override to react to the event: play a sound, show a hint, trigger dialogue, etc.
+# `_region` is the PopochiuRegion that stopped the character.
+func _on_blocked_by_region(_region: PopochiuRegion) -> void:
+	pass
+
+
 #endregion
 
 #region Public #####################################################################################


### PR DESCRIPTION
### Region Blocking for Character Navigation

Characters are now prevented from entering regions marked as non-walkable.
To achieve this, the navigation path is trimmed before movement: if a segment would cross into a blocking region, the path is cut at the nearest intersection, and the character stops just before the boundary.
The nearest intersection is the one who wins the trim.
In addition, signals are emitted when a character is blocked by a region, so the engine can react.

A first implementation was testing the areas collisions, but this was creating a problem: since the logic was triggered by the character **entering** a blocked region, clicking again on the destination was unblocking the path since the character was already inside the region.

A `BLOCKING_REGION_PULLBACK` constant (current value 2) representing a distance in pixels to trim the segment from the area border, to avoid ambiguous boundary cases (if the character stops on the edge of the region, it is still considered inside, triggering the case above).

Performance impact is negligible: the check is only performed when a new path is set, not during walk, and the number of regions is typically small in a room. In a room with three regions (I consider this pretty crowded compare to average), we can get ~15-20 aritmethic operations per click, which is unmeasurable on modern hardware.