### PR TITLE
refs #115: Add parallax support

### DIFF
--- a/addons/popochiu/editor/config/config.gd
+++ b/addons/popochiu/editor/config/config.gd
@@ -13,6 +13,8 @@ enum DialogStyle {
 # Thanks to @drbloop for providing the bases of the new approach for moving the popochiu settings to
 # Godot's ProjectSettings instead of using a Resource file.
 # ---- GUI -----------------------------------------------------------------------------------------
+const PARALLAX_SCROLLING = "popochiu/gui/parallax_scrolling"
+const PARALLAX_SCROLLING_RESET_DURATION = "popochiu/gui/parallax_scrolling_reset_duration"
 const SCALE_GUI = "popochiu/gui/experimental_scale_gui"
 # ---- GUI / Transition Layer ----------------------------------------------------------------------
 const TL_FADE_COLOR = "popochiu/gui/transition_layer/fade_color"
@@ -83,6 +85,8 @@ const AUTOTRACE_NOISE_REDUCTION = "popochiu/auto_tracer/noise_reduction"
 const AUTOTRACE_CONVEX_OUTLINE = "popochiu/auto_tracer/convex_outline"
 
 static var defaults := {
+	PARALLAX_SCROLLING: true,
+	PARALLAX_SCROLLING_RESET_DURATION: 1.0,
 	SCALE_GUI: false,
 	TL_FADE_COLOR: Color.BLACK,
 	TL_SKIP_CUTSCENE_TIME: 0.2,
@@ -141,6 +145,8 @@ static func reload_transitions() -> void:
 
 static func initialize_project_settings() -> void:
 	# ---- GUI -------------------------------------------------------------------------------------
+	_initialize_project_setting(PARALLAX_SCROLLING, TYPE_BOOL)
+	_initialize_project_setting(PARALLAX_SCROLLING_RESET_DURATION, TYPE_FLOAT)
 	_initialize_project_setting(SCALE_GUI, TYPE_BOOL)
 	# Transition Layer
 	var transition_hint: String = _get_transitions_hint()
@@ -253,6 +259,14 @@ static func set_project_setting(key: String, value: Variant) -> void:
 
 
 # ---- GUI -----------------------------------------------------------------------------------------
+static func is_parallax_scrolling() -> bool:
+	return _get_project_setting(PARALLAX_SCROLLING)
+
+
+static func get_parallax_scrolling_reset_duration() -> float:
+	return _get_project_setting(PARALLAX_SCROLLING_RESET_DURATION)
+
+
 static func is_scale_gui() -> bool:
 	return _get_project_setting(SCALE_GUI)
 

--- a/addons/popochiu/engine/objects/popochiu_main_camera.gd
+++ b/addons/popochiu/engine/objects/popochiu_main_camera.gd
@@ -6,6 +6,9 @@ extends Camera2D
 ## This camera follows the player character and can be manipulated to create visual effects
 ## during gameplay, such as screen shake for impacts or zoom for dramatic moments.
 
+## Emitted when the camera's transform changes.
+signal camera_changed()
+
 var is_shaking := false
 
 var _camera_shake_amount := 15.0
@@ -23,6 +26,11 @@ var _shake_timer := 0.0
 
 
 #region Godot ######################################################################################
+func _notification(event: int) -> void:
+	if event == NOTIFICATION_TRANSFORM_CHANGED:
+		camera_changed.emit()
+
+
 func _process(delta: float) -> void:
 	if is_shaking:
 		_shake_timer -= delta
@@ -39,9 +47,22 @@ func _process(delta: float) -> void:
 	):
 		position = PopochiuUtils.c.camera_owner.get_buffered_position()
 
+	force_update_scroll()
+
+
 #endregion
 
 #region Public #####################################################################################
+## Returns the camera limits as [Rect2].
+func get_limits_rect() -> Rect2:
+	return Rect2(
+		limit_left,
+		limit_top,
+		limit_right  - limit_left,
+		limit_bottom - limit_top,
+	)
+
+
 ## Changes the main camera's offset by [param offset] pixels. Useful when zooming the camera.
 ##
 ## [i]This method is intended to be used inside a [method Popochiu.queue] of instructions.[/i]

--- a/addons/popochiu/engine/objects/popochiu_settings.gd
+++ b/addons/popochiu/engine/objects/popochiu_settings.gd
@@ -34,6 +34,13 @@ var tl_room_transition := ""
 var tl_room_transition_duration := 0.0
 ## A flag telling if the transition layer should be shown when the game starts.
 var show_tl_in_first_room := false
+## Whether to scroll props (with [member PopochiuProp.parallax_scroll_scale] set to non-zero values) in
+## rooms bigger than the window.
+var parallax_scrolling := true
+## The animation duration for resetting parallax props to their original/intended position when
+## [member parallax_scrolling] changes during runtime. Set to [code]0[/code] to turn off the
+## animation.
+var parallax_scrolling_reset_duration := 1.0
 ## Whether the GUI should scale to match the native game resolution. The default GUI has a 356x200
 ## resolution.
 var scale_gui := false
@@ -63,6 +70,8 @@ var dev_use_addon_template := false
 #region Godot ######################################################################################
 func _init() -> void:
 	# ---- GUI -------------------------------------------------------------------------------------
+	parallax_scrolling = PopochiuConfig.is_parallax_scrolling()
+	parallax_scrolling_reset_duration = PopochiuConfig.get_parallax_scrolling_reset_duration()
 	scale_gui = PopochiuConfig.is_scale_gui()
 	tl_fade_color = PopochiuConfig.get_tl_fade_color()
 	tl_skip_cutscene_time = PopochiuConfig.get_tl_skip_cutscene_time()

--- a/addons/popochiu/engine/objects/prop/popochiu_prop.gd
+++ b/addons/popochiu/engine/objects/prop/popochiu_prop.gd
@@ -50,6 +50,40 @@ signal obstacle_state_changed(prop: PopochiuProp)
 @export_range(0.0, 1.0) var alpha: float = 1.0: set = set_alpha
 ## Total frames available the texture image has. [code](frames * vframes)[/code]
 var total_frames: get = get_total_frames
+## A per-axis scroll-speed multiplier, where [code]1[/code] means "100% camera speed".
+## Positive values move with the camera, negative values move opposite of the camera.[br]
+## [br]
+## Examples:[br]
+## [br]
+##   - [code]   [0, 0][/code]: Disables parallax scrolling on both axes.[br]
+##   - [code][-0.1, 0][/code]: Moves the prop away from the camera on the x-axis at 10% camera speed.
+@export var parallax_scroll_scale: Vector2 = Vector2.ZERO
+## Specifies the parallax prop's "neutral" position, i.e. at which normalized camera position the
+## prop renders at its original position as seen in the editor, where [code]-1[/code] means
+## "100% left/top", [code]0[/code] means "center" and [code]1[/code] means "100% right/bottom".
+## Deviations from the given position are rendered at a shifted position in accordance with
+## [member parallax_scroll_scale].[br]
+## [br]
+## This allows for deterministically anchoring a prop in its editor position ("what you see is what
+## you get"), irrespective of how big the actual overall texture is. This is especially useful for
+## room-sized props coming from an Aseprite-imported layer where the visible pixels only occupy a
+## part of the room.[br]
+## [br]
+## Examples:[br]
+## [br]
+##   - [code][ -1, 0][/code]: "Render the prop at its initial (editor) position when the camera is
+##                             at its leftmost (x-axis) center (y-axis) position."[br]
+##   - [code][0.5, 0][/code]: "Render the prop at its initial (editor) position when the camera is
+##                             halfway between the room center and its rightmost (x-axis) center
+##                             (y-axis) position."[br]
+##   - [code]  [1, 1][/code]: "Render the prop at its initial (editor) position when the camera is
+##                             at its topmost (x-axis) rightmost (y-axis) position."[br]
+@export var parallax_anchor: Vector2 = Vector2.ZERO
+
+var _original_position: Vector2
+@onready var _parallax_enabled: bool = PopochiuUtils.e.settings.parallax_scrolling
+@onready var _parallax_weight := float(_parallax_enabled)
+var _parallax_tween: Tween
 
 # Tween used for alpha fade operations.
 var _alpha_tween: Tween = null
@@ -118,6 +152,17 @@ func _ready() -> void:
 		):
 			disable()
 
