### PR TITLE
refs #368: Allow to get the array of characters in the current rom

### DIFF
--- a/addons/popochiu/engine/interfaces/i_room.gd
+++ b/addons/popochiu/engine/interfaces/i_room.gd
@@ -103,6 +103,18 @@ func get_markers() -> Array:
 	return current.get_markers()
 
 
+## Returns an [Array] with all the [PopochiuCharacter]s in the current room.
+func get_characters() -> Array[PopochiuCharacter]:
+	var characters: Array[PopochiuCharacter] = []
+	characters.assign(current.get_characters())
+	return characters
+
+
+## Returns the number of [PopochiuCharacter]s in the current room.
+func get_characters_count() -> int:
+	return current.get_characters_count()
+
+
 ## Returns the runtime instance of the [PopochiuRoom] identified by [param script_name], or
 ## [code]null[/code] if it cannot be found.
 ##


### PR DESCRIPTION
`PopochiuRoom.get_characters()` and `PopochiuRoom.get_character_count()` can be now directly called from the IRoom interface.

Closes #368 .