+	# Save the prop's initial position regardless of whether it is configured as a scrolling
+	# parallax prop, as this may be useful in other contexts as well.
+	_original_position = position
+
+	# Connect to the relevant signals for updating the prop's position if configured for parallax
+	# scrolling regardless of whether parallax scrolling is enabled in the settings, as we want
+	# this to be runtime-toggleable.
+	if parallax_scroll_scale != Vector2.ZERO:
+		get_viewport().size_changed.connect(_update_parallax)
+		PopochiuUtils.e.camera.camera_changed.connect(_update_parallax)
+
 
 func _notification(event: int) -> void:
 	if event == NOTIFICATION_EDITOR_PRE_SAVE:
@@ -162,6 +207,50 @@ func _on_movement_started() -> void:
 ## animation sequence in the room's narrative.
 func _on_movement_ended() -> void:
 	pass
+
+
+## Called when [member parallax_scroll_scale] is set to non-zero values to update the prop's
+## position based on [member parallax_scroll_scale], [member parallax_anchor] and the camera's
+## position.[br]
+## [br]
+## See also [member PopochiuSettings.parallax_scrolling].
+func _update_parallax() -> void:
+	var visible_rect: Rect2 = PopochiuUtils.e.get_visible_room_rect()
+	var camera_rect: Rect2 = PopochiuUtils.e.camera.get_limits_rect()
+	var max_scroll := camera_rect.size - visible_rect.size
+	var parallax_anchor_offset := camera_rect.get_center() + (max_scroll * 0.5 * parallax_anchor)
+	var camera_pos: Vector2 = PopochiuUtils.e.camera.get_screen_center_position()
+	var parallax_prop_offset := (camera_pos - parallax_anchor_offset) * parallax_scroll_scale
+
+	if _parallax_enabled != PopochiuUtils.e.settings.parallax_scrolling:
+		# When the `parallax_scrolling` setting changes during runtime, we need to move the prop
+		# back to its new intended position, which is:
+		#   disabled -> enabled:  offset based on parallax prop settings and camera position
+		#   enabled  -> disabled: original prop position
+		# To allow animating the transition (looks nicer), and because the player/camera position
+		# may change during the transition, we use a tween to calculate a weight between
+		# [0, 1] (aka [parallax_scrolling==false, parallax_scrolling==true]) which is then applied to
+		# the overall target offset for the current frame. This is to avoid the reset animation
+		# fighting against simultaneous camera movement.
+		# Under normal circumstances (i.e. when the setting hasn't just changed and there is no
+		# current animation/running tween) the last calculated weight effectively acts as a toggle
+		# for enabling/disabling the parallax effect as a whole.
+		# The transition is animated for `E.settings.parallax_scrolling_reset_duration` seconds, by
+		# setting it to 0 the animation can be disabled and the prop teleports instantly, if desired.
+		_parallax_enabled = PopochiuUtils.e.settings.parallax_scrolling
+
+		if _parallax_tween:
+			_parallax_tween.kill()
+
+		_parallax_tween = create_tween().set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+		_parallax_tween.tween_property(
+			self,
+			"_parallax_weight",
+			float(_parallax_enabled),
+			PopochiuUtils.e.settings.parallax_scrolling_reset_duration
+		)
+
+	position = _original_position + (parallax_prop_offset * _parallax_weight)
 
 
 #endregion

--- a/addons/popochiu/engine/popochiu.gd
+++ b/addons/popochiu/engine/popochiu.gd
@@ -532,6 +532,30 @@ func get_current_command_name() -> String:
 #endregion
 
 #region SetGet #####################################################################################
+## Returns the visible room's rectangle in global screen coordinates.[br]
+## [br]
+## With [code]display/window/stretch/aspect[/code] set to something other than
+## [code]keep_width[/code]/[code]keep_height[/code] this is identical to
+## [method Viewport.get_visible_rect].[br]
+## With [code]keep_width/keep_height[/code] the root viewport may grow larger than the room so this
+## effectively clips [method Viewport.get_visible_rect] to the currently loaded room's bounds.[br]
+## [br]
+## If there is no current room this returns [method Viewport.get_visible_rect].
+func get_visible_room_rect() -> Rect2:
+	var viewport_rect := get_viewport().get_visible_rect()
+
+	# If there is no current room we have no concept of "visible room area" so return the
+	# viewport rect as-is.
+	if not R.current:
+		return viewport_rect
+
+	var viewport_size := viewport_rect.size
+	var room_size := Vector2(R.current.width, R.current.height)
+	var visible_size := viewport_size.min(room_size)
+	var visible_rect := Rect2((viewport_size - visible_size) * 0.5, visible_size)
+	return visible_rect
+
+
 func get_width() -> float:
 	return get_viewport().get_visible_rect().end.x
 


### PR DESCRIPTION
I well-intentionedly chose to ignore the proposed implementation of a simple `z-index` and implemented it similarly to what PowerQuest does, having two settings called `parallax_anchor` (PowerQuest calls this `parallax_alignment`) and `parallax_scroll_scale` (PowerQuest calls this `parallax_depth`).

`parallax_anchor` is responsible for configuring "at this room's relative camera position, position the prop exactly here" - this makes it simple to position props where they appear in the editor for the camera extremes/room bounds.

`parallax_scroll_scale` configures the depth as a factor of the camera movement. I went with this name because that's what `Parallax2D` uses as it describes the relationship with the camera better (`0.5` == "prop moves 50% of camera movement").