### PR TITLE
refs #412: First working version of animations groups per props.

### DIFF
--- a/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
+++ b/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
@@ -41,10 +41,10 @@ func create_tag_animations(target_node: Node, aseprite_tag: String, options: Dic
 	return await _create_animations(target_node, options, aseprite_tag)
 
 
-## Create animations for a "group tag": one spritesheet containing only the
-## frames covered by the group's range, sliced into one animation per child tag.
-## [param group] must contain: name, from, to and children (each child with
-## tag_name, anim_name, from, to, direction and, optionally, loops/autoplays).
+# Create animations for a "group tag": one spritesheet containing only the
+# frames covered by the group's range, sliced into one animation per child tag.
+# [param group] must contain: name, from, to and children (each child with
+# tag_name, anim_name, from, to, direction and, optionally, loops/autoplays).
 func create_group_animations(target_node: Node, group: Dictionary, options: Dictionary) -> int:
 	var result := _setup_common(target_node, options)
 	if result != RESULT_CODE.SUCCESS:
@@ -179,7 +179,7 @@ func _create_spritesheet_from_tag(selected_tag: String) -> int:
 	return RESULT_CODE.SUCCESS
 
 
-## Create a spritesheet with the frames inside the given range (a group tag).
+# Create a spritesheet with the frames inside the given range (a group tag).
 func _create_spritesheet_from_frame_range(name: String, from: int, to: int) -> int:
 	_output = _aseprite.export_frame_range(
 		_options.source, name, from, to, _options.output_folder, _options
@@ -189,7 +189,10 @@ func _create_spritesheet_from_frame_range(name: String, from: int, to: int) -> i
 	return RESULT_CODE.SUCCESS
 
 
-func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPTY_STRING) -> int:
+# Loads the exported Aseprite JSON into _spritesheet_metadata (meta and frames)
+# and returns the parsed content. Returns an error code (int) when the file
+# cannot be read or the spritesheet is invalid.
+func _load_spritesheet_file() -> Variant:
 	_spritesheet_metadata = {
 		tags = {},
 		frames = {},
@@ -200,40 +203,52 @@ func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPT
 	# Refresh filesystem
 	await _scan_filesystem()
 
-	# Collect all needed info
-	var source_file = _output.data_file
-	var sprite_sheet = _output.sprite_sheet
-	
 	# Try to access, decode and validate Aseprite JSON output
-	var file = FileAccess.open(source_file, FileAccess.READ)
+	var file = FileAccess.open(_output.data_file, FileAccess.READ)
 	if file == null:
 		return file.get_open_error()
-		
-	var test_json_conv = JSON.new()
-	test_json_conv.parse(file.get_as_text())
-	var content = test_json_conv.get_data()
-	
+
+	var json = JSON.new()
+	json.parse(file.get_as_text())
+	var content = json.get_data()
+
 	if not _aseprite.is_valid_spritesheet(content):
 		return RESULT_CODE.ERR_INVALID_ASEPRITE_SPRITESHEET
-	
-	# Save image metadata from JSON data
-	_spritesheet_metadata.meta = content.meta
 
-	# Save frames metadata from JSON data
+	# Save image and frames metadata from JSON data
+	_spritesheet_metadata.meta = content.meta
 	_spritesheet_metadata.frames = _aseprite.get_content_frames(content)
+	return content
+
+
+# Saves the spritesheet path and removes the JSON file when configured to.
+func _finalize_spritesheet_metadata() -> void:
+	# Save spritesheet path from the command output
+	_spritesheet_metadata.sprite_sheet = _output.sprite_sheet
+
+	# Remove the JSON file if config says so
+	if PopochiuEditorConfig.should_remove_source_files():
+		DirAccess.remove_absolute(_output.data_file)
+		await _scan_filesystem()
+
+
+func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPTY_STRING) -> int:
+	var content = await _load_spritesheet_file()
+	if typeof(content) != TYPE_DICTIONARY:
+		return content
 
 	# Save tags metadata, starting from user's selection
 	var tags = _options.get("tags").filter(func(tag): return tag.get("import"))
 
 	for t in tags:
 		# If a tag is specified, ignore every other ones
-		if not selected_tag.is_empty() and selected_tag != t.tag_name: 
+		if not selected_tag.is_empty() and selected_tag != t.tag_name:
 			continue
 		# Create a lookup table for tags
 		_spritesheet_metadata.tags[t.tag_name] = t
 
 	for ft in _aseprite.get_content_meta_tags(content):
-		if not _spritesheet_metadata.tags.has(ft.name): 
+		if not _spritesheet_metadata.tags.has(ft.name):
 			continue
 		_spritesheet_metadata.tags.get(ft.name).merge({
 			from = ft.from,
@@ -248,14 +263,7 @@ func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPT
 		t.from = 0
 		_spritesheet_metadata.tags[selected_tag] = t
 
-	# Save spritesheet path from the command output
-	_spritesheet_metadata.sprite_sheet = sprite_sheet
-
-	# Remove the JSON file if config says so
-	if PopochiuEditorConfig.should_remove_source_files():
-		DirAccess.remove_absolute(_output.data_file)
-		await _scan_filesystem()
-
+	await _finalize_spritesheet_metadata()
 	return RESULT_CODE.SUCCESS
 
 
@@ -263,31 +271,9 @@ func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPT
 # tag flow, child frame ranges keep their whole-file indices (they are sliced
 # against the group's `from` in _configure_group_animations).
 func _load_group_spritesheet_metadata(group: Dictionary) -> int:
-	_spritesheet_metadata = {
-		tags = {},
-		frames = {},
-		meta = {},
-		sprite_sheet = {}
-	}
-
-	await _scan_filesystem()
-
-	var source_file = _output.data_file
-	var sprite_sheet = _output.sprite_sheet
-
-	var file = FileAccess.open(source_file, FileAccess.READ)
-	if file == null:
-		return file.get_open_error()
-
-	var test_json_conv = JSON.new()
-	test_json_conv.parse(file.get_as_text())
-	var content = test_json_conv.get_data()
-
-	if not _aseprite.is_valid_spritesheet(content):
-		return RESULT_CODE.ERR_INVALID_ASEPRITE_SPRITESHEET
-
-	_spritesheet_metadata.meta = content.meta
-	_spritesheet_metadata.frames = _aseprite.get_content_frames(content)
+	var content = await _load_spritesheet_file()
+	if typeof(content) != TYPE_DICTIONARY:
+		return content
 
 	# Build the tag lookup from the group's children, keeping the user's per-tag
 	# options (loops, autoplays, ...) and the frame data gathered at scan time
@@ -306,20 +292,18 @@ func _load_group_spritesheet_metadata(group: Dictionary) -> int:
 		})
 		_spritesheet_metadata.tags[child.tag_name] = entry
 
-	# Save spritesheet path from the command output
-	_spritesheet_metadata.sprite_sheet = sprite_sheet
-
-	# Remove the JSON file if config says so
-	if PopochiuEditorConfig.should_remove_source_files():
-		DirAccess.remove_absolute(_output.data_file)
-		await _scan_filesystem()
-
+	await _finalize_spritesheet_metadata()
 	return RESULT_CODE.SUCCESS
 
 
-func _configure_animations() -> int:
+# Creates the default animation library when it's missing.
+func _ensure_animation_library() -> void:
 	if not _player.has_animation_library(_DEFAULT_AL):
 		_player.add_animation_library(_DEFAULT_AL, AnimationLibrary.new())
+
+
+func _configure_animations() -> int:
+	_ensure_animation_library()
 
 	if _spritesheet_metadata.tags.size() > 0:
 		var result = RESULT_CODE.SUCCESS
@@ -338,8 +322,7 @@ func _configure_animations() -> int:
 # Creates one animation per child tag of a group, slicing the exported frames by
 # the child's range relative to the group's start frame.
 func _configure_group_animations(group: Dictionary) -> int:
-	if not _player.has_animation_library(_DEFAULT_AL):
-		_player.add_animation_library(_DEFAULT_AL, AnimationLibrary.new())
+	_ensure_animation_library()
 
 	var group_from: int = group.from
 	var result := RESULT_CODE.SUCCESS
@@ -362,12 +345,16 @@ func _configure_group_animations(group: Dictionary) -> int:
 # Creates one animation from the given frames. [param anim_name] is the final
 # animation name (already prefix-stripped for group children). [param is_loopable]
 # is passed explicitly because group children are looked up by their full tag name.
-func _add_animation_frames(anim_name: String, frames: Array, direction = 'forward', is_loopable := false) -> int:
+func _add_animation_frames(
+	anim_name: String,
+	frames: Array,
+	direction: String = 'forward',
+	is_loopable: bool = false
+) -> int:
 	var animation_name = anim_name.to_snake_case()
 
 	# Create animation library if it doesn't exist
-	if not _player.has_animation_library(_DEFAULT_AL):
-		_player.add_animation_library(_DEFAULT_AL, AnimationLibrary.new())
+	_ensure_animation_library()
 
 	if not _player.get_animation_library(_DEFAULT_AL).has_animation(animation_name):
 		_player.get_animation_library(_DEFAULT_AL).add_animation(animation_name, Animation.new())

--- a/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
+++ b/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
@@ -41,6 +41,34 @@ func create_tag_animations(target_node: Node, aseprite_tag: String, options: Dic
 	return await _create_animations(target_node, options, aseprite_tag)
 
 
+## Create animations for a "group tag": one spritesheet containing only the
+## frames covered by the group's range, sliced into one animation per child tag.
+## [param group] must contain: name, from, to and children (each child with
+## tag_name, anim_name, from, to, direction and, optionally, loops/autoplays).
+func create_group_animations(target_node: Node, group: Dictionary, options: Dictionary) -> int:
+	var result := _setup_common(target_node, options)
+	if result != RESULT_CODE.SUCCESS:
+		return result
+
+	result = _perform_common_checks()
+	if result != RESULT_CODE.SUCCESS:
+		return result
+
+	# Export only the frames covered by the group's range
+	result = await _create_spritesheet_from_frame_range(group.name, group.from, group.to)
+	if result != RESULT_CODE.SUCCESS:
+		return result
+
+	# Load metadata without offset normalization (child ranges are whole-file indices)
+	result = await _load_group_spritesheet_metadata(group)
+	if result != RESULT_CODE.SUCCESS:
+		return result
+
+	_setup_texture()
+	result = _configure_group_animations(group)
+	return result
+
+
 ## Configure autoplay based on the specified mode and context.
 func setup_autoplay(animation: String = PopochiuEditorHelper.EMPTY_STRING) -> void:
 	_player.autoplay = PopochiuEditorHelper.EMPTY_STRING  # Reset autoplay to default
@@ -151,6 +179,16 @@ func _create_spritesheet_from_tag(selected_tag: String) -> int:
 	return RESULT_CODE.SUCCESS
 
 
+## Create a spritesheet with the frames inside the given range (a group tag).
+func _create_spritesheet_from_frame_range(name: String, from: int, to: int) -> int:
+	_output = _aseprite.export_frame_range(
+		_options.source, name, from, to, _options.output_folder, _options
+	)
+	if _output.is_empty():
+		return RESULT_CODE.ERR_ASEPRITE_EXPORT_FAILED
+	return RESULT_CODE.SUCCESS
+
+
 func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPTY_STRING) -> int:
 	_spritesheet_metadata = {
 		tags = {},
@@ -221,6 +259,64 @@ func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPT
 	return RESULT_CODE.SUCCESS
 
 
+# Loads the exported spritesheet metadata for a group import. Unlike the single
+# tag flow, child frame ranges keep their whole-file indices (they are sliced
+# against the group's `from` in _configure_group_animations).
+func _load_group_spritesheet_metadata(group: Dictionary) -> int:
+	_spritesheet_metadata = {
+		tags = {},
+		frames = {},
+		meta = {},
+		sprite_sheet = {}
+	}
+
+	await _scan_filesystem()
+
+	var source_file = _output.data_file
+	var sprite_sheet = _output.sprite_sheet
+
+	var file = FileAccess.open(source_file, FileAccess.READ)
+	if file == null:
+		return file.get_open_error()
+
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(file.get_as_text())
+	var content = test_json_conv.get_data()
+
+	if not _aseprite.is_valid_spritesheet(content):
+		return RESULT_CODE.ERR_INVALID_ASEPRITE_SPRITESHEET
+
+	_spritesheet_metadata.meta = content.meta
+	_spritesheet_metadata.frames = _aseprite.get_content_frames(content)
+
+	# Build the tag lookup from the group's children, keeping the user's per-tag
+	# options (loops, autoplays, ...) and the frame data gathered at scan time
+	var all_tags: Array = _options.get("tags")
+	for child in group.get("children", []):
+		var child_cfg: Dictionary = {}
+		for t in all_tags:
+			if t.get("tag_name") == child.tag_name:
+				child_cfg = t
+				break
+		var entry: Dictionary = child_cfg.duplicate()
+		entry.merge({
+			"from": child.from,
+			"to": child.to,
+			"direction": child.direction,
+		})
+		_spritesheet_metadata.tags[child.tag_name] = entry
+
+	# Save spritesheet path from the command output
+	_spritesheet_metadata.sprite_sheet = sprite_sheet
+
+	# Remove the JSON file if config says so
+	if PopochiuEditorConfig.should_remove_source_files():
+		DirAccess.remove_absolute(_output.data_file)
+		await _scan_filesystem()
+
+	return RESULT_CODE.SUCCESS
+
+
 func _configure_animations() -> int:
 	if not _player.has_animation_library(_DEFAULT_AL):
 		_player.add_animation_library(_DEFAULT_AL, AnimationLibrary.new())
@@ -229,7 +325,9 @@ func _configure_animations() -> int:
 		var result = RESULT_CODE.SUCCESS
 		for tag in _spritesheet_metadata.tags.values():
 			var selected_frames = _spritesheet_metadata.frames.slice(tag.from, tag.to + 1)
-			result = _add_animation_frames(tag.tag_name, selected_frames, tag.direction)
+			result = _add_animation_frames(
+				tag.tag_name, selected_frames, tag.direction, tag.get("loops", false)
+			)
 			if result != RESULT_CODE.SUCCESS:
 				break
 		return result
@@ -237,9 +335,35 @@ func _configure_animations() -> int:
 		return _add_animation_frames("default", _spritesheet_metadata.frames)
 
 
-func _add_animation_frames(anim_name: String, frames: Array, direction = 'forward') -> int:
+# Creates one animation per child tag of a group, slicing the exported frames by
+# the child's range relative to the group's start frame.
+func _configure_group_animations(group: Dictionary) -> int:
+	if not _player.has_animation_library(_DEFAULT_AL):
+		_player.add_animation_library(_DEFAULT_AL, AnimationLibrary.new())
+
+	var group_from: int = group.from
+	var result := RESULT_CODE.SUCCESS
+	for child in group.get("children", []):
+		var tag = _spritesheet_metadata.tags.get(child.tag_name)
+		if tag == null:
+			continue
+		var selected_frames = _spritesheet_metadata.frames.slice(
+			tag.from - group_from,
+			tag.to - group_from + 1
+		)
+		result = _add_animation_frames(
+			child.anim_name, selected_frames, tag.direction, tag.get("loops", false)
+		)
+		if result != RESULT_CODE.SUCCESS:
+			break
+	return result
+
+
+# Creates one animation from the given frames. [param anim_name] is the final
+# animation name (already prefix-stripped for group children). [param is_loopable]
+# is passed explicitly because group children are looked up by their full tag name.
+func _add_animation_frames(anim_name: String, frames: Array, direction = 'forward', is_loopable := false) -> int:
 	var animation_name = anim_name.to_snake_case()
-	var is_loopable = _spritesheet_metadata.tags.get(anim_name).get("loops")
 
 	# Create animation library if it doesn't exist
 	if not _player.has_animation_library(_DEFAULT_AL):

--- a/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
+++ b/addons/popochiu/editor/importers/aseprite/animation_creator_base.gd
@@ -7,7 +7,8 @@ extends RefCounted
 ## from Aseprite files for different node types.
 
 const RESULT_CODE = preload("res://addons/popochiu/editor/config/result_codes.gd")
-const _DEFAULT_AL = PopochiuEditorHelper.EMPTY_STRING # Empty string equals default "Global" animation library
+# Empty string equals default "Global" animation library
+const _DEFAULT_AL = PopochiuEditorHelper.EMPTY_STRING
 
 # Vars configured on initialization
 var _file_system: EditorFileSystem
@@ -81,7 +82,9 @@ func setup_autoplay(animation: String = PopochiuEditorHelper.EMPTY_STRING) -> vo
 
 #region Protected #################################################################################
 ## Main animation creation logic that handles both full-file and tag-based imports.
-func _create_animations(target_node: Node, options: Dictionary, tag: String = PopochiuEditorHelper.EMPTY_STRING) -> int:
+func _create_animations(
+	target_node: Node, options: Dictionary, tag: String = PopochiuEditorHelper.EMPTY_STRING
+) -> int:
 	var result := _setup_common(target_node, options)
 	if result != RESULT_CODE.SUCCESS:
 		return result
@@ -96,7 +99,7 @@ func _create_animations(target_node: Node, options: Dictionary, tag: String = Po
 		result = await _create_spritesheet_from_file()
 	else:
 		result = await _create_spritesheet_from_tag(tag)
-	
+
 	if result != RESULT_CODE.SUCCESS:
 		return result
 
@@ -108,7 +111,7 @@ func _create_animations(target_node: Node, options: Dictionary, tag: String = Po
 	# Set the texture and configure animations
 	_setup_texture()
 	result = _configure_animations()
-	
+
 	return result
 
 
@@ -121,7 +124,7 @@ func _setup_common(target_node: Node, options: Dictionary) -> int:
 			RESULT_CODE.get_error_message(RESULT_CODE.ERR_NO_ANIMATION_PLAYER_FOUND)
 		)
 		return RESULT_CODE.ERR_NO_ANIMATION_PLAYER_FOUND
-	
+
 	_options = options
 	return RESULT_CODE.SUCCESS
 
@@ -255,7 +258,7 @@ func _load_spritesheet_metadata(selected_tag: String = PopochiuEditorHelper.EMPT
 			to = ft.to,
 			direction = ft.direction,
 		})
-	
+
 	# If a tag is specified, adjust frame range
 	if not selected_tag.is_empty():
 		var t = _spritesheet_metadata.tags[selected_tag]
@@ -361,7 +364,7 @@ func _add_animation_frames(
 
 	var animation = _player.get_animation(animation_name)
 	_create_meta_tracks(animation)
-	
+
 	var frame_track: String = _get_frame_property_track()
 	var frame_track_index = _create_track(_target_sprite, animation, frame_track)
 
@@ -434,13 +437,13 @@ func _perform_common_checks() -> int:
 
 	if _target_sprite == null:
 		return RESULT_CODE.ERR_NO_SPRITE_FOUND
-	
+
 	if typeof(_options.get("tags")) != TYPE_ARRAY:
 		return RESULT_CODE.ERR_TAGS_OPTIONS_ARRAY_EMPTY
 
 	if _options.wipe_old_animations:
 		_remove_animations_from_player(_player)
-	
+
 	return RESULT_CODE.SUCCESS
 
 

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -61,7 +61,7 @@ func export_layer(file_name: String, layer_name: String, output_folder: String, 
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 	arguments.push_front(layer_name)
 	arguments.push_front("--layer")
-	
+
 	_add_sheet_type_arguments(arguments, options)
 
 	var exit_code = _execute(arguments, output)
@@ -131,7 +131,7 @@ func export_frame_range(
 	}
 
 
-func list_layers(file_name: String, only_visible = false) -> Array:
+func list_layers(file_name: String, only_visible: bool = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layers", file_name]
 
@@ -184,23 +184,23 @@ func list_tags_with_ranges(file_name: String) -> Array:
 	return tags
 
 
-func is_valid_spritesheet(content):
+func is_valid_spritesheet(content: Dictionary) -> bool:
 	return content.has("frames") and content.has("meta") and content.meta.has('image')
 
 
-func get_content_frames(content):
-	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
+func get_content_frames(content: Dictionary) -> Array:
+	return content.frames if typeof(content.frames) == TYPE_ARRAY else content.frames.values()
 
 
-func get_content_meta_tags(content):
+func get_content_meta_tags(content: Dictionary) -> Array:
 	return content.meta.frameTags if content.meta.has("frameTags")  else []
 
 
-func check_command_path():
+func check_command_path() -> bool:
 	# On Linux, MacOS or other *nix platforms, nothing to do
 	if not OS.get_name() in ["Windows", "UWP"]:
 		return true
-	
+
 	# On Windows, OS.Execute() calls trigger an uncatchable
 	# internal error if the invoked executable is not found.
 	# Since the error is unclear, we have to check that the aseprite
@@ -213,9 +213,8 @@ func check_command_path():
 		FileAccess.file_exists(_get_aseprite_command())
 
 
-func test_command():
-	var exit_code = OS.execute(_get_aseprite_command(), ['--version'], [], true)
-	return exit_code == 0
+func test_command() -> bool:
+	return OS.execute(_get_aseprite_command(), ['--version'], [], true) == 0
 
 
 
@@ -252,10 +251,10 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
 	return exception_layers
 
 
-func _sanitize_list_output(output) -> Array:
+func _sanitize_list_output(output: Array) -> Array:
 	if output.is_empty():
 		return output
-	
+
 	var raw = output[0].split('\n')
 	var sanitized = []
 	for s in raw:
@@ -277,7 +276,7 @@ func _export_command_common_arguments(source_name: String, data_path: String, sp
 	]
 
 
-func _execute(arguments, output) -> int:
+func _execute(arguments: Array, output: Array) -> int:
 	return OS.execute(_get_aseprite_command(), arguments, output, true, true)
 
 
@@ -289,15 +288,16 @@ func _get_file_basename(file_path: String) -> String:
 	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
 
 
-func _compile_regex(pattern):
+func _compile_regex(pattern: String) -> RegEx:
 	if pattern == PopochiuEditorHelper.EMPTY_STRING:
-		return
+		return null
 
 	var rgx = RegEx.new()
 	if rgx.compile(pattern) == OK:
 		return rgx
 
 	printerr('[Popochiu] exception regex error')
+	return null
 
 
 # Exports only the sprite metadata (no sheet, so it is fast) and reads the tag

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -30,76 +30,43 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 		printerr(output)
 		return {}
 
-	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
-	}
+	return _export_result(data_file, sprite_sheet)
 
 
 func export_layers(file_name: String, output_folder: String, options: Dictionary) -> Array:
 	var exception_pattern = options.get('exception_pattern', PopochiuEditorHelper.EMPTY_STRING)
 	var only_visible_layers = options.get('only_visible_layers', false)
-	var basename = _get_file_basename(file_name)
 	var layers = list_layers(file_name, only_visible_layers)
 	var exception_regex = _compile_regex(exception_pattern)
 
 	var output = []
 
 	for layer in layers:
-		if layer != PopochiuEditorHelper.EMPTY_STRING and (not exception_regex or exception_regex.search(layer) == null):
+		if (
+			layer != PopochiuEditorHelper.EMPTY_STRING
+			and (not exception_regex or exception_regex.search(layer) == null)
+		):
 			output.push_back(export_layer(file_name, layer, output_folder, options))
 
 	return output
 
 
-func export_layer(file_name: String, layer_name: String, output_folder: String, options: Dictionary) -> Dictionary:
-	var output_prefix = options.get('output_filename', PopochiuEditorHelper.EMPTY_STRING).strip_edges()
-	var output_dir = output_folder.replace("res://", "./").strip_edges()
-	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, layer_name]
-	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, layer_name]
-	var output = []
-	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
-	arguments.push_front(layer_name)
-	arguments.push_front("--layer")
-
-	_add_sheet_type_arguments(arguments, options)
-
-	var exit_code = _execute(arguments, output)
-	if exit_code != 0:
-		printerr('[Popochiu] Aseprite: Failed to export layer spritesheet. Command output follows:')
-		print(output)
-		return {}
-
-	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
-	}
+func export_layer(
+	file_name: String, layer_name: String, output_folder: String, options: Dictionary
+) -> Dictionary:
+	return _export_with_selector(
+		["--layer", layer_name], layer_name, file_name, output_folder, options
+	)
 
 
 # IMPROVE: See if we can extract JSON data limited to the single tag
 # (so we don't have to reckon offset framerange)
-func export_tag(file_name: String, tag_name: String, output_folder: String, options: Dictionary) -> Dictionary:
-	var output_prefix = options.get('output_filename', PopochiuEditorHelper.EMPTY_STRING).strip_edges()
-	var output_dir = output_folder.replace("res://", "./").strip_edges()
-	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, tag_name]
-	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, tag_name]
-	var output = []
-	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
-	arguments.push_front(tag_name)
-	arguments.push_front("--tag")
-
-	_add_sheet_type_arguments(arguments, options)
-
-	var exit_code = _execute(arguments, output)
-	if exit_code != 0:
-		printerr('[Popochiu] Aseprite: Failed to export tag spritesheet. Command output follows:')
-		print(output)
-		return {}
-
-	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
-	}
+func export_tag(
+	file_name: String, tag_name: String, output_folder: String, options: Dictionary
+) -> Dictionary:
+	return _export_with_selector(
+		["--tag", tag_name], tag_name, file_name, output_folder, options
+	)
 
 
 # Exports the frames inside the given [from, to] range into a single spritesheet.
@@ -108,27 +75,9 @@ func export_tag(file_name: String, tag_name: String, output_folder: String, opti
 func export_frame_range(
 	file_name: String, name: String, from: int, to: int, output_folder: String, options: Dictionary
 ) -> Dictionary:
-	var output_prefix = options.get('output_filename', PopochiuEditorHelper.EMPTY_STRING).strip_edges()
-	var output_dir = output_folder.replace("res://", "./").strip_edges()
-	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, name]
-	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, name]
-	var output = []
-	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
-	arguments.push_front("%d,%d" % [from, to])
-	arguments.push_front("--frame-range")
-
-	_add_sheet_type_arguments(arguments, options)
-
-	var exit_code = _execute(arguments, output)
-	if exit_code != 0:
-		printerr('[Popochiu] Aseprite: Failed to export frame range spritesheet. Command output follows:')
-		print(output)
-		return {}
-
-	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
-	}
+	return _export_with_selector(
+		["--frame-range", "%d,%d" % [from, to]], name, file_name, output_folder, options
+	)
 
 
 func list_layers(file_name: String, only_visible: bool = false) -> Array:
@@ -193,7 +142,7 @@ func get_content_frames(content: Dictionary) -> Array:
 
 
 func get_content_meta_tags(content: Dictionary) -> Array:
-	return content.meta.frameTags if content.meta.has("frameTags")  else []
+	return content.meta.frameTags if content.meta.has("frameTags") else []
 
 
 func check_command_path() -> bool:
@@ -219,7 +168,55 @@ func test_command() -> bool:
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
-func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_pattern: String) -> void:
+# Runs an Aseprite export that targets part of the file (a layer, a tag or a
+# frame range), writing the spritesheet to files named after [param output_name],
+# and returns the {'data_file', 'sprite_sheet'} dictionary (or {} on failure).
+# [param selector_args] are prepended to the Aseprite command, e.g.
+# ["--tag", "Run"].
+func _export_with_selector(
+	selector_args: Array,
+	output_name: String,
+	file_name: String,
+	output_folder: String,
+	options: Dictionary
+) -> Dictionary:
+	var output_prefix: String = options.get(
+		'output_filename', PopochiuEditorHelper.EMPTY_STRING
+	).strip_edges()
+	var output_dir := output_folder.replace("res://", "./").strip_edges()
+	var data_file := "%s/%s%s.json" % [output_dir, output_prefix, output_name]
+	var sprite_sheet := "%s/%s%s.png" % [output_dir, output_prefix, output_name]
+	var output := []
+	var arguments := selector_args + _export_command_common_arguments(
+		file_name, data_file, sprite_sheet
+	)
+
+	_add_sheet_type_arguments(arguments, options)
+
+	var exit_code := _execute(arguments, output)
+	if exit_code != 0:
+		printerr(
+			'[Popochiu] Aseprite: failed to export spritesheet for "%s". Command output follows:'
+			% output_name
+		)
+		print(output)
+		return {}
+
+	return _export_result(data_file, sprite_sheet)
+
+
+# Builds the dictionary returned by the export functions from the generated
+# data and sprite sheet files (paths are converted back to res://).
+func _export_result(data_file: String, sprite_sheet: String) -> Dictionary:
+	return {
+		'data_file': data_file.replace("./", "res://"),
+		"sprite_sheet": sprite_sheet.replace("./", "res://")
+	}
+
+
+func _add_ignore_layer_arguments(
+	file_name: String, arguments: Array, exception_pattern: String
+) -> void:
 	var layers = _get_exception_layers(file_name, exception_pattern)
 	if not layers.is_empty():
 		for l in layers:
@@ -227,8 +224,8 @@ func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_
 			arguments.push_front('--ignore-layer')
 
 
-func _add_sheet_type_arguments(arguments: Array, options : Dictionary) -> void:
-	var column_count : int = options.get("column_count", 0)
+func _add_sheet_type_arguments(arguments: Array, options: Dictionary) -> void:
+	var column_count: int = options.get("column_count", 0)
 	if column_count > 0:
 		arguments.push_back("--merge-duplicates") # Yes, this is undocumented
 		arguments.push_back("--sheet-columns")
@@ -262,7 +259,9 @@ func _sanitize_list_output(output: Array) -> Array:
 	return sanitized
 
 
-func _export_command_common_arguments(source_name: String, data_path: String, spritesheet_path: String) -> Array:
+func _export_command_common_arguments(
+	source_name: String, data_path: String, spritesheet_path: String
+) -> Array:
 	return [
 		"-b",
 		"--list-tags",

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -102,6 +102,35 @@ func export_tag(file_name: String, tag_name: String, output_folder: String, opti
 	}
 
 
+# Exports the frames inside the given [from, to] range into a single spritesheet.
+# Used to import a "group tag": one prop with several animations, where the
+# spritesheet only contains the frames covered by the group's range.
+func export_frame_range(
+	file_name: String, name: String, from: int, to: int, output_folder: String, options: Dictionary
+) -> Dictionary:
+	var output_prefix = options.get('output_filename', PopochiuEditorHelper.EMPTY_STRING).strip_edges()
+	var output_dir = output_folder.replace("res://", "./").strip_edges()
+	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, name]
+	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, name]
+	var output = []
+	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
+	arguments.push_front("%d,%d" % [from, to])
+	arguments.push_front("--frame-range")
+
+	_add_sheet_type_arguments(arguments, options)
+
+	var exit_code = _execute(arguments, output)
+	if exit_code != 0:
+		printerr('[Popochiu] Aseprite: Failed to export frame range spritesheet. Command output follows:')
+		print(output)
+		return {}
+
+	return {
+		'data_file': data_file.replace("./", "res://"),
+		"sprite_sheet": sprite_sheet.replace("./", "res://")
+	}
+
+
 func list_layers(file_name: String, only_visible = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layers", file_name]
@@ -131,6 +160,28 @@ func list_tags(file_name: String) -> Array:
 		return []
 
 	return _sanitize_list_output(output)
+
+
+# Lists the tags of a file together with their frame ranges and direction.
+# `--list-tags` alone only prints tag names, so we export a throwaway spritesheet
+# and read the `meta.frameTags` from its JSON. This is what the importer dock
+# needs to detect "group tags".
+# Falls back to name-only tags whenever the ranges can't be obtained, so the
+# scan always shows the tag list.
+func list_tags_with_ranges(file_name: String) -> Array:
+	var tags := _fetch_tags_with_ranges(file_name)
+
+	# Fallback: if we couldn't get the frame ranges, at least return the tag
+	# names so the importer still works (groups just won't be detected).
+	if tags.is_empty():
+		var names := list_tags(file_name)
+		if not names.is_empty():
+			printerr('[Popochiu] Aseprite: could not read tag frame ranges; groups will not be detected')
+		for name in names:
+			if not name.is_empty():
+				tags.push_back({ "tag_name": name })
+
+	return tags
 
 
 func is_valid_spritesheet(content):
@@ -247,3 +298,52 @@ func _compile_regex(pattern):
 		return rgx
 
 	printerr('[Popochiu] exception regex error')
+
+
+# Exports a throwaway spritesheet and reads the frame tags from it.
+# Returns an empty array on any failure.
+# The export is written to the project folder using relative paths (the same
+# style as the working import exports), because some sandboxed Aseprite
+# installs cannot write to the OS temp directory.
+func _fetch_tags_with_ranges(file_name: String) -> Array:
+	var temp_name := "popochiu_tags_%d_%d" % [Time.get_ticks_msec(), randi()]
+	var data_file := "res://%s.json" % temp_name
+	var sprite_sheet := "res://%s.png" % temp_name
+	var output := []
+	var arguments := _export_command_common_arguments(
+		file_name, "./%s.json" % temp_name, "./%s.png" % temp_name
+	)
+	_add_sheet_type_arguments(arguments, {})
+
+	var tags := []
+	var exit_code := _execute(arguments, output)
+	if exit_code != 0:
+		printerr('[Popochiu] Aseprite: failed to export tags metadata (exit code %d)' % exit_code)
+		printerr(output)
+	elif not FileAccess.file_exists(data_file):
+		printerr('[Popochiu] Aseprite: export succeeded but no JSON data file was produced at %s' % data_file)
+	elif FileAccess.file_exists(data_file):
+		var file := FileAccess.open(data_file, FileAccess.READ)
+		if file != null:
+			var json := JSON.new()
+			if json.parse(file.get_as_text()) == OK and json.data is Dictionary:
+				for ft in json.data.get("meta", {}).get("frameTags", []):
+					tags.push_back({
+						"tag_name": ft.name,
+						"from": ft.from,
+						"to": ft.to,
+						"direction": ft.direction,
+					})
+				if tags.is_empty():
+					printerr('[Popochiu] Aseprite: no frame tags found in the exported metadata')
+			else:
+				printerr('[Popochiu] Aseprite: could not parse the exported JSON metadata')
+			file.close()
+
+	# Always clean up the throwaway files
+	if FileAccess.file_exists(data_file):
+		DirAccess.remove_absolute(data_file)
+	if FileAccess.file_exists(sprite_sheet):
+		DirAccess.remove_absolute(sprite_sheet)
+	return tags
+

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -125,8 +125,8 @@ func list_tags_with_ranges(file_name: String) -> Array:
 	if tags.is_empty():
 		var names := list_tags(file_name)
 		if not names.is_empty():
-			printerr('[Popochiu] Aseprite: could not read tag frame ranges; groups will not be detected')
-		for name in names:
+			PopochiuUtils.print_error('Aseprite: could not read tag frame ranges; groups will not be detected')
+		for name: String in names:
 			if not name.is_empty():
 				tags.push_back({ "tag_name": name })
 
@@ -195,8 +195,8 @@ func _export_with_selector(
 
 	var exit_code := _execute(arguments, output)
 	if exit_code != 0:
-		printerr(
-			'[Popochiu] Aseprite: failed to export spritesheet for "%s". Command output follows:'
+		PopochiuUtils.print_error(
+			'Aseprite: failed to export spritesheet for "%s". Command output follows:'
 			% output_name
 		)
 		print(output)
@@ -321,7 +321,7 @@ func _fetch_tags_with_ranges(file_name: String) -> Array:
 	var tags := []
 	var exit_code := _execute(arguments, output)
 	if exit_code != 0:
-		printerr('[Popochiu] Aseprite: failed to export tags metadata (exit code %d)' % exit_code)
+		PopochiuUtils.print_error('Aseprite: failed to export tags metadata (exit code %d)' % exit_code)
 		printerr(output)
 	elif not FileAccess.file_exists(data_file):
 		printerr(
@@ -341,9 +341,9 @@ func _fetch_tags_with_ranges(file_name: String) -> Array:
 						"direction": ft.direction,
 					})
 				if tags.is_empty():
-					printerr('[Popochiu] Aseprite: no frame tags found in the exported metadata')
+					PopochiuUtils.print_error('Aseprite: no frame tags found in the exported metadata')
 			else:
-				printerr('[Popochiu] Aseprite: could not parse the exported JSON metadata')
+				PopochiuUtils.print_error('Aseprite: could not parse the exported JSON metadata')
 			file.close()
 
 	# Always clean up the throwaway file

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -300,20 +300,24 @@ func _compile_regex(pattern):
 	printerr('[Popochiu] exception regex error')
 
 
-# Exports a throwaway spritesheet and reads the frame tags from it.
-# Returns an empty array on any failure.
+# Exports only the sprite metadata (no sheet, so it is fast) and reads the tag
+# frame ranges from it. Returns an empty array on any failure.
 # The export is written to the project folder using relative paths (the same
 # style as the working import exports), because some sandboxed Aseprite
 # installs cannot write to the OS temp directory.
 func _fetch_tags_with_ranges(file_name: String) -> Array:
 	var temp_name := "popochiu_tags_%d_%d" % [Time.get_ticks_msec(), randi()]
 	var data_file := "res://%s.json" % temp_name
-	var sprite_sheet := "res://%s.png" % temp_name
 	var output := []
-	var arguments := _export_command_common_arguments(
-		file_name, "./%s.json" % temp_name, "./%s.png" % temp_name
-	)
-	_add_sheet_type_arguments(arguments, {})
+	var arguments := [
+		"-b",
+		"--list-tags",
+		"--data",
+		"./%s.json" % temp_name,
+		"--format",
+		"json-array",
+		file_name,
+	]
 
 	var tags := []
 	var exit_code := _execute(arguments, output)
@@ -340,10 +344,8 @@ func _fetch_tags_with_ranges(file_name: String) -> Array:
 				printerr('[Popochiu] Aseprite: could not parse the exported JSON metadata')
 			file.close()
 
-	# Always clean up the throwaway files
+	# Always clean up the throwaway file
 	if FileAccess.file_exists(data_file):
 		DirAccess.remove_absolute(data_file)
-	if FileAccess.file_exists(sprite_sheet):
-		DirAccess.remove_absolute(sprite_sheet)
 	return tags
 

--- a/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_controller.gd
@@ -306,14 +306,14 @@ func _compile_regex(pattern):
 # style as the working import exports), because some sandboxed Aseprite
 # installs cannot write to the OS temp directory.
 func _fetch_tags_with_ranges(file_name: String) -> Array:
-	var temp_name := "popochiu_tags_%d_%d" % [Time.get_ticks_msec(), randi()]
-	var data_file := "res://%s.json" % temp_name
+	var relative_data_file := "./popochiu_tags_%d_%d.json" % [Time.get_ticks_msec(), randi()]
+	var data_file := relative_data_file.replace("./", "res://")
 	var output := []
 	var arguments := [
 		"-b",
 		"--list-tags",
 		"--data",
-		"./%s.json" % temp_name,
+		relative_data_file,
 		"--format",
 		"json-array",
 		file_name,
@@ -325,8 +325,11 @@ func _fetch_tags_with_ranges(file_name: String) -> Array:
 		printerr('[Popochiu] Aseprite: failed to export tags metadata (exit code %d)' % exit_code)
 		printerr(output)
 	elif not FileAccess.file_exists(data_file):
-		printerr('[Popochiu] Aseprite: export succeeded but no JSON data file was produced at %s' % data_file)
-	elif FileAccess.file_exists(data_file):
+		printerr(
+			'[Popochiu] Aseprite: export succeeded but no JSON data file was produced at %s'
+			% data_file
+		)
+	else:
 		var file := FileAccess.open(data_file, FileAccess.READ)
 		if file != null:
 			var json := JSON.new()

--- a/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
@@ -2,40 +2,63 @@
 class_name PopochiuAsepriteTagGrouper
 extends RefCounted
 
-# Detects and validates "group tags" in the list of Aseprite tags of a file.
+# Groups Aseprite tags using an EXPLICIT prefix convention (no guessing):
+#   "@Door"            -> a group tag. The prop will be named "Door". The group
+#                         tag's own frame range is the group's SPAN: it is used
+#                         both to export the group spritesheet and to validate
+#                         that every ":..." animation is fully inside it.
+#   ":DoorClosed"      -> an animation of group "Door", named "closed".
+#   plain tags         -> standalone single-animation props (unchanged behavior).
 #
-# A tag is a group when its frame range fully contains other tags and its name
-# is a case-insensitive prefix of all of them (CamelCase or snake_case). A group
-# is imported as a single prop with one animation per child tag, named after the
-# child with the group prefix stripped (e.g. group "Door" + tags "DoorClose" and
-# "DoorOpen" -> prop "Door" with animations "close" and "open").
+# Association is by NAME: ":DoorClosed" belongs to "@Door". The "@" and ":"
+# characters are reserved for this convention. Misconfigurations are reported
+# as errors or warnings instead of being silently guessed.
 #
-# Any misconfiguration (a contained tag that doesn't follow the naming, nested
-# groups, etc.) invalidates the whole cluster: the importer must skip it and
-# report the problem instead of guessing.
+# When frame ranges are available (fetched at scan time for files with group
+# tags), the grouper also validates that every animation is fully inside its
+# group's span, and the safety net only warns for plain tags that actually fall
+# inside a group's span.
+
+
+const GROUP_PREFIX := "@"
+const ANIM_PREFIX := ":"
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
-# Analyzes a list of tags (each with tag_name/from/to/direction) and returns:
+# Analyzes a list of tags (each with tag_name, and optionally from/to/direction)
+# and returns:
 # {
-#   groups: [ { name, from, to, direction, children: [{tag_name, anim_name, from, to, direction}], is_valid, error } ],
-#   singles: [ { tag_name, from, to, direction } ],
-#   errors: [ String, ... ]
-#   warnings: [ String, ... ],
+#   items: [ {kind:"group", ...} | {kind:"single", tag:{...}} ],  # source order
+#   groups: [...],    # the group entries (same objects as in items)
+#   singles: [...],   # the plain tag dicts
+#   errors: [String, ...],
+#   warnings: [String, ...],
 # }
 func analyze(tags: Array) -> Dictionary:
 	var result := {
+		"items": [],
 		"groups": [],
 		"singles": [],
 		"errors": [],
 		"warnings": [],
 	}
 
-	# Only tags with a usable frame range can take part in a group. Ranges can
-	# arrive as int or float (Godot's JSON parser may produce floats), so they
-	# are normalized to int here.
-	var ranged := []
+	var group_names := {}  # lower(name) -> display name ("Door")
+	var group_spans := {}  # lower(name) -> {from, to} of the @ tag, or null
+	var group_name_count := {}  # lower(name) -> how many @ tags share it
 	for tag in tags:
+		var name: String = tag.get("tag_name", "")
+		if not name.begins_with(GROUP_PREFIX):
+			continue
+		if name.length() == 1:
+			result.errors.append(
+				"Aseprite importer: tag '%s' is not a valid group tag (missing name)." % name
+			)
+			continue
+		var display := name.substr(1)
+		var lower := display.to_lower()
+		group_names[lower] = display
+		group_name_count[lower] = group_name_count.get(lower, 0) + 1
 		var tag_from = tag.get("from")
 		var tag_to = tag.get("to")
 		if (
@@ -44,174 +67,243 @@ func analyze(tags: Array) -> Dictionary:
 			and int(tag_from) >= 0
 			and int(tag_to) >= int(tag_from)
 		):
-			var ranged_tag: Dictionary = tag.duplicate()
-			ranged_tag.from = int(tag_from)
-			ranged_tag.to = int(tag_to)
-			ranged.push_back(ranged_tag)
+			group_spans[lower] = { "from": int(tag_from), "to": int(tag_to) }
+		else:
+			group_spans[lower] = null
 
-	# Compute which tags are fully contained in the range of each tag
-	var contained_by := {}
-	for tag in ranged:
-		contained_by[tag.tag_name] = []
-	for outer in ranged:
-		for inner in ranged:
-			if inner.tag_name == outer.tag_name:
-				continue
-			# A tag with the exact same range is not "inside" another one: with
-			# identical ranges every tag would contain every other, making them
-			# all "claimed" and dropping them from the list.
-			if inner.from == outer.from and inner.to == outer.to:
-				continue
-			if outer.from <= inner.from and inner.to <= outer.to:
-				contained_by[outer.tag_name].push_back(inner)
+	# Duplicate group names (case-insensitive) are ambiguous and must be fixed
+	var duplicate_groups := {}
+	for lower in group_name_count:
+		if group_name_count[lower] > 1:
+			duplicate_groups[lower] = true
+			result.errors.append(
+				"Aseprite importer: multiple group tags are named '%s' (case-insensitive). "
+				% group_names[lower]
+				+ "Rename them so each group name is unique."
+			)
 
-	# Tags contained in at least one other tag belong to a cluster: they must not
-	# be offered as standalone tags (they are either group children or blocked
-	# with their group)
-	var claimed := {}
-	for tag in ranged:
-		for inner in contained_by.get(tag.tag_name, []):
-			claimed[inner.tag_name] = true
-
-	# Group candidates are tags that contain others. A candidate that is itself
-	# contained in another tag (nested group) is rendered as part of its parent's
-	# cluster, never as its own group.
-	var group_candidates := []
-	for tag in ranged:
-		if contained_by.get(tag.tag_name, []).is_empty():
+	# Associate every ":..." tag with its group by name (longest match wins)
+	var anims_by_group := {}  # lower(group name) -> [ {tag, anim_name} ]
+	for tag in tags:
+		var name: String = tag.get("tag_name", "")
+		if not name.begins_with(ANIM_PREFIX):
 			continue
-		if claimed.has(tag.tag_name):
+		if name.length() == 1:
+			result.errors.append(
+				"Aseprite importer: tag '%s' is not a valid animation tag (missing name)." % name
+			)
 			continue
-		group_candidates.push_back(tag)
 
-	for tag in group_candidates:
+		var remainder := name.substr(1)
+		var matched_lower := _find_matching_group(remainder, group_names, duplicate_groups, false)
+
+		if matched_lower.is_empty():
+			# Give a more precise message when the animation is named after a group
+			var looked_like_group := false
+			for lower in group_names:
+				if remainder.to_lower() == lower:
+					looked_like_group = true
+					break
+			if looked_like_group:
+				result.errors.append(
+					"Aseprite importer: animation tag '%s' has no animation name after the group prefix." % name
+				)
+			else:
+				result.errors.append(
+					"Aseprite importer: animation tag '%s' has no matching group. "
+					% name
+					+ "Expected ':GroupNameAnimation' with a corresponding '@GroupName' tag."
+				)
+			continue
+
+		if not anims_by_group.has(matched_lower):
+			anims_by_group[matched_lower] = []
+		anims_by_group[matched_lower].append({
+			"tag": tag,
+			"anim_name": _strip_group_from_name(remainder, matched_lower),
+		})
+
+	# Build the group entries in source order
+	var groups_by_tag := {}
+	for tag in tags:
+		var name: String = tag.get("tag_name", "")
+		if not name.begins_with(GROUP_PREFIX):
+			continue
+		if name.length() == 1:
+			continue  # already reported
+		var display := name.substr(1)
+		var lower := display.to_lower()
+		if duplicate_groups.has(lower):
+			continue  # already reported
+
+		var anims := anims_by_group.get(lower, [])
+		if anims.is_empty():
+			result.warnings.append(
+				"Aseprite importer: group '%s' has no animations. "
+				% display
+				+ "Add ':...' tags for it (e.g. ':%sClosed') or remove the '@%s' tag." % [display, display]
+			)
+			continue
+
 		var group := {
-			"name": tag.tag_name,
-			"from": tag.from,
-			"to": tag.to,
-			"direction": tag.direction,
+			"kind": "group",
+			"tag_name": name,
+			"name": display,
+			"from": -1,
+			"to": -1,
+			"direction": "forward",
 			"children": [],
 			"is_valid": true,
 			"error": "",
 		}
+		# The group's own frame range is the SPAN: it drives both the export
+		# range and the validation (animations must be fully inside it).
+		var span: Dictionary = group_spans.get(lower)
+		if span != null:
+			group.from = span.from
+			group.to = span.to
+
 		var errors := []
+		for anim in anims:
+			var child := {
+				"tag_name": anim.tag.tag_name,
+				"anim_name": anim.anim_name,
+			}
+			var cf = anim.tag.get("from")
+			var ct = anim.tag.get("to")
+			if typeof(cf) in [TYPE_INT, TYPE_FLOAT] and typeof(ct) in [TYPE_INT, TYPE_FLOAT]:
+				child.from = int(cf)
+				child.to = int(ct)
+				child.direction = anim.tag.get("direction", "forward")
+				# The group span must fully cover every animation. Frame numbers
+				# are shown 1-based to match the Aseprite editor UI.
+				if group.from < 0 or child.from < group.from or child.to > group.to:
+					errors.append(
+						"Aseprite importer: group '@%s' does not fully cover its animation '%s' "
+						% [display, child.tag_name]
+						+ "(group spans %d-%d, animation spans %d-%d). "
+						% [group.from + 1, group.to + 1, child.from + 1, child.to + 1]
+						+ "Extend the group tag range or move the animation inside it."
+					)
+			group.children.append(child)
 
-		for child in contained_by.get(tag.tag_name, []):
-			# Nested groups are not supported: a child cannot span other tags itself
-			if not contained_by.get(child.tag_name, []).is_empty():
-				errors.append(
-					"Tag '%s' contains other tags. Nested groups are not supported." % child.tag_name
-				)
-				continue
-
-			# The child name must follow the group naming convention
-			var anim_name := strip_prefix(child.tag_name, tag.tag_name)
-			if anim_name.is_empty():
-				errors.append(
-					"Tag '%s' is inside the range of '%s' but does not follow the naming convention "
-					% [child.tag_name, tag.tag_name]
-					+ "(it must start with '%s' and have a distinct name, e.g. '%sClose')."
-					% [tag.tag_name, tag.tag_name]
-				)
-				continue
-
-			group.children.push_back({
-				"tag_name": child.tag_name,
-				"anim_name": anim_name,
-				"from": child.from,
-				"to": child.to,
-				"direction": child.direction,
-			})
-
-		# A tag that follows the group naming but is only partially inside the
-		# group's range means the group doesn't encompass all its animations.
-		# Such tags belong to the cluster and must not be imported standalone.
-		for other in ranged:
-			if other.tag_name == tag.tag_name:
-				continue
-			if not _matches_prefix(other.tag_name, tag.tag_name):
-				continue
-			if _is_contained(other, tag, contained_by):
-				continue
-			if other.from <= tag.to and tag.from <= other.to:
-				claimed[other.tag_name] = true
-				errors.append(
-					"Tag '%s' follows the group naming of '%s' but is only partially inside its range "
-					% [other.tag_name, tag.tag_name]
-					+ "(%d-%d). The group must fully encompass all its animations." % [tag.from, tag.to]
-				)
+		if group.from < 0:
+			errors.append(
+				"Aseprite importer: group '@%s' has no usable frame range." % name
+			)
 
 		if errors.is_empty():
 			_check_group_gaps(result, group)
-			result.groups.push_back(group)
 		else:
 			group.is_valid = false
 			group.error = " ".join(errors)
 			result.errors.append(group.error)
-			result.groups.push_back(group)
 
-	# Tags that don't belong to any cluster are standalone. Iterate the FULL tag
-	# list (not just ranged ones): when frame ranges are unavailable the tags
-	# still render as a flat list, so a failed range fetch never empties the list.
+		result.groups.append(group)
+		groups_by_tag[name] = group
+
+	# Safety net: a plain tag that matches a group name and falls inside the
+	# group's span probably means a forgotten ':' prefix. Plain tags outside
+	# the span are legit separate props.
 	for tag in tags:
-		if claimed.has(tag.tag_name) or not contained_by.get(tag.tag_name, []).is_empty():
+		var name: String = tag.get("tag_name", "")
+		if name.begins_with(GROUP_PREFIX) or name.begins_with(ANIM_PREFIX):
 			continue
-		result.singles.push_back(tag)
+		var matched_lower := _find_matching_group(name, group_names, duplicate_groups, true)
+		if matched_lower.is_empty():
+			continue
+		var span: Dictionary = group_spans.get(matched_lower)
+		if span != null and not _is_fully_inside(tag, span):
+			continue  # outside the group's span: a legit separate prop
+		result.warnings.append(
+			"Aseprite importer: plain tag '%s' matches group '%s'%s. Did you forget the ':' prefix?"
+			% [name, group_names[matched_lower], "" if span == null else " and is inside its range"]
+		)
+
+	# Build the ordered item list and the standalone singles
+	for tag in tags:
+		var name: String = tag.get("tag_name", "")
+		if name.begins_with(GROUP_PREFIX):
+			if groups_by_tag.has(name):
+				result.items.append(groups_by_tag[name])
+			continue
+		if name.begins_with(ANIM_PREFIX):
+			continue
+		result.singles.append(tag)
+		result.items.append({ "kind": "single", "tag": tag })
 
 	return result
 
 
-# Returns the animation name for a child tag of a group (prefix stripped and
+# Returns the animation name for a ":GroupAnim" tag (group prefix stripped and
 # snake_cased), or an empty string when the name doesn't follow the convention.
-# A word boundary is required after the prefix so that names that merely share a
-# prefix (e.g. "Doors" inside "Door") are not treated as children.
-func strip_prefix(child_name: String, group_name: String) -> String:
-	var lower_child := child_name.to_lower()
-	var lower_group := group_name.to_lower()
-
-	if not lower_child.begins_with(lower_group):
+# The name must begin with the group name, and a word boundary is required right
+# after it so that names that merely share a prefix (e.g. "Doors" under group
+# "Door", or unrelated names like "TestAnim" under "Door") are not matched.
+func _strip_group_from_name(remainder: String, lower_group: String) -> String:
+	if not remainder.to_lower().begins_with(lower_group):
 		return ""
-
-	# A tag with the exact same name (case-insensitive) is not a child
-	if child_name.length() == group_name.length():
+	if remainder.to_lower() == lower_group:
 		return ""
-
-	# Require a separator or an uppercase letter right after the prefix
-	var next_char := child_name.substr(group_name.length(), 1)
+	var next_char := remainder.substr(lower_group.length(), 1)
 	if not (next_char == "_" or next_char == " " or _is_uppercase(next_char)):
 		return ""
-
-	var remainder := child_name.substr(group_name.length())
-	remainder = remainder.trim_prefix("_").trim_prefix(" ")
-	return remainder.to_snake_case()
+	var rest := remainder.substr(lower_group.length()).trim_prefix("_").trim_prefix(" ")
+	return rest.to_snake_case()
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
-# Whether the child name follows the group naming convention.
-func _matches_prefix(child_name: String, group_name: String) -> bool:
-	return not strip_prefix(child_name, group_name).is_empty()
+# Returns the lower-cased name of the longest group that [param remainder]
+# matches (case-insensitive, with a word boundary after the group name), or ""
+# when none matches. [param allow_exact] also accepts a name that is exactly the
+# group name (used by the safety net, not by the animation association).
+func _find_matching_group(remainder: String, group_names: Dictionary, duplicate_groups: Dictionary, allow_exact: bool) -> String:
+	var matched_lower := ""
+	var matched_display := ""
+	for lower in group_names:
+		if duplicate_groups.has(lower):
+			continue
+		if not remainder.to_lower().begins_with(lower):
+			continue
+		if group_names[lower].length() <= matched_display.length():
+			continue
+		if (
+			_strip_group_from_name(remainder, lower).is_empty()
+			and not (allow_exact and remainder.to_lower() == lower)
+		):
+			continue
+		matched_lower = lower
+		matched_display = group_names[lower]
+	return matched_lower
 
 
-# Whether [param inner] is fully contained in [param outer]'s range.
-func _is_contained(inner: Dictionary, outer: Dictionary, contained_by: Dictionary) -> bool:
-	for c in contained_by.get(outer.tag_name, []):
-		if c.tag_name == inner.tag_name:
-			return true
-	return false
+# Whether the tag's frame range is fully inside the given span.
+func _is_fully_inside(tag: Dictionary, span: Dictionary) -> bool:
+	var tag_from = tag.get("from")
+	var tag_to = tag.get("to")
+	if typeof(tag_from) not in [TYPE_INT, TYPE_FLOAT] or typeof(tag_to) not in [TYPE_INT, TYPE_FLOAT]:
+		return false
+	return span.from <= int(tag_from) and int(tag_to) <= span.to
 
 
-# Emits a warning when frames inside the group's range are not covered by any
+# Emits a warning when frames inside the group's span are not covered by any
 # child animation. The group is still imported (gaps are tolerated).
 func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
+	if group.get("from", -1) < 0 or group.get("to", -1) < group.get("from", -1):
+		return
 	var children: Array = group.get("children", [])
-	if children.is_empty():
+	var ranged_children := []
+	for child in children:
+		if child.has("from") and child.has("to"):
+			ranged_children.append(child)
+	if ranged_children.is_empty():
 		return
 
-	children.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return a.from < b.from)
+	ranged_children.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return a.from < b.from)
 
 	var uncovered := []
 	var cursor: int = group.from
-	for child in children:
+	for child in ranged_children:
 		if child.from > cursor:
 			uncovered.push_back([cursor, child.from - 1])
 		if child.to + 1 > cursor:
@@ -222,7 +314,8 @@ func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
 	if not uncovered.is_empty():
 		var ranges := []
 		for r in uncovered:
-			ranges.append("%d-%d" % [r[0], r[1]])
+			# Frame numbers are shown 1-based to match the Aseprite editor UI
+			ranges.append("%d-%d" % [r[0] + 1, r[1] + 1])
 		result.warnings.append(
 			"Aseprite importer: Group '%s' has frames not covered by any animation: %s. "
 			% [group.name, ", ".join(ranges)]

--- a/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
@@ -1,0 +1,234 @@
+@tool
+class_name PopochiuAsepriteTagGrouper
+extends RefCounted
+
+# Detects and validates "group tags" in the list of Aseprite tags of a file.
+#
+# A tag is a group when its frame range fully contains other tags and its name
+# is a case-insensitive prefix of all of them (CamelCase or snake_case). A group
+# is imported as a single prop with one animation per child tag, named after the
+# child with the group prefix stripped (e.g. group "Door" + tags "DoorClose" and
+# "DoorOpen" -> prop "Door" with animations "close" and "open").
+#
+# Any misconfiguration (a contained tag that doesn't follow the naming, nested
+# groups, etc.) invalidates the whole cluster: the importer must skip it and
+# report the problem instead of guessing.
+
+
+# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+# Analyzes a list of tags (each with tag_name/from/to/direction) and returns:
+# {
+#   groups: [ { name, from, to, direction, children: [{tag_name, anim_name, from, to, direction}], is_valid, error } ],
+#   singles: [ { tag_name, from, to, direction } ],
+#   errors: [ String, ... ]
+#   warnings: [ String, ... ],
+# }
+func analyze(tags: Array) -> Dictionary:
+	var result := {
+		"groups": [],
+		"singles": [],
+		"errors": [],
+		"warnings": [],
+	}
+
+	# Only tags with a usable frame range can take part in a group. Ranges can
+	# arrive as int or float (Godot's JSON parser may produce floats), so they
+	# are normalized to int here.
+	var ranged := []
+	for tag in tags:
+		var tag_from = tag.get("from")
+		var tag_to = tag.get("to")
+		if (
+			typeof(tag_from) in [TYPE_INT, TYPE_FLOAT]
+			and typeof(tag_to) in [TYPE_INT, TYPE_FLOAT]
+			and int(tag_from) >= 0
+			and int(tag_to) >= int(tag_from)
+		):
+			var ranged_tag: Dictionary = tag.duplicate()
+			ranged_tag.from = int(tag_from)
+			ranged_tag.to = int(tag_to)
+			ranged.push_back(ranged_tag)
+
+	# Compute which tags are fully contained in the range of each tag
+	var contained_by := {}
+	for tag in ranged:
+		contained_by[tag.tag_name] = []
+	for outer in ranged:
+		for inner in ranged:
+			if inner.tag_name == outer.tag_name:
+				continue
+			# A tag with the exact same range is not "inside" another one: with
+			# identical ranges every tag would contain every other, making them
+			# all "claimed" and dropping them from the list.
+			if inner.from == outer.from and inner.to == outer.to:
+				continue
+			if outer.from <= inner.from and inner.to <= outer.to:
+				contained_by[outer.tag_name].push_back(inner)
+
+	# Tags contained in at least one other tag belong to a cluster: they must not
+	# be offered as standalone tags (they are either group children or blocked
+	# with their group)
+	var claimed := {}
+	for tag in ranged:
+		for inner in contained_by.get(tag.tag_name, []):
+			claimed[inner.tag_name] = true
+
+	# Group candidates are tags that contain others. A candidate that is itself
+	# contained in another tag (nested group) is rendered as part of its parent's
+	# cluster, never as its own group.
+	var group_candidates := []
+	for tag in ranged:
+		if contained_by.get(tag.tag_name, []).is_empty():
+			continue
+		if claimed.has(tag.tag_name):
+			continue
+		group_candidates.push_back(tag)
+
+	for tag in group_candidates:
+		var group := {
+			"name": tag.tag_name,
+			"from": tag.from,
+			"to": tag.to,
+			"direction": tag.direction,
+			"children": [],
+			"is_valid": true,
+			"error": "",
+		}
+		var errors := []
+
+		for child in contained_by.get(tag.tag_name, []):
+			# Nested groups are not supported: a child cannot span other tags itself
+			if not contained_by.get(child.tag_name, []).is_empty():
+				errors.append(
+					"Tag '%s' contains other tags. Nested groups are not supported." % child.tag_name
+				)
+				continue
+
+			# The child name must follow the group naming convention
+			var anim_name := strip_prefix(child.tag_name, tag.tag_name)
+			if anim_name.is_empty():
+				errors.append(
+					"Tag '%s' is inside the range of '%s' but does not follow the naming convention "
+					% [child.tag_name, tag.tag_name]
+					+ "(it must start with '%s' and have a distinct name, e.g. '%sClose')."
+					% [tag.tag_name, tag.tag_name]
+				)
+				continue
+
+			group.children.push_back({
+				"tag_name": child.tag_name,
+				"anim_name": anim_name,
+				"from": child.from,
+				"to": child.to,
+				"direction": child.direction,
+			})
+
+		# A tag that follows the group naming but is only partially inside the
+		# group's range means the group doesn't encompass all its animations.
+		# Such tags belong to the cluster and must not be imported standalone.
+		for other in ranged:
+			if other.tag_name == tag.tag_name:
+				continue
+			if not _matches_prefix(other.tag_name, tag.tag_name):
+				continue
+			if _is_contained(other, tag, contained_by):
+				continue
+			if other.from <= tag.to and tag.from <= other.to:
+				claimed[other.tag_name] = true
+				errors.append(
+					"Tag '%s' follows the group naming of '%s' but is only partially inside its range "
+					% [other.tag_name, tag.tag_name]
+					+ "(%d-%d). The group must fully encompass all its animations." % [tag.from, tag.to]
+				)
+
+		if errors.is_empty():
+			_check_group_gaps(result, group)
+			result.groups.push_back(group)
+		else:
+			group.is_valid = false
+			group.error = " ".join(errors)
+			result.errors.append(group.error)
+			result.groups.push_back(group)
+
+	# Tags that don't belong to any cluster are standalone. Iterate the FULL tag
+	# list (not just ranged ones): when frame ranges are unavailable the tags
+	# still render as a flat list, so a failed range fetch never empties the list.
+	for tag in tags:
+		if claimed.has(tag.tag_name) or not contained_by.get(tag.tag_name, []).is_empty():
+			continue
+		result.singles.push_back(tag)
+
+	return result
+
+
+# Returns the animation name for a child tag of a group (prefix stripped and
+# snake_cased), or an empty string when the name doesn't follow the convention.
+# A word boundary is required after the prefix so that names that merely share a
+# prefix (e.g. "Doors" inside "Door") are not treated as children.
+func strip_prefix(child_name: String, group_name: String) -> String:
+	var lower_child := child_name.to_lower()
+	var lower_group := group_name.to_lower()
+
+	if not lower_child.begins_with(lower_group):
+		return ""
+
+	# A tag with the exact same name (case-insensitive) is not a child
+	if child_name.length() == group_name.length():
+		return ""
+
+	# Require a separator or an uppercase letter right after the prefix
+	var next_char := child_name.substr(group_name.length(), 1)
+	if not (next_char == "_" or next_char == " " or _is_uppercase(next_char)):
+		return ""
+
+	var remainder := child_name.substr(group_name.length())
+	remainder = remainder.trim_prefix("_").trim_prefix(" ")
+	return remainder.to_snake_case()
+
+
+# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+# Whether the child name follows the group naming convention.
+func _matches_prefix(child_name: String, group_name: String) -> bool:
+	return not strip_prefix(child_name, group_name).is_empty()
+
+
+# Whether [param inner] is fully contained in [param outer]'s range.
+func _is_contained(inner: Dictionary, outer: Dictionary, contained_by: Dictionary) -> bool:
+	for c in contained_by.get(outer.tag_name, []):
+		if c.tag_name == inner.tag_name:
+			return true
+	return false
+
+
+# Emits a warning when frames inside the group's range are not covered by any
+# child animation. The group is still imported (gaps are tolerated).
+func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
+	var children: Array = group.get("children", [])
+	if children.is_empty():
+		return
+
+	children.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return a.from < b.from)
+
+	var uncovered := []
+	var cursor: int = group.from
+	for child in children:
+		if child.from > cursor:
+			uncovered.push_back([cursor, child.from - 1])
+		if child.to + 1 > cursor:
+			cursor = child.to + 1
+	if cursor <= group.to:
+		uncovered.push_back([cursor, group.to])
+
+	if not uncovered.is_empty():
+		var ranges := []
+		for r in uncovered:
+			ranges.append("%d-%d" % [r[0], r[1]])
+		result.warnings.append(
+			"Aseprite importer: Group '%s' has frames not covered by any animation: %s. "
+			% [group.name, ", ".join(ranges)]
+			+ "They will be ignored."
+		)
+
+
+func _is_uppercase(char: String) -> bool:
+	return char != "" and char == char.to_upper() and char != char.to_lower()

--- a/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
@@ -24,7 +24,7 @@ const GROUP_PREFIX := "@"
 const ANIM_PREFIX := ":"
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PUBLIC ░░░░
+#region Public #####################################################################################
 # Analyzes a list of tags (each with tag_name, and optionally from/to/direction)
 # and returns:
 # {
@@ -84,7 +84,7 @@ func analyze(tags: Array) -> Dictionary:
 
 	# Associate every ":..." tag with its group by name (longest match wins)
 	var anims_by_group := {}  # lower(group name) -> [ {tag, anim_name} ]
-	for tag in tags:
+	for tag: Dictionary in tags:
 		var name: String = tag.get("tag_name", "")
 		if not name.begins_with(ANIM_PREFIX):
 			continue
@@ -100,7 +100,7 @@ func analyze(tags: Array) -> Dictionary:
 		if matched_lower.is_empty():
 			# Give a more precise message when the animation is named after a group
 			var looked_like_group := false
-			for lower in group_names:
+			for lower: String in group_names:
 				if remainder.to_lower() == lower:
 					looked_like_group = true
 					break
@@ -125,7 +125,7 @@ func analyze(tags: Array) -> Dictionary:
 
 	# Build the group entries in source order
 	var groups_by_tag := {}
-	for tag in tags:
+	for tag: Dictionary in tags:
 		var name: String = tag.get("tag_name", "")
 		if not name.begins_with(GROUP_PREFIX):
 			continue
@@ -205,7 +205,7 @@ func analyze(tags: Array) -> Dictionary:
 	# Safety net: a plain tag that matches a group name and falls inside the
 	# group's span probably means a forgotten ':' prefix. Plain tags outside
 	# the span are legit separate props.
-	for tag in tags:
+	for tag: Dictionary in tags:
 		var name: String = tag.get("tag_name", "")
 		if name.begins_with(GROUP_PREFIX) or name.begins_with(ANIM_PREFIX):
 			continue
@@ -221,7 +221,7 @@ func analyze(tags: Array) -> Dictionary:
 		)
 
 	# Build the ordered item list and the standalone singles
-	for tag in tags:
+	for tag: Dictionary in tags:
 		var name: String = tag.get("tag_name", "")
 		if name.begins_with(GROUP_PREFIX):
 			if groups_by_tag.has(name):
@@ -252,7 +252,9 @@ func _strip_group_from_name(remainder: String, lower_group: String) -> String:
 	return rest.to_snake_case()
 
 
-# ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░
+#endregion
+
+#region Private ####################################################################################
 # Returns the lower-cased name of the longest group that [param remainder]
 # matches (case-insensitive, with a word boundary after the group name), or ""
 # when none matches. [param allow_exact] also accepts a name that is exactly the
@@ -298,7 +300,7 @@ func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
 		return
 	var children: Array = group.get("children", [])
 	var ranged_children := []
-	for child in children:
+	for child: Dictionary in children:
 		if child.has("from") and child.has("to"):
 			ranged_children.append(child)
 	if ranged_children.is_empty():
@@ -308,7 +310,7 @@ func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
 
 	var uncovered := []
 	var cursor: int = group.from
-	for child in ranged_children:
+	for child: Dictionary in ranged_children:
 		if child.from > cursor:
 			uncovered.push_back([cursor, child.from - 1])
 		if child.to + 1 > cursor:
@@ -318,7 +320,7 @@ func _check_group_gaps(result: Dictionary, group: Dictionary) -> void:
 
 	if not uncovered.is_empty():
 		var ranges := []
-		for r in uncovered:
+		for r: Array in uncovered:
 			# Frame numbers are shown 1-based to match the Aseprite editor UI
 			ranges.append("%d-%d" % [r[0] + 1, r[1] + 1])
 		result.warnings.append(

--- a/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd
@@ -257,7 +257,12 @@ func _strip_group_from_name(remainder: String, lower_group: String) -> String:
 # matches (case-insensitive, with a word boundary after the group name), or ""
 # when none matches. [param allow_exact] also accepts a name that is exactly the
 # group name (used by the safety net, not by the animation association).
-func _find_matching_group(remainder: String, group_names: Dictionary, duplicate_groups: Dictionary, allow_exact: bool) -> String:
+func _find_matching_group(
+	remainder: String,
+	group_names: Dictionary,
+	duplicate_groups: Dictionary,
+	allow_exact: bool
+) -> String:
 	var matched_lower := ""
 	var matched_display := ""
 	for lower in group_names:

--- a/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd.uid
+++ b/addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd.uid
@@ -1,0 +1,1 @@
+uid://b4koprc3nha1u

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -1,0 +1,98 @@
+@tool
+extends HBoxContainer
+
+# A single row representing a "group tag" in the importer dock tag list.
+# It carries the prop-level toggles (Import, Visible, Clickable); the
+# animation-level toggles (Loops, Autoplays) live on its child rows.
+
+signal tag_state_changed
+
+var tag_name_label: Control
+var import_toggle: Control
+var visible_toggle: Control
+var clickable_toggle: Control
+
+var _anim_tag_state: Dictionary = {}
+
+#region Public #####################################################################################
+func init(group_cfg: Dictionary):
+	# Manually initialize node references (the container gets repopulated without
+	# the script being reloaded, so @onready is not reliable here).
+	tag_name_label = $HBoxContainer/GroupName
+	import_toggle = $HBoxContainer/Panel/HBoxContainer/Import
+	visible_toggle = $HBoxContainer/Panel/HBoxContainer/Visible
+	clickable_toggle = $HBoxContainer/Panel/HBoxContainer/Clickable
+
+	# Set icons manually, like AnimationTagRow does
+	import_toggle.icon = get_theme_icon('Load', 'EditorIcons')
+	visible_toggle.icon = get_theme_icon('GuiVisibilityVisible', 'EditorIcons')
+	clickable_toggle.icon = get_theme_icon('ToolSelect', 'EditorIcons')
+
+	# Bold the group name so it reads as a header over its children
+	var bold_font := get_theme_font("bold", "EditorFonts")
+	if bold_font:
+		tag_name_label.add_theme_font_override("font", bold_font)
+
+	_anim_tag_state = {
+		"tag_name": "",
+		"import": PopochiuConfig.is_default_animation_import_enabled(),
+		"prop_visible": PopochiuConfig.is_default_animation_prop_visible(),
+		"prop_clickable": PopochiuConfig.is_default_animation_prop_clickable(),
+	}
+	_anim_tag_state.merge(group_cfg, true)
+	_setup_scene()
+
+
+func get_cfg() -> Dictionary:
+	# Only expose the fields that are meaningful to persist; the group structure
+	# (children, validation) is always derived from the scan.
+	return {
+		"tag_name": _anim_tag_state.tag_name,
+		"import": _anim_tag_state.import,
+		"prop_visible": _anim_tag_state.prop_visible,
+		"prop_clickable": _anim_tag_state.prop_clickable,
+		"from": _anim_tag_state.get("from", -1),
+		"to": _anim_tag_state.get("to", -1),
+		"direction": _anim_tag_state.get("direction", "forward"),
+	}
+
+
+func get_search_name() -> String:
+	return _anim_tag_state.tag_name
+
+
+# Marks the group as misconfigured: tints the name and adds an explanatory
+# tooltip with actionable information.
+func set_error(message: String) -> void:
+	tag_name_label.add_theme_color_override("font_color", get_theme_color("error_color", "Editor"))
+	tag_name_label.tooltip_text = message
+
+
+#endregion
+
+
+#region Private ####################################################################################
+func _setup_scene() -> void:
+	tag_name_label.text = _anim_tag_state.tag_name
+	import_toggle.set_pressed_no_signal(_anim_tag_state.import)
+	visible_toggle.set_pressed_no_signal(_anim_tag_state.prop_visible)
+	clickable_toggle.set_pressed_no_signal(_anim_tag_state.prop_clickable)
+	emit_signal("tag_state_changed")
+
+
+func _on_import_toggled(button_pressed: bool) -> void:
+	_anim_tag_state.import = button_pressed
+	emit_signal("tag_state_changed")
+
+
+func _on_visible_toggled(button_pressed: bool) -> void:
+	_anim_tag_state.prop_visible = button_pressed
+	emit_signal("tag_state_changed")
+
+
+func _on_clickable_toggled(button_pressed: bool) -> void:
+	_anim_tag_state.prop_clickable = button_pressed
+	emit_signal("tag_state_changed")
+
+
+#endregion

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -13,6 +13,7 @@ var visible_toggle: Control
 var clickable_toggle: Control
 
 var _anim_tag_state: Dictionary = {}
+var _display_name: String = PopochiuEditorHelper.EMPTY_STRING
 
 #region Public #####################################################################################
 func init(group_cfg: Dictionary):
@@ -32,6 +33,8 @@ func init(group_cfg: Dictionary):
 	var bold_font := get_theme_font("bold", "EditorFonts")
 	if bold_font:
 		tag_name_label.add_theme_font_override("font", bold_font)
+
+	_display_name = group_cfg.get("display_name", group_cfg.get("tag_name", ""))
 
 	_anim_tag_state = {
 		"tag_name": "",
@@ -58,7 +61,7 @@ func get_cfg() -> Dictionary:
 
 
 func get_search_name() -> String:
-	return _anim_tag_state.tag_name
+	return _display_name if not _display_name.is_empty() else _anim_tag_state.tag_name
 
 
 # Marks the group as misconfigured: tints the name and adds an explanatory
@@ -73,7 +76,7 @@ func set_error(message: String) -> void:
 
 #region Private ####################################################################################
 func _setup_scene() -> void:
-	tag_name_label.text = _anim_tag_state.tag_name
+	tag_name_label.text = _display_name
 	import_toggle.set_pressed_no_signal(_anim_tag_state.import)
 	visible_toggle.set_pressed_no_signal(_anim_tag_state.prop_visible)
 	clickable_toggle.set_pressed_no_signal(_anim_tag_state.prop_clickable)

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -7,6 +7,8 @@ extends HBoxContainer
 
 signal tag_state_changed
 
+const GROUP_TOOLTIP_BASE := "Group tag: imported as a single prop with one animation per child tag"
+
 var tag_name_label: Control
 var import_toggle: Control
 var visible_toggle: Control
@@ -92,11 +94,27 @@ func set_error(message: String) -> void:
 # as standalone and child rows.
 func _setup_action_grid() -> void:
 	var slot_width := Vector2(20, 0)
-	for control in [visible_toggle, clickable_toggle, import_toggle, autoplays_spacer, loops_spacer]:
-		control.custom_minimum_size = slot_width
+	# Trim the flat-button padding so every action button is exactly 20px wide,
+	# matching the spacer columns.
+	for control in [visible_toggle, clickable_toggle, import_toggle]:
+		PopochiuEditorHelper.make_icon_button_slot(control)
+	autoplays_spacer.custom_minimum_size = slot_width
+	loops_spacer.custom_minimum_size = slot_width
 	separator.custom_minimum_size = Vector2(1, 0)
 	# Size the grid to its children and keep it anchored to the right.
 	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0
+	# The buttons and spacers are both 20px, so the grids already match; the
+	# deferred sync is kept as a safety net in case a theme renders them wider.
+	call_deferred("_sync_spacer_widths")
+
+
+# Matches the Autoplays/Loops spacer columns to the real width of the action
+# buttons, so the group's right-anchored grid lines up with the other rows.
+func _sync_spacer_widths() -> void:
+	if not is_inside_tree():
+		return
+	autoplays_spacer.custom_minimum_size.x = import_toggle.size.x
+	loops_spacer.custom_minimum_size.x = import_toggle.size.x
 
 
 func _setup_scene() -> void:
@@ -104,7 +122,33 @@ func _setup_scene() -> void:
 	import_toggle.set_pressed_no_signal(_anim_tag_state.import)
 	visible_toggle.set_pressed_no_signal(_anim_tag_state.prop_visible)
 	clickable_toggle.set_pressed_no_signal(_anim_tag_state.prop_clickable)
+	_update_frame_tooltip()
 	emit_signal("tag_state_changed")
+
+
+# Shows the frame info as a tooltip on the group name, combined with the group
+# explanation. Aseprite's JSON indices are 0-based, so the range is shown
+# 1-based to match the Aseprite editor UI. Misconfigured groups override this
+# with their error message (see set_error).
+func _update_frame_tooltip() -> void:
+	var tag_from = _anim_tag_state.get("from", -1)
+	var tag_to = _anim_tag_state.get("to", -1)
+	if (
+		typeof(tag_from) in [TYPE_INT, TYPE_FLOAT]
+		and typeof(tag_to) in [TYPE_INT, TYPE_FLOAT]
+		and int(tag_from) >= 0
+		and int(tag_to) >= int(tag_from)
+	):
+		tag_name_label.tooltip_text = "%s\n%s" % [GROUP_TOOLTIP_BASE, _frame_info_text(int(tag_from), int(tag_to))]
+	else:
+		tag_name_label.tooltip_text = GROUP_TOOLTIP_BASE
+
+
+func _frame_info_text(tag_from: int, tag_to: int) -> String:
+	var count := tag_to - tag_from + 1
+	if count == 1:
+		return "1 frame [%d]" % (tag_from + 1)
+	return "%d frames [%d-%d]" % [count, tag_from + 1, tag_to + 1]
 
 
 func _on_import_toggled(button_pressed: bool) -> void:

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -11,6 +11,9 @@ var tag_name_label: Control
 var import_toggle: Control
 var visible_toggle: Control
 var clickable_toggle: Control
+var separator: Control
+var autoplays_spacer: Control
+var loops_spacer: Control
 
 var _anim_tag_state: Dictionary = {}
 var _display_name: String = PopochiuEditorHelper.EMPTY_STRING
@@ -23,11 +26,19 @@ func init(group_cfg: Dictionary):
 	import_toggle = $HBoxContainer/Panel/HBoxContainer/Import
 	visible_toggle = $HBoxContainer/Panel/HBoxContainer/Visible
 	clickable_toggle = $HBoxContainer/Panel/HBoxContainer/Clickable
+	separator = $HBoxContainer/Panel/HBoxContainer/Separator
+	autoplays_spacer = $HBoxContainer/Panel/HBoxContainer/Autoplays
+	loops_spacer = $HBoxContainer/Panel/HBoxContainer/Loops
 
 	# Set icons manually, like AnimationTagRow does
 	import_toggle.icon = get_theme_icon('Load', 'EditorIcons')
 	visible_toggle.icon = get_theme_icon('GuiVisibilityVisible', 'EditorIcons')
 	clickable_toggle.icon = get_theme_icon('ToolSelect', 'EditorIcons')
+
+	# Fixed action grid: the Autoplays and Loops columns are static spacers, so
+	# the group's prop-level toggles (Visible/Clickable/Separator/Import) line up
+	# with standalone and child rows.
+	_setup_action_grid()
 
 	# Bold the group name so it reads as a header over its children
 	var bold_font := get_theme_font("bold", "EditorFonts")
@@ -75,6 +86,19 @@ func set_error(message: String) -> void:
 
 
 #region Private ####################################################################################
+# Gives every action button a fixed width and the Autoplays/Loops columns a
+# static spacer of the same width. The container is anchored to the row's right
+# edge and sized to its children, so the group's toggles share the same columns
+# as standalone and child rows.
+func _setup_action_grid() -> void:
+	var slot_width := Vector2(20, 0)
+	for control in [visible_toggle, clickable_toggle, import_toggle, autoplays_spacer, loops_spacer]:
+		control.custom_minimum_size = slot_width
+	separator.custom_minimum_size = Vector2(1, 0)
+	# Size the grid to its children and keep it anchored to the right.
+	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0
+
+
 func _setup_scene() -> void:
 	tag_name_label.text = _display_name
 	import_toggle.set_pressed_no_signal(_anim_tag_state.import)

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -19,7 +19,7 @@ var _anim_tag_state: Dictionary = {}
 var _display_name: String = PopochiuEditorHelper.EMPTY_STRING
 
 #region Public #####################################################################################
-func init(group_cfg: Dictionary):
+func init(group_cfg: Dictionary) -> void:
 	# Manually initialize node references (the container gets repopulated without
 	# the script being reloaded, so @onready is not reliable here).
 	tag_name_label = $HBoxContainer/GroupName

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd
@@ -7,8 +7,6 @@ extends HBoxContainer
 
 signal tag_state_changed
 
-const GROUP_TOOLTIP_BASE := "Group tag: imported as a single prop with one animation per child tag"
-
 var tag_name_label: Control
 var import_toggle: Control
 var visible_toggle: Control
@@ -94,17 +92,14 @@ func set_error(message: String) -> void:
 # as standalone and child rows.
 func _setup_action_grid() -> void:
 	var slot_width := Vector2(20, 0)
-	# Trim the flat-button padding so every action button is exactly 20px wide,
-	# matching the spacer columns.
-	for control in [visible_toggle, clickable_toggle, import_toggle]:
-		PopochiuEditorHelper.make_icon_button_slot(control)
-	autoplays_spacer.custom_minimum_size = slot_width
-	loops_spacer.custom_minimum_size = slot_width
+	for control in [visible_toggle, clickable_toggle, import_toggle, autoplays_spacer, loops_spacer]:
+		control.custom_minimum_size = slot_width
 	separator.custom_minimum_size = Vector2(1, 0)
 	# Size the grid to its children and keep it anchored to the right.
 	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0
-	# The buttons and spacers are both 20px, so the grids already match; the
-	# deferred sync is kept as a safety net in case a theme renders them wider.
+	# The action buttons render wider than their 20px floor (icon + padding).
+	# Once laid out, size the spacer columns to match, so the group's grid has
+	# the same width as the standalone/child rows and the buttons stay aligned.
 	call_deferred("_sync_spacer_widths")
 
 
@@ -122,33 +117,7 @@ func _setup_scene() -> void:
 	import_toggle.set_pressed_no_signal(_anim_tag_state.import)
 	visible_toggle.set_pressed_no_signal(_anim_tag_state.prop_visible)
 	clickable_toggle.set_pressed_no_signal(_anim_tag_state.prop_clickable)
-	_update_frame_tooltip()
 	emit_signal("tag_state_changed")
-
-
-# Shows the frame info as a tooltip on the group name, combined with the group
-# explanation. Aseprite's JSON indices are 0-based, so the range is shown
-# 1-based to match the Aseprite editor UI. Misconfigured groups override this
-# with their error message (see set_error).
-func _update_frame_tooltip() -> void:
-	var tag_from = _anim_tag_state.get("from", -1)
-	var tag_to = _anim_tag_state.get("to", -1)
-	if (
-		typeof(tag_from) in [TYPE_INT, TYPE_FLOAT]
-		and typeof(tag_to) in [TYPE_INT, TYPE_FLOAT]
-		and int(tag_from) >= 0
-		and int(tag_to) >= int(tag_from)
-	):
-		tag_name_label.tooltip_text = "%s\n%s" % [GROUP_TOOLTIP_BASE, _frame_info_text(int(tag_from), int(tag_to))]
-	else:
-		tag_name_label.tooltip_text = GROUP_TOOLTIP_BASE
-
-
-func _frame_info_text(tag_from: int, tag_to: int) -> String:
-	var count := tag_to - tag_from + 1
-	if count == 1:
-		return "1 frame [%d]" % (tag_from + 1)
-	return "%d frames [%d-%d]" % [count, tag_from + 1, tag_to + 1]
 
 
 func _on_import_toggled(button_pressed: bool) -> void:

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd.uid
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd.uid
@@ -1,0 +1,1 @@
+uid://dmkxxjw5l7lud

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
@@ -1,0 +1,62 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd" id="1"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_grp"]
+
+[node name="AnimationGroupRow" type="HBoxContainer"]
+offset_right = 320.0
+offset_bottom = 20.0
+script = ExtResource("1")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="GroupName" type="Label" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Group"
+tooltip_text = "Group tag: imported as a single prop with one animation per child tag"
+
+[node name="Panel" type="Panel" parent="HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_styles/panel = SubResource("StyleBoxEmpty_grp")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Panel"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -90.0
+offset_bottom = 20.0
+grow_horizontal = 0
+
+[node name="Visible" type="Button" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+tooltip_text = "This prop will be visible"
+toggle_mode = true
+flat = true
+
+[node name="Clickable" type="Button" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+tooltip_text = "This prop will be clickable"
+toggle_mode = true
+flat = true
+
+[node name="Import" type="Button" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+tooltip_text = "Import this group as a single prop"
+toggle_mode = true
+flat = true
+
+[connection signal="toggled" from="HBoxContainer/Panel/HBoxContainer/Visible" to="." method="_on_visible_toggled"]
+[connection signal="toggled" from="HBoxContainer/Panel/HBoxContainer/Clickable" to="." method="_on_clickable_toggled"]
+[connection signal="toggled" from="HBoxContainer/Panel/HBoxContainer/Import" to="." method="_on_import_toggled"]

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd" id="1"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_grp"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sep"]
+bg_color = Color(0.5, 0.5, 0.5, 0.4)
 
 [node name="AnimationGroupRow" type="HBoxContainer"]
 offset_right = 320.0
@@ -49,6 +52,16 @@ tooltip_text = "This prop will be clickable"
 toggle_mode = true
 flat = true
 
+[node name="Autoplays" type="Control" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+mouse_filter = 2
+
+[node name="Separator" type="Panel" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_sep")
+
 [node name="Import" type="Button" parent="HBoxContainer/Panel/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 4
@@ -56,6 +69,12 @@ size_flags_vertical = 3
 tooltip_text = "Import this group as a single prop"
 toggle_mode = true
 flat = true
+
+[node name="Loops" type="Control" parent="HBoxContainer/Panel/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 3
+mouse_filter = 2
 
 [connection signal="toggled" from="HBoxContainer/Panel/HBoxContainer/Visible" to="." method="_on_visible_toggled"]
 [connection signal="toggled" from="HBoxContainer/Panel/HBoxContainer/Clickable" to="." method="_on_clickable_toggled"]

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn
@@ -19,6 +19,7 @@ size_flags_horizontal = 3
 [node name="GroupName" type="Label" parent="HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
+mouse_filter = 0
 text = "Group"
 tooltip_text = "Group tag: imported as a single prop with one animation per child tag"
 

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
@@ -24,7 +24,7 @@ var _display_name: String = PopochiuEditorHelper.EMPTY_STRING
 var _group_name: String = PopochiuEditorHelper.EMPTY_STRING
 
 #region Public #####################################################################################
-func init(tag_cfg: Dictionary):
+func init(tag_cfg: Dictionary) -> void:
 	# Manually initialize node references if not already done
 	# Used to be @onready var but it doesn't work because the
 	# container gets repopulated without the script being reloaded.
@@ -36,7 +36,7 @@ func init(tag_cfg: Dictionary):
 	visible_toggle = $HBoxContainer/Panel/HBoxContainer/Visible
 	clickable_toggle = $HBoxContainer/Panel/HBoxContainer/Clickable
 	delete_anim_button = $HBoxContainer/DeleteAnim
-	
+
 	# Set icons manually too:
 	# 1. Common toggles icons
 	import_toggle.icon = get_theme_icon('Load', 'EditorIcons')
@@ -47,7 +47,7 @@ func init(tag_cfg: Dictionary):
 	clickable_toggle.icon = get_theme_icon('ToolSelect', 'EditorIcons')
 	# 3. Delete animation icon
 	delete_anim_button.icon = get_theme_icon('Remove', 'EditorIcons')
-	
+
 	# The action buttons live in a right-anchored grid. Only leading columns
 	# (Visible/Clickable) are ever hidden on this row, so the remaining buttons
 	# keep their right-anchored columns and stay aligned with every other row
@@ -59,7 +59,7 @@ func init(tag_cfg: Dictionary):
 	separator.visible = false
 	import_toggle.visible = true
 	loops_toggle.visible = true
-	
+
 	# Connect tag name button pressed signal if not already connected
 	if not tag_name_label.pressed.is_connected(_on_tag_name_pressed):
 		tag_name_label.pressed.connect(_on_tag_name_pressed)
@@ -71,8 +71,8 @@ func init(tag_cfg: Dictionary):
 	# Continue with initialization
 	if tag_cfg.tag_name == null or tag_cfg.tag_name == PopochiuEditorHelper.EMPTY_STRING:
 		printerr(RESULT_CODE.get_error_message(RESULT_CODE.ERR_UNNAMED_TAG_DETECTED))
-		return false
-	
+		return
+
 	_anim_tag_state = _load_default_tag_state()
 	_anim_tag_state.merge(tag_cfg, true)
 	_setup_scene()

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
@@ -146,10 +146,9 @@ func get_cfg() -> Dictionary:
 # same action always occupies the same column in every row type, even when
 # leading buttons (Visible/Clickable) are hidden.
 func _setup_action_grid() -> void:
-	# Trim the flat-button padding so every action button is exactly 20px wide
-	# (the tag row's grid is made only of buttons, so it is always consistent).
+	var slot_width := Vector2(20, 0)
 	for control in [visible_toggle, clickable_toggle, autoplays_toggle, import_toggle, loops_toggle]:
-		PopochiuEditorHelper.make_icon_button_slot(control)
+		control.custom_minimum_size = slot_width
 	separator.custom_minimum_size = Vector2(1, 0)
 	# Size the grid to its visible children and keep it anchored to the right.
 	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
@@ -18,6 +18,11 @@ var visible_toggle: Control
 var clickable_toggle: Control
 var delete_anim_button: Control
 
+# When the row is a child of a group, _display_name holds the animation name
+# (group prefix stripped) and _group_name the group it belongs to.
+var _display_name: String = PopochiuEditorHelper.EMPTY_STRING
+var _group_name: String = PopochiuEditorHelper.EMPTY_STRING
+
 #region Public #####################################################################################
 func init(tag_cfg: Dictionary):
 	# Manually initialize node references if not already done
@@ -69,6 +74,41 @@ func show_prop_buttons() -> void:
 func show_inventory_item_buttons() -> void:
 	separator.visible = true
 	autoplays_toggle.visible = true
+
+
+# Makes the row behave as a child of a group: shows only the animation-level
+# toggles (Loops/Autoplays) and hides the prop-level ones (Visible/Clickable),
+# which belong to the group header row. The displayed name is the animation name.
+func set_group_child(group_name: String) -> void:
+	_group_name = group_name
+	separator.visible = true
+	autoplays_toggle.visible = true
+	visible_toggle.visible = false
+	clickable_toggle.visible = false
+
+
+# Changes the displayed name (used for group children, whose label is the
+# animation name with the group prefix stripped).
+func set_display_name(name: String) -> void:
+	_display_name = name
+	tag_name_label.text = name
+
+
+# The name used by the tag list filter: prefers the displayed (stripped) name.
+func get_search_name() -> String:
+	return _display_name if not _display_name.is_empty() else _anim_tag_state.tag_name
+
+
+# The group this row belongs to, or an empty string for standalone tags.
+func get_group_name() -> String:
+	return _group_name
+
+
+# Updates the autoplay state without emitting signals. Used to enforce autoplay
+# exclusivity within a group (only one child can autoplay).
+func set_autoplay_no_signal(pressed: bool) -> void:
+	_anim_tag_state.autoplays = pressed
+	autoplays_toggle.set_pressed_no_signal(pressed)
 
 
 #endregion

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
@@ -146,9 +146,10 @@ func get_cfg() -> Dictionary:
 # same action always occupies the same column in every row type, even when
 # leading buttons (Visible/Clickable) are hidden.
 func _setup_action_grid() -> void:
-	var slot_width := Vector2(20, 0)
+	# Trim the flat-button padding so every action button is exactly 20px wide
+	# (the tag row's grid is made only of buttons, so it is always consistent).
 	for control in [visible_toggle, clickable_toggle, autoplays_toggle, import_toggle, loops_toggle]:
-		control.custom_minimum_size = slot_width
+		PopochiuEditorHelper.make_icon_button_slot(control)
 	separator.custom_minimum_size = Vector2(1, 0)
 	# Size the grid to its visible children and keep it anchored to the right.
 	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0
@@ -161,7 +162,32 @@ func _setup_scene() -> void:
 	autoplays_toggle.set_pressed_no_signal(_anim_tag_state.autoplays)
 	visible_toggle.set_pressed_no_signal(_anim_tag_state.prop_visible)
 	clickable_toggle.set_pressed_no_signal(_anim_tag_state.prop_clickable)
+	_update_frame_tooltip()
 	emit_signal("tag_state_changed")
+
+
+# Shows the frame info as a tooltip on the tag name, e.g. "4 frames [12-15]".
+# Aseprite's JSON indices are 0-based, so the range is shown 1-based to match
+# the Aseprite editor UI.
+func _update_frame_tooltip() -> void:
+	var tag_from = _anim_tag_state.get("from", -1)
+	var tag_to = _anim_tag_state.get("to", -1)
+	if (
+		typeof(tag_from) in [TYPE_INT, TYPE_FLOAT]
+		and typeof(tag_to) in [TYPE_INT, TYPE_FLOAT]
+		and int(tag_from) >= 0
+		and int(tag_to) >= int(tag_from)
+	):
+		tag_name_label.tooltip_text = _frame_info_text(int(tag_from), int(tag_to))
+	else:
+		tag_name_label.tooltip_text = ""
+
+
+func _frame_info_text(tag_from: int, tag_to: int) -> String:
+	var count := tag_to - tag_from + 1
+	if count == 1:
+		return "1 frame [%d]" % (tag_from + 1)
+	return "%d frames [%d-%d]" % [count, tag_from + 1, tag_to + 1]
 
 
 func _load_default_tag_state() -> Dictionary:

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd
@@ -48,6 +48,18 @@ func init(tag_cfg: Dictionary):
 	# 3. Delete animation icon
 	delete_anim_button.icon = get_theme_icon('Remove', 'EditorIcons')
 	
+	# The action buttons live in a right-anchored grid. Only leading columns
+	# (Visible/Clickable) are ever hidden on this row, so the remaining buttons
+	# keep their right-anchored columns and stay aligned with every other row
+	# type. Default state (characters): only Import and Loops.
+	_setup_action_grid()
+	visible_toggle.visible = false
+	clickable_toggle.visible = false
+	autoplays_toggle.visible = false
+	separator.visible = false
+	import_toggle.visible = true
+	loops_toggle.visible = true
+	
 	# Connect tag name button pressed signal if not already connected
 	if not tag_name_label.pressed.is_connected(_on_tag_name_pressed):
 		tag_name_label.pressed.connect(_on_tag_name_pressed)
@@ -66,25 +78,33 @@ func init(tag_cfg: Dictionary):
 	_setup_scene()
 
 func show_prop_buttons() -> void:
-	separator.visible = true
-	visible_toggle.visible =  true
+	visible_toggle.visible = true
 	clickable_toggle.visible = true
 	autoplays_toggle.visible = true
+	separator.visible = true
+	import_toggle.visible = true
+	loops_toggle.visible = true
 
 func show_inventory_item_buttons() -> void:
-	separator.visible = true
-	autoplays_toggle.visible = true
-
-
-# Makes the row behave as a child of a group: shows only the animation-level
-# toggles (Loops/Autoplays) and hides the prop-level ones (Visible/Clickable),
-# which belong to the group header row. The displayed name is the animation name.
-func set_group_child(group_name: String) -> void:
-	_group_name = group_name
-	separator.visible = true
-	autoplays_toggle.visible = true
 	visible_toggle.visible = false
 	clickable_toggle.visible = false
+	autoplays_toggle.visible = true
+	separator.visible = true
+	import_toggle.visible = true
+	loops_toggle.visible = true
+
+
+# Makes the row behave as a child of a group: it only owns the animation-level
+# toggles (Loops/Autoplays); the prop-level ones (Visible/Clickable) live on the
+# group header row. The displayed name is the animation name.
+func set_group_child(group_name: String) -> void:
+	_group_name = group_name
+	visible_toggle.visible = false
+	clickable_toggle.visible = false
+	autoplays_toggle.visible = true
+	separator.visible = true
+	import_toggle.visible = true
+	loops_toggle.visible = true
 
 
 # Changes the displayed name (used for group children, whose label is the
@@ -121,6 +141,19 @@ func get_cfg() -> Dictionary:
 #endregion
 
 #region Private ####################################################################################
+# Gives every action button a fixed width. The buttons live in a container that
+# is anchored to the row's right edge and sized to its visible children, so the
+# same action always occupies the same column in every row type, even when
+# leading buttons (Visible/Clickable) are hidden.
+func _setup_action_grid() -> void:
+	var slot_width := Vector2(20, 0)
+	for control in [visible_toggle, clickable_toggle, autoplays_toggle, import_toggle, loops_toggle]:
+		control.custom_minimum_size = slot_width
+	separator.custom_minimum_size = Vector2(1, 0)
+	# Size the grid to its visible children and keep it anchored to the right.
+	$HBoxContainer/Panel/HBoxContainer.offset_left = 0.0
+
+
 func _setup_scene() -> void:
 	tag_name_label.text = _anim_tag_state.tag_name
 	import_toggle.set_pressed_no_signal(_anim_tag_state.import)

--- a/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.tscn
+++ b/addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.tscn
@@ -17,6 +17,7 @@ data = {
 image = SubResource("Image_bfixh")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sd1l8"]
+bg_color = Color(0.5, 0.5, 0.5, 0.4)
 
 [node name="AnimationTagRow" type="HBoxContainer"]
 offset_right = 320.0

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -821,11 +821,6 @@ func _set_elements_styles() -> void:
 	%VisibleBulk.set_button_icon(get_theme_icon('GuiVisibilityVisible', 'EditorIcons'))
 	%ClickableBulk.set_button_icon(get_theme_icon('ToolSelect', 'EditorIcons'))
 
-	# Make the bulk buttons the same fixed width as the row action buttons (20px)
-	# so the toolbar columns line up with the tag list.
-	for bulk_button in [%VisibleBulk, %ClickableBulk, %AutoplaysBulk, %ImportBulk, %LoopsBulk]:
-		PopochiuEditorHelper.make_icon_button_slot(bulk_button)
-
 func _show_warning() -> void:
 	%Warning.visible = true
 	%Importer.visible = false

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -355,32 +355,14 @@ func _check_aseprite() -> int:
 	return RESULT_CODE.SUCCESS	
 
 
-func _list_tags(file: String) -> Variant:
-	if not _aseprite.check_command_path():
-		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
-	if not _aseprite.test_command():
-		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
-	return _aseprite.list_tags(file)
-
-
 # Slow variant used only at import time: fetches the tag frame ranges needed to
-# export group spritesheets. The dock scan only needs names (see _list_tags).
+# export group spritesheets. The dock scan only needs names.
 func _list_tags_with_ranges(file: String) -> Variant:
 	if not _aseprite.check_command_path():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
 	if not _aseprite.test_command():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
 	return _aseprite.list_tags_with_ranges(file)
-
-
-# TODO: Currently unused. keeping this as reference
-# to populate a checkable list of layers
-func _list_layers(file: String, only_visibles = false):
-	if not _aseprite.check_command_path():
-		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
-	if not _aseprite.test_command():
-		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
-	return _aseprite.list_layers(file, only_visibles)
 
 
 func _load_config(cfg) -> void:
@@ -507,7 +489,7 @@ func _populate_tags(tags: Array) -> void:
 	if not _supports_groups():
 		_populate_flat_tags(tags)
 		_update_tags_cache()
-		_update_bulk_toggles_state() # Update bulk toggles after populating tags
+		_update_all_bulk_toggles_state() # Update bulk toggles after populating tags
 		return
 
 	var grouper := PopochiuAsepriteTagGrouper.new()
@@ -531,7 +513,7 @@ func _populate_tags(tags: Array) -> void:
 			_add_single_tag_row(tag)
 
 	_update_tags_cache()
-	_update_bulk_toggles_state() # Update bulk toggles after populating tags
+	_update_all_bulk_toggles_state() # Update bulk toggles after populating tags
 
 
 # Populates the tag list without group handling (used by importers that don't
@@ -540,11 +522,7 @@ func _populate_flat_tags(tags: Array) -> void:
 	for t in tags:
 		if t.tag_name == PopochiuEditorHelper.EMPTY_STRING:
 			continue
-		var tag_row: AnimationTagRow = _animation_tag_row_scene.instantiate()
-		%Tags.add_child(tag_row)
-		tag_row.init(t)
-		_connect_tag_row_signals(tag_row)
-		_customize_tag_ui(tag_row)
+		_add_single_tag_row(t)
 
 
 # Adds a group header row and its child rows (indented) to the tag list.
@@ -675,28 +653,9 @@ func _get_tags_from_ui() -> Array:
 	return tags_list
 
 
-func _get_tags_from_source() -> Array:
-	var tags_found = _list_tags(ProjectSettings.globalize_path(_source))
-	if typeof(tags_found) == TYPE_INT:
-		PopochiuUtils.print_error(RESULT_CODE.get_error_message(tags_found))
-		return []
-	var tags_list = []
-	for t in tags_found:
-		# Plain tag names arrive as Strings (from --list-tags); they are wrapped
-		# into dicts so the rest of the pipeline can treat every tag uniformly.
-		if typeof(t) == TYPE_STRING:
-			if t == PopochiuEditorHelper.EMPTY_STRING:
-				continue
-			tags_list.push_back({ "tag_name": t })
-		elif typeof(t) == TYPE_DICTIONARY:
-			if t.get("tag_name", PopochiuEditorHelper.EMPTY_STRING) == PopochiuEditorHelper.EMPTY_STRING:
-				continue
-			tags_list.push_back(t)
-	return tags_list
-
-
-# Like _get_tags_from_source but also reads the frame ranges. Only used at import
-# time (it is slow, since it makes Aseprite export the sprite metadata).
+# Reads the tags from the source file together with their frame ranges. Only
+# used at import time (it is slow, since it makes Aseprite export the sprite
+# metadata).
 func _get_tags_from_source_with_ranges() -> Array:
 	var tags_found = _list_tags_with_ranges(ProjectSettings.globalize_path(_source))
 	if typeof(tags_found) == TYPE_INT:
@@ -864,48 +823,6 @@ func _handle_animation_in_player(tag_name: String, animation_player: AnimationPl
 				PopochiuUtils.print_warning("Unknown action for animation handling: %s." % action)
 	else:
 		PopochiuUtils.print_warning("No animation named '%s' found in character's AnimationPlayer." % animation_name)
-
-
-# Called after populating tags or when their state changes.
-# Updates the state of bulk action buttons based on individual tag states.
-func _update_bulk_toggles_state() -> void:
-	# Handle ImportBulk toggle state
-	var rows := _get_all_tag_rows()
-	if rows.is_empty():
-		return
-		
-	var all_import := true
-	var none_import := true
-	
-	# Check all tags to determine the collective state
-	for tag_row in rows:
-		var cfg: Dictionary = tag_row.get_cfg()
-		if not cfg.has("import"):
-			continue
-		if cfg.import:
-			none_import = false
-		else:
-			all_import = false
-	
-	# Set the toggle state based on the collective state
-	if all_import:
-		# All tags are set to import
-		%ImportBulk.set_pressed_no_signal(true)
-		%ImportBulk.set_meta("is_dirty", false)
-		%ImportBulk.remove_theme_color_override("icon_normal_color")
-	elif none_import:
-		# No tags are set to import
-		%ImportBulk.set_pressed_no_signal(false)
-		%ImportBulk.set_meta("is_dirty", false)
-		%ImportBulk.remove_theme_color_override("icon_normal_color")
-	else:
-		# Mixed state - mark as "dirty"
-		%ImportBulk.set_pressed_no_signal(false)
-		%ImportBulk.set_meta("is_dirty", true)
-		%ImportBulk.add_theme_color_override(
-			"icon_normal_color",
-			get_theme_color("disabled_font_color", "Editor")
-		)
 
 
 # Updates the state of all visible bulk toggle buttons based on individual tag states.

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -354,6 +354,16 @@ func _list_tags(file: String) -> Variant:
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
 	if not _aseprite.test_command():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
+	return _aseprite.list_tags(file)
+
+
+# Slow variant used only at import time: fetches the tag frame ranges needed to
+# export group spritesheets. The dock scan only needs names (see _list_tags).
+func _list_tags_with_ranges(file: String) -> Variant:
+	if not _aseprite.check_command_path():
+		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
+	if not _aseprite.test_command():
+		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
 	return _aseprite.list_tags_with_ranges(file)
 
 
@@ -390,6 +400,8 @@ func _load_config(cfg) -> void:
 	if _supports_groups() and not _source.is_empty():
 		_tags_cache = saved_tags
 		var refreshed: Array = _merge_with_cache(_get_tags_from_source())
+		if _has_group_tags(refreshed):
+			refreshed = _merge_with_cache(_get_tags_from_source_with_ranges())
 		if not refreshed.is_empty():
 			saved_tags = refreshed
 
@@ -474,11 +486,24 @@ func _create_aseprite_file_selection() -> FileDialog:
 
 
 func _scan_source() -> void:
-	_populate_tags(
-		_merge_with_cache(_get_tags_from_source())
-	)
+	var tags: Array = _merge_with_cache(_get_tags_from_source())
+	# Group tags carry frame ranges used for validation and the safety net.
+	# Fetch them at scan time (data-only, fast) so problems are actionable
+	# before importing, not after.
+	if _supports_groups() and _has_group_tags(tags):
+		tags = _merge_with_cache(_get_tags_from_source_with_ranges())
+	_populate_tags(tags)
 	_save_config()
 	_set_tags_visible(true)
+
+
+# Whether any of the tags is a "group tag" (@ prefix). Frame ranges are only
+# worth fetching at scan time when at least one group tag exists.
+func _has_group_tags(tags: Array) -> bool:
+	for tag in tags:
+		if str(tag.get("tag_name", "")).begins_with(PopochiuAsepriteTagGrouper.GROUP_PREFIX):
+			return true
+	return false
 
 
 func _populate_tags(tags: Array) -> void:
@@ -494,13 +519,22 @@ func _populate_tags(tags: Array) -> void:
 	var grouper := PopochiuAsepriteTagGrouper.new()
 	var analysis := grouper.analyze(tags)
 
-	for group in analysis.get("groups", []):
-		_add_group_rows(group, tags)
+	# Surface configuration problems as soon as the list is built (scan or
+	# reload), so the user can fix the Aseprite file before importing.
+	for importer_error in analysis.get("errors", []):
+		PopochiuUtils.print_error(importer_error)
+	for importer_warning in analysis.get("warnings", []):
+		PopochiuUtils.print_warning(importer_warning)
 
-	for tag in analysis.get("singles", []):
-		if tag.tag_name == PopochiuEditorHelper.EMPTY_STRING:
-			continue
-		_add_single_tag_row(tag)
+	# Render groups and standalone tags in their source order
+	for item in analysis.get("items", []):
+		if item.get("kind") == "group":
+			_add_group_rows(item, tags)
+		else:
+			var tag: Dictionary = item.get("tag", {})
+			if tag.get("tag_name", PopochiuEditorHelper.EMPTY_STRING) == PopochiuEditorHelper.EMPTY_STRING:
+				continue
+			_add_single_tag_row(tag)
 
 	_update_tags_cache()
 	_update_bulk_toggles_state() # Update bulk toggles after populating tags
@@ -521,13 +555,14 @@ func _populate_flat_tags(tags: Array) -> void:
 
 # Adds a group header row and its child rows (indented) to the tag list.
 func _add_group_rows(group: Dictionary, tags: Array) -> void:
-	var group_cfg := _find_tag_cfg(tags, group.name)
+	var group_cfg := _find_tag_cfg(tags, group.get("tag_name", ""))
 	var group_row_cfg := group.duplicate()
 	group_row_cfg.merge({
-		"tag_name": group.name,
-		"from": group.from,
-		"to": group.to,
-		"direction": group.direction,
+		"tag_name": group.get("tag_name", ""),
+		"display_name": group.get("name", ""),
+		"from": group.get("from", -1),
+		"to": group.get("to", -1),
+		"direction": group.get("direction", "forward"),
 		"import": group_cfg.get("import", PopochiuConfig.is_default_animation_import_enabled()),
 		"prop_visible": group_cfg.get("prop_visible", PopochiuConfig.is_default_animation_prop_visible()),
 		"prop_clickable": group_cfg.get("prop_clickable", PopochiuConfig.is_default_animation_prop_clickable()),
@@ -556,7 +591,7 @@ func _add_group_rows(group: Dictionary, tags: Array) -> void:
 		children_container.add_child(tag_row)
 		tag_row.init(child_cfg)
 		tag_row.set_display_name(child.anim_name)
-		tag_row.set_group_child(group.name)
+		tag_row.set_group_child(group.get("name", ""))
 		_connect_tag_row_signals(tag_row)
 
 
@@ -618,12 +653,14 @@ func _merge_with_cache(tags: Array) -> Array:
 	for i in tags.size():
 		if tags_cache_index.has(tags[i].tag_name):
 			# Keep the user's settings from the cache, but refresh the frame data
-			# from the source file (ranges may have changed between scans)
+			# from the source file (ranges may have changed between scans). The
+			# frame data is only present when the tags were read with ranges.
 			var cached: Dictionary = tags_cache_index[tags[i].tag_name]
 			var merged: Dictionary = cached.duplicate()
-			merged.from = tags[i].from
-			merged.to = tags[i].to
-			merged.direction = tags[i].direction
+			if tags[i].has("from") and tags[i].has("to"):
+				merged.from = tags[i].from
+				merged.to = tags[i].to
+				merged.direction = tags[i].direction
 			result.push_back(merged)
 		else:
 			# New tag: set default loop and autoplay behavior based on object type
@@ -651,9 +688,38 @@ func _get_tags_from_source() -> Array:
 		return []
 	var tags_list = []
 	for t in tags_found:
-		if t.get("tag_name") == PopochiuEditorHelper.EMPTY_STRING:
-			continue
-		tags_list.push_back(t)
+		# Plain tag names arrive as Strings (from --list-tags); they are wrapped
+		# into dicts so the rest of the pipeline can treat every tag uniformly.
+		if typeof(t) == TYPE_STRING:
+			if t == PopochiuEditorHelper.EMPTY_STRING:
+				continue
+			tags_list.push_back({ "tag_name": t })
+		elif typeof(t) == TYPE_DICTIONARY:
+			if t.get("tag_name", PopochiuEditorHelper.EMPTY_STRING) == PopochiuEditorHelper.EMPTY_STRING:
+				continue
+			tags_list.push_back(t)
+	return tags_list
+
+
+# Like _get_tags_from_source but also reads the frame ranges. Only used at import
+# time (it is slow, since it makes Aseprite export the sprite metadata).
+func _get_tags_from_source_with_ranges() -> Array:
+	var tags_found = _list_tags_with_ranges(ProjectSettings.globalize_path(_source))
+	if typeof(tags_found) == TYPE_INT:
+		PopochiuUtils.print_error(RESULT_CODE.get_error_message(tags_found))
+		return []
+	var tags_list = []
+	for t in tags_found:
+		# Ranges arrive as dicts (from list_tags_with_ranges), but stay safe
+		# against name-only strings just in case.
+		if typeof(t) == TYPE_STRING:
+			if t == PopochiuEditorHelper.EMPTY_STRING:
+				continue
+			tags_list.push_back({ "tag_name": t })
+		elif typeof(t) == TYPE_DICTIONARY:
+			if t.get("tag_name", PopochiuEditorHelper.EMPTY_STRING) == PopochiuEditorHelper.EMPTY_STRING:
+				continue
+			tags_list.push_back(t)
 	return tags_list
 
 

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -41,6 +41,7 @@ var _output_folder := PopochiuEditorHelper.EMPTY_STRING
 var _file_dialog_aseprite: FileDialog
 var _tags_cache: Array = []
 var _importing := false
+var _import_dialog: AcceptDialog = null
 
 # A mapping of bulk toggle buttons to their corresponding row properties
 var _bulk_toggle_configs = {
@@ -257,6 +258,11 @@ func _on_import_pressed() -> void:
 		_importing = false
 		return
 	
+	# Let the user know something is happening: on re-imports Godot does not show
+	# its filesystem progress bars, so without this popup the operation looks
+	# frozen. It doubles as the final summary (see _finish_import_message).
+	_show_import_working()
+
 	_options = {
 		"source": ProjectSettings.globalize_path(_source),
 		"tags": _tags_cache,
@@ -747,6 +753,41 @@ func _show_message(
 	warning_dialog.close_requested.connect(callback)
 	
 	PopochiuEditorHelper.show_dialog(warning_dialog)
+
+
+# Shows a non-blocking "working" dialog while the import runs, so the user can
+# see that something is happening even on re-imports that skip Godot's
+# filesystem progress bars. The same dialog is reused for the final summary.
+func _show_import_working() -> void:
+	if is_instance_valid(_import_dialog):
+		_import_dialog.queue_free()
+	_import_dialog = AcceptDialog.new()
+	_import_dialog.title = "Importing..."
+	_import_dialog.dialog_text = "Importing assets, please wait..."
+	_import_dialog.popup_window = true
+	# Hide the OK button until the import finishes; the dialog only has the
+	# window close button during the operation.
+	_import_dialog.get_ok_button().visible = false
+	_import_dialog.close_requested.connect(_import_dialog.queue_free)
+	PopochiuEditorHelper.show_dialog(_import_dialog)
+
+
+# Turns the working dialog into the final summary, revealing the OK button.
+# Falls back to a plain message dialog when the working one is not available.
+func _finish_import_message(message: String, title: String) -> void:
+	if is_instance_valid(_import_dialog):
+		_import_dialog.title = title
+		_import_dialog.dialog_text = message
+		var ok_button := _import_dialog.get_ok_button()
+		ok_button.visible = true
+		ok_button.disabled = false
+		if not _import_dialog.confirmed.is_connected(_import_dialog.queue_free):
+			_import_dialog.confirmed.connect(_import_dialog.queue_free)
+		# Re-fit and re-center the dialog for the new content, when it's shown
+		if _import_dialog.is_inside_tree():
+			_import_dialog.popup_centered()
+	else:
+		_show_message(message, title)
 
 
 func _show_confirmation(

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -7,6 +7,10 @@ const LOCAL_OBJ_CONFIG = preload("res://addons/popochiu/editor/config/local_obj_
 # TODO: this can be specialized, even if for a two buttons... ?
 const AnimationTagRow =\
 preload("res://addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.gd")
+const AnimationGroupRow =\
+preload("res://addons/popochiu/editor/importers/aseprite/docks/animation_group_row.gd")
+const PopochiuAsepriteTagGrouper =\
+preload("res://addons/popochiu/editor/importers/aseprite/aseprite_tag_grouper.gd")
 
 enum {
 	HANDLE_ANIM_SELECT,
@@ -25,6 +29,8 @@ var file_system: EditorFileSystem
 # ---- External logic
 var _animation_tag_row_scene: PackedScene =\
 preload("res://addons/popochiu/editor/importers/aseprite/docks/animation_tag_row.tscn")
+var _animation_group_row_scene: PackedScene =\
+preload("res://addons/popochiu/editor/importers/aseprite/docks/animation_group_row.tscn")
 var _aseprite := preload("../aseprite_controller.gd").new() # TODO: should be absolute?
 # ---- References for children scripts
 var _root_node: Node
@@ -144,6 +150,12 @@ func _get_default_autoplay_behavior() -> bool:
 	return false
 
 
+# Returns whether this importer supports "group tags" (one object with several
+# animations). Only the room importer supports groups for now.
+func _supports_groups() -> bool:
+	return false
+
+
 # This method can be overridden by child classes to customize the tag UI,
 # such as enabling additional buttons or similar.
 func _customize_tag_ui(tagrow: AnimationTagRow) -> void:
@@ -178,14 +190,40 @@ func _delete_animation_for_tag(tag_name: String) -> void:
 func _on_filter_text_changed(new_text: String) -> void:
 	var filter_text := new_text.strip_edges().to_lower().replace(" ", "")
 	
-	for tag_row in %Tags.get_children():
+	for tag_row in _get_all_tag_rows():
 		if filter_text.is_empty():
 			# Show all tags when filter is empty
 			tag_row.visible = true
 		else:
-			# Compare with tag name (removing spaces, case insensitive)
-			var tag_name: String = tag_row.get_cfg().tag_name.to_lower().replace(" ", "")
+			# Compare with the (displayed) name, removing spaces, case insensitive
+			var tag_name: String = tag_row.get_search_name().to_lower().replace(" ", "")
 			tag_row.visible = tag_name.contains(filter_text)
+
+
+# Handles tag row state changes that need coordination between rows.
+# Autoplay is exclusive within a group: enabling it on a child disables it on
+# all the other children of the same group.
+func _on_tag_state_changed(tag_row: AnimationTagRow) -> void:
+	var group_name: String = tag_row.get_group_name()
+	if group_name.is_empty():
+		return
+
+	if not tag_row.get_cfg().get("autoplays", false):
+		return
+
+	var changed := false
+	for row in _get_all_tag_rows():
+		if (
+			row is AnimationTagRow
+			and row != tag_row
+			and row.get_group_name() == group_name
+			and row.get_cfg().get("autoplays", false)
+		):
+			row.set_autoplay_no_signal(false)
+			changed = true
+
+	if changed:
+		_save_config()
 
 
 func _on_source_pressed() -> void:
@@ -316,7 +354,7 @@ func _list_tags(file: String) -> Variant:
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
 	if not _aseprite.test_command():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
-	return _aseprite.list_tags(file)
+	return _aseprite.list_tags_with_ranges(file)
 
 
 # TODO: Currently unused. keeping this as reference
@@ -343,8 +381,20 @@ func _load_config(cfg) -> void:
 		cfg.get("autotrace_polygons", false)
 	)
 
+	# Restore the tag list. When groups are supported, refresh the persisted
+	# frame data against the current source file: ranges stored in the metadata
+	# can be outdated (e.g. if the room was last saved before a re-scan), which
+	# would otherwise break group detection on reload. Falls back to the saved
+	# list when the source can't be read.
+	var saved_tags: Array = cfg.get("tags", [])
+	if _supports_groups() and not _source.is_empty():
+		_tags_cache = saved_tags
+		var refreshed: Array = _merge_with_cache(_get_tags_from_source())
+		if not refreshed.is_empty():
+			saved_tags = refreshed
+
 	_set_tags_visible(cfg.get("tags_exp", false))
-	_populate_tags(cfg.get("tags", []))
+	_populate_tags(saved_tags)
 
 
 func _save_config() -> void:
@@ -435,22 +485,117 @@ func _populate_tags(tags: Array) -> void:
 	# Reset tags container.
 	_empty_tags_container()
 
-	# Add each tag found
+	if not _supports_groups():
+		_populate_flat_tags(tags)
+		_update_tags_cache()
+		_update_bulk_toggles_state() # Update bulk toggles after populating tags
+		return
+
+	var grouper := PopochiuAsepriteTagGrouper.new()
+	var analysis := grouper.analyze(tags)
+
+	for group in analysis.get("groups", []):
+		_add_group_rows(group, tags)
+
+	for tag in analysis.get("singles", []):
+		if tag.tag_name == PopochiuEditorHelper.EMPTY_STRING:
+			continue
+		_add_single_tag_row(tag)
+
+	_update_tags_cache()
+	_update_bulk_toggles_state() # Update bulk toggles after populating tags
+
+
+# Populates the tag list without group handling (used by importers that don't
+# support groups, e.g. characters and inventory items).
+func _populate_flat_tags(tags: Array) -> void:
 	for t in tags:
 		if t.tag_name == PopochiuEditorHelper.EMPTY_STRING:
 			continue
-		
 		var tag_row: AnimationTagRow = _animation_tag_row_scene.instantiate()
 		%Tags.add_child(tag_row)
 		tag_row.init(t)
-		tag_row.tag_state_changed.connect(_save_config)
-		tag_row.tag_selected.connect(_on_tag_selected)
-		tag_row.request_delete_anim.connect(_on_request_delete_anim)
+		_connect_tag_row_signals(tag_row)
 		_customize_tag_ui(tag_row)
-		# Invoke customization hook implementable in child classes		
-	
-	_update_tags_cache()
-	_update_bulk_toggles_state() # Update bulk toggles after populating tags
+
+
+# Adds a group header row and its child rows (indented) to the tag list.
+func _add_group_rows(group: Dictionary, tags: Array) -> void:
+	var group_cfg := _find_tag_cfg(tags, group.name)
+	var group_row_cfg := group.duplicate()
+	group_row_cfg.merge({
+		"tag_name": group.name,
+		"from": group.from,
+		"to": group.to,
+		"direction": group.direction,
+		"import": group_cfg.get("import", PopochiuConfig.is_default_animation_import_enabled()),
+		"prop_visible": group_cfg.get("prop_visible", PopochiuConfig.is_default_animation_prop_visible()),
+		"prop_clickable": group_cfg.get("prop_clickable", PopochiuConfig.is_default_animation_prop_clickable()),
+	})
+
+	var group_row: AnimationGroupRow = _animation_group_row_scene.instantiate()
+	%Tags.add_child(group_row)
+	group_row.init(group_row_cfg)
+	group_row.tag_state_changed.connect(_save_config)
+
+	if not group.get("is_valid", true):
+		group_row.set_error(group.get("error", ""))
+
+	# Child rows are indented under the group header
+	var indent := MarginContainer.new()
+	indent.add_theme_constant_override("margin_left", 18)
+	var children_container := VBoxContainer.new()
+	indent.add_child(children_container)
+	%Tags.add_child(indent)
+
+	for child in group.get("children", []):
+		var child_cfg := _find_tag_cfg(tags, child.tag_name)
+		if child_cfg.is_empty():
+			continue
+		var tag_row: AnimationTagRow = _animation_tag_row_scene.instantiate()
+		children_container.add_child(tag_row)
+		tag_row.init(child_cfg)
+		tag_row.set_display_name(child.anim_name)
+		tag_row.set_group_child(group.name)
+		_connect_tag_row_signals(tag_row)
+
+
+func _add_single_tag_row(tag_cfg: Dictionary) -> void:
+	var tag_row: AnimationTagRow = _animation_tag_row_scene.instantiate()
+	%Tags.add_child(tag_row)
+	tag_row.init(tag_cfg)
+	_connect_tag_row_signals(tag_row)
+	_customize_tag_ui(tag_row)
+
+
+func _connect_tag_row_signals(tag_row: AnimationTagRow) -> void:
+	tag_row.tag_state_changed.connect(_save_config)
+	tag_row.tag_state_changed.connect(_on_tag_state_changed.bind(tag_row))
+	tag_row.tag_selected.connect(_on_tag_selected)
+	tag_row.request_delete_anim.connect(_on_request_delete_anim)
+
+
+func _find_tag_cfg(tags: Array, tag_name: String) -> Dictionary:
+	for t in tags:
+		if t.get("tag_name") == tag_name:
+			return t
+	return {}
+
+
+# Returns every tag/group row currently in the list, including rows nested in
+# the indent containers used for group children.
+func _get_all_tag_rows() -> Array:
+	var rows: Array = []
+	_collect_tag_rows(%Tags, rows)
+	return rows
+
+
+func _collect_tag_rows(container: Node, rows: Array) -> void:
+	for child in container.get_children():
+		if child is AnimationTagRow or child is AnimationGroupRow:
+			rows.push_back(child)
+		elif child is BoxContainer or child is MarginContainer:
+			_collect_tag_rows(child, rows)
 
 
 func _empty_tags_container() -> void:
@@ -472,8 +617,14 @@ func _merge_with_cache(tags: Array) -> Array:
 	
 	for i in tags.size():
 		if tags_cache_index.has(tags[i].tag_name):
-			# Use cached version (preserves user settings)
-			result.push_back(tags_cache_index[tags[i].tag_name])
+			# Keep the user's settings from the cache, but refresh the frame data
+			# from the source file (ranges may have changed between scans)
+			var cached: Dictionary = tags_cache_index[tags[i].tag_name]
+			var merged: Dictionary = cached.duplicate()
+			merged.from = tags[i].from
+			merged.to = tags[i].to
+			merged.direction = tags[i].direction
+			result.push_back(merged)
 		else:
 			# New tag: set default loop and autoplay behavior based on object type
 			tags[i].loops = _get_default_loop_behavior()
@@ -485,7 +636,7 @@ func _merge_with_cache(tags: Array) -> Array:
 
 func _get_tags_from_ui() -> Array:
 	var tags_list = []
-	for tag_row in %Tags.get_children():
+	for tag_row in _get_all_tag_rows():
 		var tag_row_cfg: Dictionary = tag_row.get_cfg()
 		if tag_row_cfg.tag_name == PopochiuEditorHelper.EMPTY_STRING:
 			continue
@@ -500,11 +651,9 @@ func _get_tags_from_source() -> Array:
 		return []
 	var tags_list = []
 	for t in tags_found:
-		if t == PopochiuEditorHelper.EMPTY_STRING:
+		if t.get("tag_name") == PopochiuEditorHelper.EMPTY_STRING:
 			continue
-		tags_list.push_back({
-			tag_name = t
-		})
+		tags_list.push_back(t)
 	return tags_list
 
 
@@ -626,15 +775,18 @@ func _handle_animation_in_player(tag_name: String, animation_player: AnimationPl
 # Updates the state of bulk action buttons based on individual tag states.
 func _update_bulk_toggles_state() -> void:
 	# Handle ImportBulk toggle state
-	if %Tags.get_child_count() == 0:
+	var rows := _get_all_tag_rows()
+	if rows.is_empty():
 		return
 		
 	var all_import := true
 	var none_import := true
 	
 	# Check all tags to determine the collective state
-	for tag_row in %Tags.get_children():
+	for tag_row in rows:
 		var cfg: Dictionary = tag_row.get_cfg()
+		if not cfg.has("import"):
+			continue
 		if cfg.import:
 			none_import = false
 		else:
@@ -707,8 +859,10 @@ func _update_bulk_toggle_state(bulk_toggle_name: String) -> void:
 	var first_iteration := true
 
 	# Check all visible tag rows to determine the collective state
-	for tag_row in %Tags.get_children():
+	for tag_row in _get_all_tag_rows():
 		var cfg: Dictionary = tag_row.get_cfg()
+		if not cfg.has(config.row_property):
+			continue
 		var current_row_status = BulkActionStatus.ON if cfg.get(config.row_property) else BulkActionStatus.OFF
 
 		if first_iteration:
@@ -727,15 +881,31 @@ func _update_bulk_toggle_state(bulk_toggle_name: String) -> void:
 # Sets all tag rows' toggle state for a specific property.
 func _set_all_row_toggle_states(bulk_toggle_name: String, toggle_state: bool) -> void:
 	var config = _bulk_toggle_configs[bulk_toggle_name]
+	var seen_groups := {}
 	
-	for tag_row in %Tags.get_children():
+	for tag_row in _get_all_tag_rows():
 		var toggle = tag_row.get(config.row_toggle)
-		if toggle:
-			toggle.set_pressed_no_signal(toggle_state)
+		if not toggle:
+			continue
+
+		# Autoplay is exclusive within a group: when bulk-enabling autoplay,
+		# only the first child of each group gets enabled
+		if config.row_property == "autoplays" and toggle_state:
+			var group_name: String = (
+				tag_row.get_group_name() if tag_row is AnimationTagRow
+				else PopochiuEditorHelper.EMPTY_STRING
+			)
+			if not group_name.is_empty():
+				if seen_groups.has(group_name):
+					tag_row.set_autoplay_no_signal(false)
+					continue
+				seen_groups[group_name] = true
+
+		toggle.set_pressed_no_signal(toggle_state)
 	
-			# Update the underlying data
-			var cfg: Dictionary = tag_row.get_cfg()
-			cfg[config.row_property] = toggle_state
+		# Update the underlying data
+		var cfg: Dictionary = tag_row.get_cfg()
+		cfg[config.row_property] = toggle_state
 	
 	# Update the bulk toggle to reflect the new state
 	var status = BulkActionStatus.ON if toggle_state else BulkActionStatus.OFF

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -397,17 +397,15 @@ func _load_config(cfg) -> void:
 		cfg.get("autotrace_polygons", false)
 	)
 
-	# Restore the tag list. When groups are supported, refresh the persisted
-	# frame data against the current source file: ranges stored in the metadata
-	# can be outdated (e.g. if the room was last saved before a re-scan), which
-	# would otherwise break group detection on reload. Falls back to the saved
-	# list when the source can't be read.
+	# Restore the tag list. Refresh the persisted frame data against the current
+	# source file: ranges stored in the metadata can be outdated (e.g. if the
+	# room was last saved before a re-scan), which would otherwise break group
+	# detection and the frame tooltips on reload. Falls back to the saved list
+	# when the source can't be read.
 	var saved_tags: Array = cfg.get("tags", [])
-	if _supports_groups() and not _source.is_empty():
+	if not _source.is_empty():
 		_tags_cache = saved_tags
-		var refreshed: Array = _merge_with_cache(_get_tags_from_source())
-		if _has_group_tags(refreshed):
-			refreshed = _merge_with_cache(_get_tags_from_source_with_ranges())
+		var refreshed: Array = _merge_with_cache(_get_tags_from_source_with_ranges())
 		if not refreshed.is_empty():
 			saved_tags = refreshed
 
@@ -492,24 +490,14 @@ func _create_aseprite_file_selection() -> FileDialog:
 
 
 func _scan_source() -> void:
-	var tags: Array = _merge_with_cache(_get_tags_from_source())
-	# Group tags carry frame ranges used for validation and the safety net.
-	# Fetch them at scan time (data-only, fast) so problems are actionable
-	# before importing, not after.
-	if _supports_groups() and _has_group_tags(tags):
-		tags = _merge_with_cache(_get_tags_from_source_with_ranges())
-	_populate_tags(tags)
+	# Fetch the frame ranges on every scan (data-only, fast) so every row can
+	# show its frame info in the tag/group tooltip. list_tags_with_ranges falls
+	# back to name-only tags when the ranges can't be obtained.
+	_populate_tags(
+		_merge_with_cache(_get_tags_from_source_with_ranges())
+	)
 	_save_config()
 	_set_tags_visible(true)
-
-
-# Whether any of the tags is a "group tag" (@ prefix). Frame ranges are only
-# worth fetching at scan time when at least one group tag exists.
-func _has_group_tags(tags: Array) -> bool:
-	for tag in tags:
-		if str(tag.get("tag_name", "")).begins_with(PopochiuAsepriteTagGrouper.GROUP_PREFIX):
-			return true
-	return false
 
 
 func _populate_tags(tags: Array) -> void:
@@ -832,6 +820,11 @@ func _set_elements_styles() -> void:
 	# 2. Room-related toggles icons
 	%VisibleBulk.set_button_icon(get_theme_icon('GuiVisibilityVisible', 'EditorIcons'))
 	%ClickableBulk.set_button_icon(get_theme_icon('ToolSelect', 'EditorIcons'))
+
+	# Make the bulk buttons the same fixed width as the row action buttons (20px)
+	# so the toolbar columns line up with the tag list.
+	for bulk_button in [%VisibleBulk, %ClickableBulk, %AutoplaysBulk, %ImportBulk, %LoopsBulk]:
+		PopochiuEditorHelper.make_icon_button_slot(bulk_button)
 
 func _show_warning() -> void:
 	%Warning.visible = true

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -72,7 +72,7 @@ var _bulk_toggle_configs = {
 	}
 }
 
-#region Public ######################################################################################
+#region Public #####################################################################################
 func init() -> void:
 	# Connect signals
 
@@ -95,11 +95,11 @@ func init() -> void:
 		var bulk_toggle = get_node_or_null("%" + bulk_toggle_name)
 		if not bulk_toggle or not bulk_toggle.visible:
 			continue
-		
+
 		# Disconnect all existing connections to the "toggled" signal to prevent duplicates
 		for connection in bulk_toggle.get_signal_connection_list("toggled"):
 			bulk_toggle.toggled.disconnect(connection.callable)
-		
+
 		# Use a lambda to capture the bulk toggle name for the handler
 		bulk_toggle.toggled.connect(
 			func(pressed): _on_bulk_toggle_toggled(bulk_toggle_name, pressed)
@@ -109,7 +109,7 @@ func init() -> void:
 
 	# Update default values for bulk toggles
 	_update_default_toggle_values()
-	
+
 	# Initialize styles and UI elements visibility
 	_set_elements_styles()
 	_customize_filter_ui()
@@ -185,12 +185,12 @@ func _delete_animation_for_tag(tag_name: String) -> void:
 #endregion
 
 
-#region Signals Handlers ####################################################################################
+#region Signals Handlers ###########################################################################
 # Filters the tag list based on the search text in the FilterField.
 # Tags whose names contain the search string (case-insensitive, ignoring spaces) will be shown.
 func _on_filter_text_changed(new_text: String) -> void:
 	var filter_text := new_text.strip_edges().to_lower().replace(" ", "")
-	
+
 	for tag_row in _get_all_tag_rows():
 		if filter_text.is_empty():
 			# Show all tags when filter is empty
@@ -244,7 +244,7 @@ func _on_rescan_pressed() -> void:
 func _on_import_pressed() -> void:
 	if _importing:
 		return
-	
+
 	_importing = true
 	_root_node = get_tree().get_edited_scene_root()
 
@@ -252,12 +252,12 @@ func _on_import_pressed() -> void:
 		PopochiuResources.INVENTORY_ITEMS_PATH if _root_node == null
 		else _root_node.scene_file_path.get_base_dir()
 	)
-	
+
 	if _source == PopochiuEditorHelper.EMPTY_STRING:
 		_show_message("Aseprite file not selected")
 		_importing = false
 		return
-	
+
 	# Let the user know something is happening: on re-imports Godot does not show
 	# its filesystem progress bars, so without this popup the operation looks
 	# frozen. It doubles as the final summary (see _finish_import_message).
@@ -283,7 +283,7 @@ func _on_reset_pressed() -> void:
 
 func _on_request_delete_anim(tag_name: String) -> void:
 	var delete_dialog = PopochiuEditorHelper.DELETE_CONFIRMATION_SCENE.instantiate()
-	
+
 	delete_dialog.title = "Remove animation for tag %s?" % tag_name
 	var anim_name := tag_name.to_snake_case()
 	delete_dialog.message = (
@@ -292,14 +292,14 @@ func _on_request_delete_anim(tag_name: String) -> void:
 	)
 	delete_dialog.ask = "Remove the animation for tag [b]%s[/b]?" % tag_name
 	delete_dialog.on_confirmed = _delete_animation_for_tag.bind(tag_name)
-	
+
 	PopochiuEditorHelper.show_delete_confirmation(delete_dialog)
 
 
 # Called when project settings that affect default values have changed.
 func _on_project_settings_changed() -> void:
 	_update_default_toggle_values()
-	
+
 	# Only update UI if it's already populated
 	if %Tags.get_child_count() > 0:
 		_update_all_bulk_toggles_state()
@@ -315,23 +315,24 @@ func _on_theme_changed() -> void:
 # Determines the action based on whether the toggle is in a clean or "dirty" state.
 func _on_bulk_toggle_toggled(bulk_toggle_name: String, button_pressed: bool) -> void:
 	var bulk_toggle = get_node("%" + bulk_toggle_name)
-	
+
 	# If all tags are in a consistent state, simply toggle them all
 	if not bulk_toggle.has_meta("is_dirty") or not bulk_toggle.get_meta("is_dirty"):
 		_set_all_row_toggle_states(bulk_toggle_name, button_pressed)
 		return
-	
+
 	# If in a mixed state ("dirty"), show confirmation dialog
 	var confirmation_dialog = _show_confirmation(
-		"This will reset all " + bulk_toggle_name.replace("Bulk", "").to_lower() + " toggles to their default state.\n" +
-		"Your individual tag preferences will be lost. Are you sure?",
+		"This will reset all " + bulk_toggle_name.replace("Bulk", "").to_lower()
+		+ " toggles to their default state.\n"
+		+ "Your individual tag preferences will be lost. Are you sure?",
 		"Confirmation required!"
 	)
-	
+
 	confirmation_dialog.get_ok_button().pressed.connect(
 		_reset_toggle_preferences.bind(bulk_toggle_name)
 	)
-	
+
 	# Reset the toggle to off state since we need confirmation
 	bulk_toggle.set_pressed_no_signal(false)
 
@@ -348,11 +349,11 @@ func _on_tag_selected(tag_name: String) -> void:
 func _check_aseprite() -> int:
 	if not _aseprite.check_command_path():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FULL_PATH
-	
+
 	if not _aseprite.test_command():
 		return RESULT_CODE.ERR_ASEPRITE_CMD_NOT_FOUND
-	
-	return RESULT_CODE.SUCCESS	
+
+	return RESULT_CODE.SUCCESS
 
 
 # Slow variant used only at import time: fetches the tag frame ranges needed to
@@ -536,8 +537,12 @@ func _add_group_rows(group: Dictionary, tags: Array) -> void:
 		"to": group.get("to", -1),
 		"direction": group.get("direction", "forward"),
 		"import": group_cfg.get("import", PopochiuConfig.is_default_animation_import_enabled()),
-		"prop_visible": group_cfg.get("prop_visible", PopochiuConfig.is_default_animation_prop_visible()),
-		"prop_clickable": group_cfg.get("prop_clickable", PopochiuConfig.is_default_animation_prop_clickable()),
+		"prop_visible": group_cfg.get(
+			"prop_visible", PopochiuConfig.is_default_animation_prop_visible()
+		),
+		"prop_clickable": group_cfg.get(
+			"prop_clickable", PopochiuConfig.is_default_animation_prop_clickable()
+		),
 	})
 
 	var group_row: AnimationGroupRow = _animation_group_row_scene.instantiate()
@@ -621,7 +626,7 @@ func _merge_with_cache(tags: Array) -> Array:
 	var result = []
 	for t in _tags_cache:
 		tags_cache_index[t.tag_name] = t
-	
+
 	for i in tags.size():
 		if tags_cache_index.has(tags[i].tag_name):
 			# Keep the user's settings from the cache, but refresh the frame data
@@ -683,22 +688,22 @@ func _show_message(
 	method := PopochiuEditorHelper.EMPTY_STRING
 ) -> void:
 	var warning_dialog = AcceptDialog.new()
-	
+
 	if title != PopochiuEditorHelper.EMPTY_STRING:
 		warning_dialog.title = title
-	
+
 	warning_dialog.dialog_text = message
 	warning_dialog.popup_window = true
-	
+
 	var callback := Callable(warning_dialog, "queue_free")
-	
+
 	if is_instance_valid(object) and not method.is_empty():
 		callback = func():
 			object.call(method)
-	
+
 	warning_dialog.confirmed.connect(callback)
 	warning_dialog.close_requested.connect(callback)
-	
+
 	PopochiuEditorHelper.show_dialog(warning_dialog)
 
 
@@ -783,14 +788,16 @@ func _set_elements_styles() -> void:
 func _show_warning() -> void:
 	%Warning.visible = true
 	%Importer.visible = false
-	
+
 
 func _show_importer() -> void:
 	%Warning.visible = false
 	%Importer.visible = true
 
 
-func _handle_animation_in_player(tag_name: String, animation_player: AnimationPlayer, action: int = HANDLE_ANIM_SELECT) -> void:
+func _handle_animation_in_player(
+	tag_name: String, animation_player: AnimationPlayer, action: int = HANDLE_ANIM_SELECT
+) -> void:
 	if tag_name.is_empty():
 		PopochiuUtils.print_warning("No tag name provided for selection.")
 		return
@@ -822,14 +829,16 @@ func _handle_animation_in_player(tag_name: String, animation_player: AnimationPl
 			_:
 				PopochiuUtils.print_warning("Unknown action for animation handling: %s." % action)
 	else:
-		PopochiuUtils.print_warning("No animation named '%s' found in character's AnimationPlayer." % animation_name)
+		PopochiuUtils.print_warning(
+			"No animation named '%s' found in character's AnimationPlayer." % animation_name
+		)
 
 
 # Updates the state of all visible bulk toggle buttons based on individual tag states.
-func _update_all_bulk_toggles_state() -> void:	
+func _update_all_bulk_toggles_state() -> void:
 	if %Tags.get_child_count() == 0:
 		return
-		
+
 	# Update each bulk toggle that's visible in the UI
 	for bulk_toggle_name in _bulk_toggle_configs.keys():
 		if get_node_or_null("%" + bulk_toggle_name):
@@ -841,7 +850,7 @@ func _set_bulk_toggle_visual_state(bulk_toggle_name: String, status: BulkActionS
 	var bulk_toggle = get_node("%" + bulk_toggle_name)
 	if not bulk_toggle:
 		return
-	
+
 	match status:
 		BulkActionStatus.ON:
 			bulk_toggle.set_pressed_no_signal(true)
@@ -875,7 +884,9 @@ func _update_bulk_toggle_state(bulk_toggle_name: String) -> void:
 		var cfg: Dictionary = tag_row.get_cfg()
 		if not cfg.has(config.row_property):
 			continue
-		var current_row_status = BulkActionStatus.ON if cfg.get(config.row_property) else BulkActionStatus.OFF
+		var current_row_status = (
+			BulkActionStatus.ON if cfg.get(config.row_property) else BulkActionStatus.OFF
+		)
 
 		if first_iteration:
 			# Set initial status from first row
@@ -894,7 +905,7 @@ func _update_bulk_toggle_state(bulk_toggle_name: String) -> void:
 func _set_all_row_toggle_states(bulk_toggle_name: String, toggle_state: bool) -> void:
 	var config = _bulk_toggle_configs[bulk_toggle_name]
 	var seen_groups := {}
-	
+
 	for tag_row in _get_all_tag_rows():
 		var toggle = tag_row.get(config.row_toggle)
 		if not toggle:
@@ -914,11 +925,11 @@ func _set_all_row_toggle_states(bulk_toggle_name: String, toggle_state: bool) ->
 				seen_groups[group_name] = true
 
 		toggle.set_pressed_no_signal(toggle_state)
-	
+
 		# Update the underlying data
 		var cfg: Dictionary = tag_row.get_cfg()
 		cfg[config.row_property] = toggle_state
-	
+
 	# Update the bulk toggle to reflect the new state
 	var status = BulkActionStatus.ON if toggle_state else BulkActionStatus.OFF
 	_set_bulk_toggle_visual_state(bulk_toggle_name, status)
@@ -930,7 +941,7 @@ func _set_all_row_toggle_states(bulk_toggle_name: String, toggle_state: bool) ->
 func _reset_toggle_preferences(bulk_toggle_name: String) -> void:
 	var config = _bulk_toggle_configs[bulk_toggle_name]
 	var default_value: bool = config.get("default_value", false)
-		
+
 	_set_all_row_toggle_states(bulk_toggle_name, default_value)
 
 
@@ -939,8 +950,14 @@ func _update_default_toggle_values() -> void:
 	# assign local values
 	_bulk_toggle_configs["LoopsBulk"]["default_value"] = _get_default_loop_behavior()
 	_bulk_toggle_configs["AutoplaysBulk"]["default_value"] = _get_default_autoplay_behavior()
-	
+
 	# Assign general configuration defaults
-	_bulk_toggle_configs["ImportBulk"]["default_value"] = PopochiuConfig.is_default_animation_import_enabled()
-	_bulk_toggle_configs["VisibleBulk"]["default_value"] = PopochiuConfig.is_default_animation_prop_visible()
-	_bulk_toggle_configs["ClickableBulk"]["default_value"] = PopochiuConfig.is_default_animation_prop_clickable()
+	_bulk_toggle_configs["ImportBulk"]["default_value"] = (
+		PopochiuConfig.is_default_animation_import_enabled()
+	)
+	_bulk_toggle_configs["VisibleBulk"]["default_value"] = (
+		PopochiuConfig.is_default_animation_prop_visible()
+	)
+	_bulk_toggle_configs["ClickableBulk"]["default_value"] = (
+		PopochiuConfig.is_default_animation_prop_clickable()
+	)

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd
@@ -42,6 +42,10 @@ var _file_dialog_aseprite: FileDialog
 var _tags_cache: Array = []
 var _importing := false
 var _import_dialog: AcceptDialog = null
+# Maps each group child tag (e.g. ":DoorClosed") to its group info, so tag
+# select/delete actions don't re-analyze the tag list on every click. Rebuilt
+# on every scan by _populate_tags.
+var _group_child_info_by_tag: Dictionary = {}
 
 # A mapping of bulk toggle buttons to their corresponding row properties
 var _bulk_toggle_configs = {
@@ -155,6 +159,13 @@ func _get_default_autoplay_behavior() -> bool:
 # animations). Only the room importer supports groups for now.
 func _supports_groups() -> bool:
 	return false
+
+
+# Returns the group info (group_name and anim_name) for a tag that is a child of
+# a group, or an empty dictionary when the tag is standalone. Populated on every
+# scan by _populate_tags, so subclasses don't re-analyze the tag list.
+func _get_group_child_info(tag_name: String) -> Dictionary:
+	return _group_child_info_by_tag.get(tag_name, {})
 
 
 # This method can be overridden by child classes to customize the tag UI,
@@ -486,6 +497,7 @@ func _scan_source() -> void:
 func _populate_tags(tags: Array) -> void:
 	# Reset tags container.
 	_empty_tags_container()
+	_group_child_info_by_tag = {}
 
 	if not _supports_groups():
 		_populate_flat_tags(tags)
@@ -502,6 +514,15 @@ func _populate_tags(tags: Array) -> void:
 		PopochiuUtils.print_error(importer_error)
 	for importer_warning in analysis.get("warnings", []):
 		PopochiuUtils.print_warning(importer_warning)
+
+	# Keep a lookup of each group child so tag select/delete actions don't have
+	# to re-run the whole analysis on every click.
+	for group in analysis.get("groups", []):
+		for child in group.get("children", []):
+			_group_child_info_by_tag[child.tag_name] = {
+				"group_name": group.name,
+				"anim_name": child.anim_name,
+			}
 
 	# Render groups and standalone tags in their source order
 	for item in analysis.get("items", []):

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.tscn
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://bcanby6n3eahm"]
+[gd_scene format=3 uid="uid://bcanby6n3eahm"]
 
 [sub_resource type="StyleBoxEmpty" id="1"]
 
@@ -19,6 +19,8 @@ image = SubResource("Image_vemq8")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_snao5"]
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_m03mu"]
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ctsm1"]
 content_margin_left = 4.0
 content_margin_top = 4.0
@@ -28,31 +30,31 @@ bg_color = Color(1, 0.364706, 0.364706, 1)
 draw_center = false
 corner_detail = 1
 
-[node name="AsepriteImporterInspectorDock" type="PanelContainer"]
+[node name="AsepriteImporterInspectorDock" type="PanelContainer" unique_id=2036129632]
 offset_right = 14.0
 offset_bottom = 14.0
 theme_override_styles/panel = SubResource("1")
 
-[node name="Margin" type="MarginContainer" parent="."]
+[node name="Margin" type="MarginContainer" parent="." unique_id=1328525319]
 layout_mode = 2
 theme_override_constants/margin_top = 2
 theme_override_constants/margin_bottom = 2
 
-[node name="Importer" type="VBoxContainer" parent="Margin"]
+[node name="Importer" type="VBoxContainer" parent="Margin" unique_id=1052446868]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Source" type="HBoxContainer" parent="Margin/Importer"]
+[node name="Source" type="HBoxContainer" parent="Margin/Importer" unique_id=346003194]
 layout_mode = 2
 tooltip_text = "Location of the Aseprite (*.ase, *.aseprite)  source file."
 
-[node name="Label" type="Label" parent="Margin/Importer/Source"]
+[node name="Label" type="Label" parent="Margin/Importer/Source" unique_id=1627602857]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Aseprite File"
 
-[node name="SourceButton" type="Button" parent="Margin/Importer/Source"]
+[node name="SourceButton" type="Button" parent="Margin/Importer/Source" unique_id=1303017145]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -60,20 +62,20 @@ size_flags_stretch_ratio = 2.0
 text = "[empty]"
 clip_text = true
 
-[node name="RescanButton" type="Button" parent="Margin/Importer/Source"]
+[node name="RescanButton" type="Button" parent="Margin/Importer/Source" unique_id=979411303]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Rescan"
 
-[node name="FilterBulkBtnContainer" type="PanelContainer" parent="Margin/Importer"]
+[node name="FilterBulkBtnContainer" type="PanelContainer" parent="Margin/Importer" unique_id=1795241642]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_wwoxk")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Margin/Importer/FilterBulkBtnContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Margin/Importer/FilterBulkBtnContainer" unique_id=842256842]
 layout_mode = 2
 
-[node name="FilterField" type="LineEdit" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="FilterField" type="LineEdit" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=1015027343]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -82,7 +84,7 @@ keep_editing_on_text_submit = true
 emoji_menu_enabled = false
 clear_button_enabled = true
 
-[node name="VisibleBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="VisibleBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=1122585908]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -93,7 +95,7 @@ toggle_mode = true
 icon = SubResource("ImageTexture_dkl0r")
 flat = true
 
-[node name="ClickableBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="ClickableBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=511655929]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -104,7 +106,7 @@ toggle_mode = true
 icon = SubResource("ImageTexture_dkl0r")
 flat = true
 
-[node name="AutoplaysBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="AutoplaysBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=710950879]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -115,14 +117,14 @@ toggle_mode = true
 icon = SubResource("ImageTexture_dkl0r")
 flat = true
 
-[node name="FilterSeparator" type="Panel" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="FilterSeparator" type="Panel" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=767376194]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(1, 0)
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_snao5")
 
-[node name="ImportBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="ImportBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=1822248276]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -132,7 +134,7 @@ toggle_mode = true
 icon = SubResource("ImageTexture_dkl0r")
 flat = true
 
-[node name="LoopsBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
+[node name="LoopsBulk" type="Button" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=1727904686]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
@@ -142,11 +144,12 @@ toggle_mode = true
 icon = SubResource("ImageTexture_dkl0r")
 flat = true
 
-[node name="FinalSpacer" type="Panel" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer"]
-custom_minimum_size = Vector2(8, 0)
+[node name="FinalSpacer" type="Panel" parent="Margin/Importer/FilterBulkBtnContainer/HBoxContainer" unique_id=1361304907]
+custom_minimum_size = Vector2(10, 0)
 layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxEmpty_m03mu")
 
-[node name="TagsScrollContainer" type="ScrollContainer" parent="Margin/Importer"]
+[node name="TagsScrollContainer" type="ScrollContainer" parent="Margin/Importer" unique_id=337301252]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(0, 150)
@@ -156,12 +159,12 @@ follow_focus = true
 horizontal_scroll_mode = 0
 vertical_scroll_mode = 4
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Margin/Importer/TagsScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Margin/Importer/TagsScrollContainer" unique_id=2092599885]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="TagsInfo" type="Panel" parent="Margin/Importer/TagsScrollContainer/VBoxContainer"]
+[node name="TagsInfo" type="Panel" parent="Margin/Importer/TagsScrollContainer/VBoxContainer" unique_id=1274324053]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(222, 50)
 layout_mode = 2
@@ -169,7 +172,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_ctsm1")
 
-[node name="InfoLabel" type="Label" parent="Margin/Importer/TagsScrollContainer/VBoxContainer/TagsInfo"]
+[node name="InfoLabel" type="Label" parent="Margin/Importer/TagsScrollContainer/VBoxContainer/TagsInfo" unique_id=1433389959]
 custom_minimum_size = Vector2(0, 42)
 layout_mode = 0
 anchor_right = 1.0
@@ -179,39 +182,39 @@ size_flags_vertical = 6
 text = "To import animations, select a properly tagged Aseprite source file."
 autowrap_mode = 3
 
-[node name="Tags" type="VBoxContainer" parent="Margin/Importer/TagsScrollContainer/VBoxContainer"]
+[node name="Tags" type="VBoxContainer" parent="Margin/Importer/TagsScrollContainer/VBoxContainer" unique_id=2093920181]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="OptionsContainer" type="PanelContainer" parent="Margin/Importer"]
+[node name="OptionsContainer" type="PanelContainer" parent="Margin/Importer" unique_id=1407668064]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Options" type="VBoxContainer" parent="Margin/Importer/OptionsContainer"]
+[node name="Options" type="VBoxContainer" parent="Margin/Importer/OptionsContainer" unique_id=509009280]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="VisibleLayers" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options"]
+[node name="VisibleLayers" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options" unique_id=1081260672]
 layout_mode = 2
 tooltip_text = "If active, layers not visible in the source file won't be included in the final image."
 
-[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/VisibleLayers"]
+[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/VisibleLayers" unique_id=892252341]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Only visible layers"
 
-[node name="VisibleLayersCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/VisibleLayers"]
+[node name="VisibleLayersCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/VisibleLayers" unique_id=1503946280]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
-[node name="WipeOldAnimations" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options"]
+[node name="WipeOldAnimations" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options" unique_id=359241323]
 layout_mode = 2
 tooltip_text = "If active, layers not visible in the source file won't be included in the final image."
 
-[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/WipeOldAnimations"]
+[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/WipeOldAnimations" unique_id=2056958721]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
@@ -219,55 +222,55 @@ tooltip_text = "Set this to OFF if you want to add new animations on top of old 
 mouse_filter = 0
 text = "Wipe old animations"
 
-[node name="WipeOldAnimationsCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/WipeOldAnimations"]
+[node name="WipeOldAnimationsCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/WipeOldAnimations" unique_id=780699023]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
-[node name="AutotracePolygons" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options"]
+[node name="AutotracePolygons" type="HBoxContainer" parent="Margin/Importer/OptionsContainer/Options" unique_id=1203228738]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 tooltip_text = "If active, the interaction polygon of each imported prop or character will be traced automatically from its sprite's alpha channel."
 
-[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/AutotracePolygons"]
+[node name="Label" type="Label" parent="Margin/Importer/OptionsContainer/Options/AutotracePolygons" unique_id=1083015784]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Autotrace polygons"
 
-[node name="AutotracePolygonsCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/AutotracePolygons"]
+[node name="AutotracePolygonsCheckButton" type="CheckButton" parent="Margin/Importer/OptionsContainer/Options/AutotracePolygons" unique_id=753026819]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
-[node name="ButtonsBox" type="HBoxContainer" parent="Margin/Importer"]
+[node name="ButtonsBox" type="HBoxContainer" parent="Margin/Importer" unique_id=1790388292]
 layout_mode = 2
 size_flags_horizontal = 8
 
-[node name="Reset" type="Button" parent="Margin/Importer/ButtonsBox"]
+[node name="Reset" type="Button" parent="Margin/Importer/ButtonsBox" unique_id=1855505685]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reset all preferences"
 flat = true
 
-[node name="Import" type="Button" parent="Margin/Importer/ButtonsBox"]
+[node name="Import" type="Button" parent="Margin/Importer/ButtonsBox" unique_id=1615011572]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Import selected animations"
 text = "Import"
 
-[node name="Warning" type="VBoxContainer" parent="Margin"]
+[node name="Warning" type="VBoxContainer" parent="Margin" unique_id=261532572]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Margin/Warning"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Margin/Warning" unique_id=53624499]
 layout_mode = 2
 
-[node name="WarningPanel" type="Panel" parent="Margin/Warning/HBoxContainer"]
+[node name="WarningPanel" type="Panel" parent="Margin/Warning/HBoxContainer" unique_id=61283041]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(222, 65)
 layout_mode = 2
@@ -275,7 +278,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_ctsm1")
 
-[node name="WarningLabel" type="Label" parent="Margin/Warning/HBoxContainer/WarningPanel"]
+[node name="WarningLabel" type="Label" parent="Margin/Warning/HBoxContainer/WarningPanel" unique_id=788180189]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 42)
 layout_mode = 0

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_character.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_character.gd
@@ -34,11 +34,11 @@ func _on_import_pressed() -> void:
 
 	if typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS:
 		PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
-		_show_message("Some errors occurred. Please check output panel.", "Warning!")
+		_finish_import_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
 		if %AutotracePolygonsCheckButton.is_pressed():
 			PopochiuPolygonsHelper.trace_interaction_polygon_direct(target_node)
-		_show_message("%d animation tags processed." % [_tags_cache.size()], "Done!")
+		_finish_import_message("%d animation tags processed." % [_tags_cache.size()], "Done!")
 
 
 func _customize_tag_ui(tag_row: AnimationTagRow) -> void:

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_character.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_character.gd
@@ -6,7 +6,7 @@ var _animation_creator := preload(
 ).new()
 
 
-#region Public ######################################################################################
+#region Public #####################################################################################
 func init() -> void:
 	# Instantiate animation creator
 	_animation_creator.init(_aseprite, file_system)
@@ -26,7 +26,7 @@ func _on_import_pressed() -> void:
 	# Set everything up
 	# This will populate _root_node and _options class variables
 	super()
-	
+
 	var result := await _animation_creator.create_all_animations(
 		target_node, _options
 	)

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
@@ -121,8 +121,9 @@ func _create_inventory_item(name: String) -> PopochiuInventoryItem:
 ## Check if an inventory item with the given name already exists and load it.
 ## Returns the loaded inventory item scene or null if it doesn't exist.
 func _get_existing_inventory_item(item_name: String) -> PopochiuInventoryItem:
+	# The inventory_items data section is keyed by the PascalCase script_name.
 	var item_res_path: String = PopochiuResources.get_data_value(
-		"inventory_items", item_name.to_snake_case(), PopochiuEditorHelper.EMPTY_STRING
+		"inventory_items", item_name, PopochiuEditorHelper.EMPTY_STRING
 	)
 	if item_res_path == PopochiuEditorHelper.EMPTY_STRING:
 		return null

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
@@ -88,11 +88,9 @@ func _on_import_pressed():
 
 	if typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS:
 		PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
-		_show_message("Some errors occurred. Please check output panel.", "Warning!")
+		_finish_import_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
-		await get_tree().create_timer(0.1).timeout
-		
-		_show_message(
+		_finish_import_message(
 			"%d inventory items created." % [created_items.size()],
 			"Done!"
 		)

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_inventory.gd
@@ -10,7 +10,7 @@ var _animation_creator = preload(
 ).new()
 
 
-#region Public ######################################################################################
+#region Public #####################################################################################
 ## Initialize the inventory importer dock.
 func init():
 	# Instantiate animation creator
@@ -39,10 +39,10 @@ func _on_import_pressed():
 	for tag in _options.get("tags"):
 		# Ignore unwanted tags
 		if not tag.import: continue
-			
+
 		# Always convert to PascalCase as a standard
 		var item_name: String = tag.tag_name.to_pascal_case()
-		
+
 		# Check if the inventory item already exists, if so load it instead of creating new
 		var inventory_item = _get_existing_inventory_item(item_name)
 		if inventory_item == null:
@@ -50,19 +50,19 @@ func _on_import_pressed():
 			inventory_item = _create_inventory_item(item_name)
 			if inventory_item == null:
 				result = RESULT_CODE.ERR_CANT_CREATE_OBJ_FOLDER
-		
+
 		inventory_item.set_meta("ANIM_NAME", tag.tag_name)
 		inventory_item.set_meta("ANIM_AUTOPLAY", tag.autoplays)
 
 		created_items.append(inventory_item)
-	
+
 	# Import animations for each created item
 	for item in created_items:
 		if not item.has_meta("ANIM_NAME"): continue
-		
+
 		# Make the output folder match the item's folder
 		_options.output_folder = item.scene_file_path.get_base_dir()
-		
+
 		# Import a single tag animation
 		result = await _animation_creator.create_tag_animations(
 			item,
@@ -79,9 +79,9 @@ func _on_import_pressed():
 
 	# Save all created items
 	for item in created_items:
-		if not item.has_meta("ANIM_NAME"): 
+		if not item.has_meta("ANIM_NAME"):
 			continue
-		
+
 		result = await _save_inventory_item(item)
 
 	_importing = false
@@ -111,7 +111,7 @@ func _customize_filter_ui():
 ## Create a new inventory item with the specified name.
 func _create_inventory_item(name: String) -> PopochiuInventoryItem:
 	var factory = PopochiuInventoryItemFactory.new()
-	
+
 	if factory.create(name) != ResultCodes.SUCCESS:
 		return null
 
@@ -121,17 +121,19 @@ func _create_inventory_item(name: String) -> PopochiuInventoryItem:
 ## Check if an inventory item with the given name already exists and load it.
 ## Returns the loaded inventory item scene or null if it doesn't exist.
 func _get_existing_inventory_item(item_name: String) -> PopochiuInventoryItem:
-	var item_res_path: String = PopochiuResources.get_data_value("inventory_items", item_name.to_snake_case(), PopochiuEditorHelper.EMPTY_STRING)
+	var item_res_path: String = PopochiuResources.get_data_value(
+		"inventory_items", item_name.to_snake_case(), PopochiuEditorHelper.EMPTY_STRING
+	)
 	if item_res_path == PopochiuEditorHelper.EMPTY_STRING:
 		return null
 
 	var packed_scene: PackedScene = load(load(item_res_path).scene)
-	
+
 	var inventory_item = packed_scene.instantiate()
 	if not inventory_item is PopochiuInventoryItem:
 		inventory_item.queue_free()
 		return null
-	
+
 	return inventory_item
 
 
@@ -151,7 +153,7 @@ func _save_inventory_item(item: PopochiuInventoryItem) -> int:
 func _get_scene_path_for_tag(tag_name: String) -> String:
 	if not tag_name:
 		return PopochiuEditorHelper.EMPTY_STRING
-	
+
 	# For inventory items, we need to find the scene path from the resource
 	var item_name: String = tag_name.to_pascal_case()
 	var item_resource_path: String = PopochiuResources.get_data_value(
@@ -184,7 +186,7 @@ func _select_animation(tag_name: String) -> void:
 	if scene_path.is_empty():
 		PopochiuUtils.print_warning("No scene path found for inventory item '%s'" % item_name)
 		return
-	
+
 	EditorInterface.open_scene_from_path(scene_path)
 
 	# Wait a frame to ensure the scene is fully loaded
@@ -214,7 +216,7 @@ func _delete_animation_for_tag(tag_name: String) -> void:
 	if not packed_scene:
 		PopochiuUtils.print_warning("Failed to load scene for inventory item '%s'" % item_name)
 		return
-	
+
 	# Instance the scene to work with it in memory
 	var item_scene_root: Node = packed_scene.instantiate()
 	if not is_instance_valid(item_scene_root):

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -291,15 +291,10 @@ func _get_scene_path_for_prop(prop_name: String) -> String:
 
 #region Protected ##################################################################################
 # Returns the group info for a tag that is a child of a group, or an empty
-# dictionary when the tag is a standalone animation.
+# dictionary when the tag is a standalone animation. The lookup is built at scan
+# time by _populate_tags, so this is a cheap dictionary access.
 func _get_group_anim_info(tag_name: String) -> Dictionary:
-	var grouper := PopochiuAsepriteTagGrouper.new()
-	var analysis := grouper.analyze(_tags_cache)
-	for group in analysis.get("groups", []):
-		for child in group.get("children", []):
-			if child.tag_name == tag_name:
-				return { "group_name": group.name, "anim_name": child.anim_name }
-	return {}
+	return _get_group_child_info(tag_name)
 
 
 # Selects the animation in the room prop's AnimationPlayer.

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -18,6 +18,11 @@ func _get_default_autoplay_behavior() -> bool:
 	return false
 
 
+# The room importer supports "group tags": one prop with several animations.
+func _supports_groups() -> bool:
+	return true
+
+
 #endregion
 
 
@@ -30,50 +35,135 @@ func _on_import_pressed() -> void:
 	var props_container := _root_node.get_node("Props")
 	var result: int = RESULT_CODE.SUCCESS
 
-	# Create a prop for each tag that must be imported
-	# and populate it with the right sprite
+	var grouper := PopochiuAsepriteTagGrouper.new()
+	var analysis := grouper.analyze(_options.get("tags"))
+
+	# Build a lookup of the tag configurations (with user toggles) by name
+	var tags_by_name := {}
 	for tag in _options.get("tags"):
-		# Ignore unwanted tags
-		if not tag.import: continue
-			
+		tags_by_name[tag.tag_name] = tag
+
+	# Track the tags that are actually imported in this run, so that props whose
+	# source tag was removed or whose group became invalid are not re-imported
+	# from stale metadata.
+	var importable_names := {}
+
+	# Create a prop for each group and each single tag that must be imported,
+	# and populate it with the right sprite.
+	for group in analysis.get("groups", []):
+		# Misconfigured groups are skipped entirely and reported at the end
+		if not group.get("is_valid", true):
+			continue
+
+		var group_cfg: Dictionary = tags_by_name.get(group.name, {})
+		if not group_cfg.get("import", true):
+			continue
+
+		# Only keep the children the user wants to import as animations
+		var children := []
+		for child in group.get("children", []):
+			var child_cfg: Dictionary = tags_by_name.get(child.tag_name, {})
+			if not child_cfg.get("import", true):
+				continue
+			var child_import: Dictionary = child.duplicate()
+			child_import.loops = child_cfg.get("loops", false)
+			child_import.autoplays = child_cfg.get("autoplays", false)
+			children.push_back(child_import)
+
+		# No animation to import for this group: don't create the prop
+		if children.is_empty():
+			continue
+
 		# Always convert to PascalCase as a standard
 		# TODO: check Godot 4 standards, I can't find info
-		var prop_name: String = tag.tag_name.to_pascal_case()
-		
+		var prop_name: String = group.name.to_pascal_case()
+
 		# In case the prop is there, use the one we already have
 		var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
 		if prop == null:
-			# Create a new prop if necessary, specifying the
-			# interaction flags.
-			prop = _create_prop(prop_name, tag.prop_clickable, tag.prop_visible)
+			# Create a new prop if necessary, specifying the interaction flags.
+			prop = _create_prop(
+				prop_name,
+				group_cfg.get("prop_clickable", true),
+				group_cfg.get("prop_visible", true)
+			)
 		else:
 			# Force flags (a bit redundant but they may have been changed
 			# in the Importer interface, for already imported props)
-			prop.clickable = tag.prop_clickable
-			prop.visible = tag.prop_visible
+			prop.clickable = group_cfg.get("prop_clickable", true)
+			prop.visible = group_cfg.get("prop_visible", true)
+
+		var group_import: Dictionary = group.duplicate()
+		group_import.children = children
+		prop.set_meta("ANIM_NAME", group.name)
+		prop.set_meta("ANIM_GROUP", group_import)
+		importable_names[group.name] = true
+
+	for tag in analysis.get("singles", []):
+		# Ignore unwanted tags
+		if not tag.get("import", true): continue
+
+		# Always convert to PascalCase as a standard
+		# TODO: check Godot 4 standards, I can't find info
+		var prop_name: String = tag.tag_name.to_pascal_case()
+
+		# In case the prop is there, use the one we already have
+		var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
+		if prop == null:
+			# Create a new prop if necessary, specifying the interaction flags.
+			prop = _create_prop(
+				prop_name,
+				tag.get("prop_clickable", true),
+				tag.get("prop_visible", true)
+			)
+		else:
+			# Force flags (a bit redundant but they may have been changed
+			# in the Importer interface, for already imported props)
+			prop.clickable = tag.get("prop_clickable", true)
+			prop.visible = tag.get("prop_visible", true)
 
 		prop.set_meta("ANIM_NAME", tag.tag_name)
-		prop.set_meta("ANIM_AUTOPLAY", tag.autoplays)
-		
+		prop.set_meta("ANIM_AUTOPLAY", tag.get("autoplays", false))
+		prop.set_meta("ANIM_GROUP", {})
+		importable_names[tag.tag_name] = true
+
 	for prop in props_container.get_children():
 		if not prop.has_meta("ANIM_NAME"): continue
-		
+
+		# Skip props whose source tag is no longer importable in this run
+		# (the tag was removed from the file or its group became invalid)
+		if not importable_names.has(prop.get_meta("ANIM_NAME", "")):
+			prop.remove_meta("ANIM_NAME")
+			prop.remove_meta("ANIM_AUTOPLAY")
+			prop.remove_meta("ANIM_GROUP")
+			continue
+
 		# Make the output folder match the prop's folder
 		_options.output_folder = prop.scene_file_path.get_base_dir()
-		
-		# Import a single tag animation
-		result = await _animation_creator.create_tag_animations(
-			prop,
-			prop.get_meta("ANIM_NAME"),
-			_options
-		)
 
-		if prop.get_meta("ANIM_AUTOPLAY", false):
-			# If the item has autoplay enabled, set it up
-			_animation_creator.setup_autoplay(prop.get_meta("ANIM_NAME"))
+		var group_meta: Dictionary = prop.get_meta("ANIM_GROUP", {})
+		if not group_meta.is_empty() and not group_meta.get("children", []).is_empty():
+			# Import the group as a single prop with several animations
+			result = await _animation_creator.create_group_animations(prop, group_meta, _options)
+
+			# Only one child can autoplay per group (enforced by the UI)
+			_animation_creator.setup_autoplay(
+				_get_autoplay_child(group_meta.get("children", []))
+			)
 		else:
-			# Otherwise, ensure autoplay animation is unset
-			_animation_creator.setup_autoplay(PopochiuEditorHelper.EMPTY_STRING)
+			# Import a single tag animation
+			result = await _animation_creator.create_tag_animations(
+				prop,
+				prop.get_meta("ANIM_NAME"),
+				_options
+			)
+
+			if prop.get_meta("ANIM_AUTOPLAY", false):
+				# If the item has autoplay enabled, set it up
+				_animation_creator.setup_autoplay(prop.get_meta("ANIM_NAME"))
+			else:
+				# Otherwise, ensure autoplay animation is unset
+				_animation_creator.setup_autoplay(PopochiuEditorHelper.EMPTY_STRING)
 
 	for prop in props_container.get_children():
 		if not prop.has_meta("ANIM_NAME"): continue
@@ -90,17 +180,56 @@ func _on_import_pressed() -> void:
 	# TODO: maybe check if this is better done with signals
 	_importing = false
 
-	if typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS:
+	var has_errors := typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS
+	var group_errors := _get_group_errors(analysis)
+
+	if has_errors:
 		PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
+
+	for group_error in group_errors:
+		PopochiuUtils.print_error(group_error)
+
+	for group_warning in analysis.get("warnings", []):
+		PopochiuUtils.print_warning(group_warning)
+
+	if has_errors or not group_errors.is_empty():
 		_show_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
 		await get_tree().create_timer(0.1).timeout
-		
+
 		# Once the popup is closed, call _clean_props()
 		_show_message(
 			"%d animation tags processed." % [_tags_cache.size()],
 			"Done!"
 		)
+
+
+# Returns the animation name of the single child that should autoplay (the first
+# one with the autoplay toggle on), or an empty string when none is set.
+func _get_autoplay_child(children: Array) -> String:
+	for child in children:
+		if child.get("autoplays", false):
+			return child.get("anim_name", "")
+	return PopochiuEditorHelper.EMPTY_STRING
+
+
+# Builds the actionable error messages for misconfigured groups, so they can be
+# printed to the Output panel.
+func _get_group_errors(analysis: Dictionary) -> Array:
+	var errors := []
+	for group in analysis.get("groups", []):
+		if not group.get("is_valid", true):
+			var message: String = group.get("error", "")
+			if not message.is_empty():
+				errors.push_back("Aseprite importer: Group '%s': %s" % [group.get("name", ""), message])
+
+	if not errors.is_empty():
+		errors.push_back(
+			"Aseprite importer: no prop was created for the misconfigured group(s) above. "
+			+ "Fix the Aseprite file: remove the group tag (its tags will be imported as separate props) "
+			+ "or rename the contained tags so they start with the group name."
+		)
+	return errors
 
 
 func _customize_tag_ui(tag_row: AnimationTagRow) -> void:
@@ -142,8 +271,8 @@ func _save_prop(prop: PopochiuProp) -> int:
 	return ResultCodes.SUCCESS
 
 
-func _get_scene_path_for_tag(tag_name: String) -> String:
-	if not is_instance_valid(target_node) or not tag_name:
+func _get_scene_path_for_prop(prop_name: String) -> String:
+	if not is_instance_valid(target_node) or not prop_name:
 		return PopochiuEditorHelper.EMPTY_STRING
 
 	# In a room, props are in the "Props" node
@@ -152,8 +281,7 @@ func _get_scene_path_for_tag(tag_name: String) -> String:
 		PopochiuUtils.print_warning("No Props container found in room. Are you sure this is a valid room?")
 		return PopochiuEditorHelper.EMPTY_STRING
 
-	# Find the prop with the matching name (converted to PascalCase)
-	var prop_name := tag_name.to_pascal_case()
+	# Find the prop with the matching name
 	var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
 
 	if not is_instance_valid(prop):
@@ -167,11 +295,26 @@ func _get_scene_path_for_tag(tag_name: String) -> String:
 
 
 #region Protected ##################################################################################
+# Returns the group info for a tag that is a child of a group, or an empty
+# dictionary when the tag is a standalone animation.
+func _get_group_anim_info(tag_name: String) -> Dictionary:
+	var grouper := PopochiuAsepriteTagGrouper.new()
+	var analysis := grouper.analyze(_tags_cache)
+	for group in analysis.get("groups", []):
+		for child in group.get("children", []):
+			if child.tag_name == tag_name:
+				return { "group_name": group.name, "anim_name": child.anim_name }
+	return {}
+
+
 # Selects the animation in the room prop's AnimationPlayer.
 # This involves opening the prop scene and then selecting the AnimationPlayer.
 func _select_animation(tag_name: String) -> void:
-	var prop_name := tag_name.to_pascal_case()
-	var prop_scene_path := _get_scene_path_for_tag(tag_name)
+	var group_info := _get_group_anim_info(tag_name)
+	var prop_name: String = group_info.get("group_name", tag_name).to_pascal_case()
+	var anim_name: String = group_info.get("anim_name", tag_name)
+
+	var prop_scene_path := _get_scene_path_for_prop(prop_name)
 	if prop_scene_path.is_empty():
 		PopochiuUtils.print_warning("Prop '%s' does not have a scene file path. The prop may be corrupted, try to reimport it." % prop_name)
 		return
@@ -191,13 +334,16 @@ func _select_animation(tag_name: String) -> void:
 	# Find the AnimationPlayer in the prop scene
 	var animation_player: AnimationPlayer = prop_scene_root.get_node_or_null("AnimationPlayer")
 
-	_handle_animation_in_player(tag_name, animation_player, HANDLE_ANIM_SELECT)
+	_handle_animation_in_player(anim_name, animation_player, HANDLE_ANIM_SELECT)
 
 
 # Removes the animation for the given tag from the room prop's AnimationPlayer.
 func _delete_animation_for_tag(tag_name: String) -> void:
-	var prop_name := tag_name.to_pascal_case()
-	var prop_scene_path := _get_scene_path_for_tag(tag_name)
+	var group_info := _get_group_anim_info(tag_name)
+	var prop_name: String = group_info.get("group_name", tag_name).to_pascal_case()
+	var anim_name: String = group_info.get("anim_name", tag_name)
+
+	var prop_scene_path := _get_scene_path_for_prop(prop_name)
 	if prop_scene_path.is_empty():
 		PopochiuUtils.print_warning("Prop '%s' does not have a scene file path. The prop may be corrupted, try to reimport it." % prop_name)
 		return
@@ -216,7 +362,7 @@ func _delete_animation_for_tag(tag_name: String) -> void:
 	
 	# Find the AnimationPlayer in the prop scene
 	var animation_player: AnimationPlayer = prop_scene_root.get_node_or_null("AnimationPlayer")
-	_handle_animation_in_player(tag_name, animation_player, HANDLE_ANIM_DELETE)
+	_handle_animation_in_player(anim_name, animation_player, HANDLE_ANIM_DELETE)
 
 	PopochiuEditorHelper.pack_scene(prop_scene_root)
 

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -94,17 +94,7 @@ func _on_import_pressed() -> void:
 			# TODO: check Godot 4 standards, I can't find info
 			var prop_name: String = group.name.to_pascal_case()
 
-			# In case the prop is there, use the one we already have
-			var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
-			if prop == null:
-				prop = _create_prop(
-					prop_name,
-					group_cfg.get("prop_clickable", true),
-					group_cfg.get("prop_visible", true)
-				)
-			else:
-				prop.clickable = group_cfg.get("prop_clickable", true)
-				prop.visible = group_cfg.get("prop_visible", true)
+			var prop: PopochiuProp = _get_or_create_prop(props_container, prop_name, group_cfg)
 
 			var group_import: Dictionary = group.duplicate()
 			group_import.children = children
@@ -120,34 +110,27 @@ func _on_import_pressed() -> void:
 			# TODO: check Godot 4 standards, I can't find info
 			var prop_name: String = tag.tag_name.to_pascal_case()
 
-			# In case the prop is there, use the one we already have
-			var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
-			if prop == null:
-				prop = _create_prop(
-					prop_name,
-					tag.get("prop_clickable", true),
-					tag.get("prop_visible", true)
-				)
-			else:
-				prop.clickable = tag.get("prop_clickable", true)
-				prop.visible = tag.get("prop_visible", true)
+			var prop: PopochiuProp = _get_or_create_prop(props_container, prop_name, tag)
 
 			prop.set_meta("ANIM_NAME", tag.tag_name)
 			prop.set_meta("ANIM_AUTOPLAY", tag.get("autoplays", false))
 			prop.set_meta("ANIM_GROUP", {})
 			importable_names[tag.tag_name] = true
 
+	# Collect the props to (re)import in this run; drop the metadata from props
+	# whose source tag was removed from the file or whose group became invalid.
+	var props_to_import: Array[Node] = []
 	for prop in props_container.get_children():
-		if not prop.has_meta("ANIM_NAME"): continue
-
-		# Skip props whose source tag is no longer importable in this run
-		# (the tag was removed from the file or its group became invalid)
+		if not prop.has_meta("ANIM_NAME"):
+			continue
 		if not importable_names.has(prop.get_meta("ANIM_NAME", "")):
 			prop.remove_meta("ANIM_NAME")
 			prop.remove_meta("ANIM_AUTOPLAY")
 			prop.remove_meta("ANIM_GROUP")
 			continue
+		props_to_import.push_back(prop)
 
+	for prop in props_to_import:
 		# Make the output folder match the prop's folder
 		_options.output_folder = prop.scene_file_path.get_base_dir()
 
@@ -175,15 +158,12 @@ func _on_import_pressed() -> void:
 				# Otherwise, ensure autoplay animation is unset
 				_animation_creator.setup_autoplay(PopochiuEditorHelper.EMPTY_STRING)
 
-	for prop in props_container.get_children():
-		if not prop.has_meta("ANIM_NAME"): continue
-		# If autotrace is enabled, trace the interaction polygon from the sprite's alpha channel
-		# before packing the scene, so the polygon is included in the saved resource.
+		# If autotrace is enabled, trace the interaction polygon from the sprite's
+		# alpha channel before packing the scene, so the polygon is included in
+		# the saved resource.
 		if %AutotracePolygonsCheckButton.is_pressed():
 			PopochiuPolygonsHelper.trace_interaction_polygon_direct(prop)
 
-	for prop in props_container.get_children():
-		if not prop.has_meta("ANIM_NAME"): continue
 		# Save the prop
 		result = await _save_prop(prop)
 
@@ -233,6 +213,22 @@ func _customize_filter_ui() -> void:
 	%ClickableBulk.visible = true
 	%AutoplaysBulk.visible = true
 	%AutotracePolygons.visible = true
+
+
+# Returns the prop with the given name, creating it if needed and applying the
+# clickable/visible flags from the tag or group configuration.
+func _get_or_create_prop(props_container: Node, prop_name: String, cfg: Dictionary) -> PopochiuProp:
+	var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
+	if prop == null:
+		prop = _create_prop(
+			prop_name,
+			cfg.get("prop_clickable", true),
+			cfg.get("prop_visible", true)
+		)
+	else:
+		prop.clickable = cfg.get("prop_clickable", true)
+		prop.visible = cfg.get("prop_visible", true)
+	return prop
 
 
 func _create_prop(name: String, is_clickable: bool = true, is_visible: bool = true) -> PopochiuProp:

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -1,12 +1,13 @@
 @tool
 extends "res://addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock.gd"
 
-var _animation_creator := preload(\
-"res://addons/popochiu/editor/importers/aseprite/animation_creator_sprite2d.gd").new()
+var _animation_creator := preload(
+	"res://addons/popochiu/editor/importers/aseprite/animation_creator_sprite2d.gd"
+).new()
 
 
 
-#region Public ######################################################################################
+#region Public #####################################################################################
 func init() -> void:
 	# Instantiate animation creator
 	_animation_creator.init(_aseprite, file_system)
@@ -34,6 +35,7 @@ func _on_import_pressed() -> void:
 
 	var props_container := _root_node.get_node("Props")
 	var result: int = RESULT_CODE.SUCCESS
+	var has_errors := false
 
 	# Refresh the frame ranges from the source file right now (this is the slow
 	# operation, but it only happens on import, never on scan). Groups are built
@@ -158,6 +160,11 @@ func _on_import_pressed() -> void:
 				# Otherwise, ensure autoplay animation is unset
 				_animation_creator.setup_autoplay(PopochiuEditorHelper.EMPTY_STRING)
 
+		if result != RESULT_CODE.SUCCESS:
+			has_errors = true
+			PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
+			continue
+
 		# If autotrace is enabled, trace the interaction polygon from the sprite's
 		# alpha channel before packing the scene, so the polygon is included in
 		# the saved resource.
@@ -166,15 +173,14 @@ func _on_import_pressed() -> void:
 
 		# Save the prop
 		result = await _save_prop(prop)
+		if result != RESULT_CODE.SUCCESS:
+			has_errors = true
+			PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
 
 	# TODO: maybe check if this is better done with signals
 	_importing = false
 
-	var has_errors := typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS
 	var importer_errors: Array = analysis.get("errors", [])
-
-	if has_errors:
-		PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
 
 	for importer_error in importer_errors:
 		PopochiuUtils.print_error(importer_error)
@@ -238,7 +244,7 @@ func _create_prop(name: String, is_clickable: bool = true, is_visible: bool = tr
 	param.room = _root_node
 	param.is_interactive = is_clickable
 	param.is_visible = is_visible
-	
+
 	if factory.create(param) != ResultCodes.SUCCESS:
 		return
 
@@ -263,14 +269,18 @@ func _get_scene_path_for_prop(prop_name: String) -> String:
 	# In a room, props are in the "Props" node
 	var props_container := target_node.get_node_or_null("Props")
 	if not is_instance_valid(props_container):
-		PopochiuUtils.print_warning("No Props container found in room. Are you sure this is a valid room?")
+		PopochiuUtils.print_warning(
+			"No Props container found in room. Are you sure this is a valid room?"
+		)
 		return PopochiuEditorHelper.EMPTY_STRING
 
 	# Find the prop with the matching name
 	var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
 
 	if not is_instance_valid(prop):
-		PopochiuUtils.print_warning("No prop named '%s' found in room. Did you import this animation?" % prop_name)
+		PopochiuUtils.print_warning(
+			"No prop named '%s' found in room. Did you import this animation?" % prop_name
+		)
 		return PopochiuEditorHelper.EMPTY_STRING
 
 	return prop.scene_file_path
@@ -301,7 +311,10 @@ func _select_animation(tag_name: String) -> void:
 
 	var prop_scene_path := _get_scene_path_for_prop(prop_name)
 	if prop_scene_path.is_empty():
-		PopochiuUtils.print_warning("Prop '%s' does not have a scene file path. The prop may be corrupted, try to reimport it." % prop_name)
+		PopochiuUtils.print_warning(
+			"Prop '%s' does not have a scene file path. " % prop_name
+			+ "The prop may be corrupted, try to reimport it."
+		)
 		return
 
 	# Open the prop's scene
@@ -313,7 +326,10 @@ func _select_animation(tag_name: String) -> void:
 	# Get the current scene root (should be the prop now)
 	var prop_scene_root: Node = EditorInterface.get_edited_scene_root()
 	if not is_instance_valid(prop_scene_root):
-		PopochiuUtils.print_warning("Failed to get edited scene root for prop '%s'. The prop may be corrupted, try to reimport it." % prop_name)
+		PopochiuUtils.print_warning(
+			"Failed to get edited scene root for prop '%s'. " % prop_name
+			+ "The prop may be corrupted, try to reimport it."
+		)
 		return
 
 	# Find the AnimationPlayer in the prop scene
@@ -330,21 +346,24 @@ func _delete_animation_for_tag(tag_name: String) -> void:
 
 	var prop_scene_path := _get_scene_path_for_prop(prop_name)
 	if prop_scene_path.is_empty():
-		PopochiuUtils.print_warning("Prop '%s' does not have a scene file path. The prop may be corrupted, try to reimport it." % prop_name)
+		PopochiuUtils.print_warning(
+			"Prop '%s' does not have a scene file path. " % prop_name
+			+ "The prop may be corrupted, try to reimport it."
+		)
 		return
-	
+
 	# Load the scene without opening it in the editor
 	var packed_scene: PackedScene = load(prop_scene_path)
 	if not packed_scene:
 		PopochiuUtils.print_warning("Failed to load scene for prop '%s'" % prop_name)
 		return
-	
+
 	# Instance the scene to work with it in memory
 	var prop_scene_root: Node = packed_scene.instantiate()
 	if not is_instance_valid(prop_scene_root):
 		PopochiuUtils.print_warning("Failed to instantiate scene for prop '%s'" % prop_name)
 		return
-	
+
 	# Find the AnimationPlayer in the prop scene
 	var animation_player: AnimationPlayer = prop_scene_root.get_node_or_null("AnimationPlayer")
 	_handle_animation_in_player(anim_name, animation_player, HANDLE_ANIM_DELETE)

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -204,12 +204,9 @@ func _on_import_pressed() -> void:
 	# caused tags to be skipped are repeated as a confirmation.
 
 	if has_errors or not importer_errors.is_empty():
-		_show_message("Some errors occurred. Please check output panel.", "Warning!")
+		_finish_import_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
-		await get_tree().create_timer(0.1).timeout
-
-		# Once the popup is closed, call _clean_props()
-		_show_message(
+		_finish_import_message(
 			"%d animation tags processed." % [_tags_cache.size()],
 			"Done!"
 		)

--- a/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
+++ b/addons/popochiu/editor/importers/aseprite/docks/aseprite_importer_dock_room.gd
@@ -35,12 +35,20 @@ func _on_import_pressed() -> void:
 	var props_container := _root_node.get_node("Props")
 	var result: int = RESULT_CODE.SUCCESS
 
+	# Refresh the frame ranges from the source file right now (this is the slow
+	# operation, but it only happens on import, never on scan). Groups are built
+	# from fresh indices so the import never uses a stale framing.
+	var refreshed_tags: Array = _get_tags_from_source_with_ranges()
+	var analysis_input: Array = _options.get("tags")
+	if not refreshed_tags.is_empty():
+		analysis_input = _merge_with_cache(refreshed_tags)
+
 	var grouper := PopochiuAsepriteTagGrouper.new()
-	var analysis := grouper.analyze(_options.get("tags"))
+	var analysis := grouper.analyze(analysis_input)
 
 	# Build a lookup of the tag configurations (with user toggles) by name
 	var tags_by_name := {}
-	for tag in _options.get("tags"):
+	for tag in analysis_input:
 		tags_by_name[tag.tag_name] = tag
 
 	# Track the tags that are actually imported in this run, so that props whose
@@ -48,84 +56,86 @@ func _on_import_pressed() -> void:
 	# from stale metadata.
 	var importable_names := {}
 
-	# Create a prop for each group and each single tag that must be imported,
-	# and populate it with the right sprite.
-	for group in analysis.get("groups", []):
-		# Misconfigured groups are skipped entirely and reported at the end
-		if not group.get("is_valid", true):
-			continue
-
-		var group_cfg: Dictionary = tags_by_name.get(group.name, {})
-		if not group_cfg.get("import", true):
-			continue
-
-		# Only keep the children the user wants to import as animations
-		var children := []
-		for child in group.get("children", []):
-			var child_cfg: Dictionary = tags_by_name.get(child.tag_name, {})
-			if not child_cfg.get("import", true):
+	for item in analysis.get("items", []):
+		if item.get("kind") == "group":
+			var group: Dictionary = item
+			# Misconfigured groups are skipped entirely and reported at the end
+			if not group.get("is_valid", true):
 				continue
-			var child_import: Dictionary = child.duplicate()
-			child_import.loops = child_cfg.get("loops", false)
-			child_import.autoplays = child_cfg.get("autoplays", false)
-			children.push_back(child_import)
 
-		# No animation to import for this group: don't create the prop
-		if children.is_empty():
-			continue
+			var group_cfg: Dictionary = tags_by_name.get(group.tag_name, {})
+			if not group_cfg.get("import", true):
+				continue
 
-		# Always convert to PascalCase as a standard
-		# TODO: check Godot 4 standards, I can't find info
-		var prop_name: String = group.name.to_pascal_case()
+			# Without frame ranges we cannot export the group spritesheet
+			if group.get("from", -1) < 0 or group.get("to", -1) < group.get("from", -1):
+				PopochiuUtils.print_error(
+					"Aseprite importer: could not determine the frame ranges for group '%s'. "
+					% group.name + "Rescan the file and try again."
+				)
+				continue
 
-		# In case the prop is there, use the one we already have
-		var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
-		if prop == null:
-			# Create a new prop if necessary, specifying the interaction flags.
-			prop = _create_prop(
-				prop_name,
-				group_cfg.get("prop_clickable", true),
-				group_cfg.get("prop_visible", true)
-			)
+			# Only keep the children the user wants to import as animations
+			var children := []
+			for child in group.get("children", []):
+				var child_cfg: Dictionary = tags_by_name.get(child.tag_name, {})
+				if not child_cfg.get("import", true):
+					continue
+				var child_import: Dictionary = child.duplicate()
+				child_import.loops = child_cfg.get("loops", false)
+				child_import.autoplays = child_cfg.get("autoplays", false)
+				children.push_back(child_import)
+
+			# No animation to import for this group: don't create the prop
+			if children.is_empty():
+				continue
+
+			# Always convert to PascalCase as a standard
+			# TODO: check Godot 4 standards, I can't find info
+			var prop_name: String = group.name.to_pascal_case()
+
+			# In case the prop is there, use the one we already have
+			var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
+			if prop == null:
+				prop = _create_prop(
+					prop_name,
+					group_cfg.get("prop_clickable", true),
+					group_cfg.get("prop_visible", true)
+				)
+			else:
+				prop.clickable = group_cfg.get("prop_clickable", true)
+				prop.visible = group_cfg.get("prop_visible", true)
+
+			var group_import: Dictionary = group.duplicate()
+			group_import.children = children
+			prop.set_meta("ANIM_NAME", group.tag_name)
+			prop.set_meta("ANIM_GROUP", group_import)
+			importable_names[group.tag_name] = true
 		else:
-			# Force flags (a bit redundant but they may have been changed
-			# in the Importer interface, for already imported props)
-			prop.clickable = group_cfg.get("prop_clickable", true)
-			prop.visible = group_cfg.get("prop_visible", true)
+			var tag: Dictionary = item.get("tag", {})
+			# Ignore unwanted tags
+			if not tag.get("import", true): continue
 
-		var group_import: Dictionary = group.duplicate()
-		group_import.children = children
-		prop.set_meta("ANIM_NAME", group.name)
-		prop.set_meta("ANIM_GROUP", group_import)
-		importable_names[group.name] = true
+			# Always convert to PascalCase as a standard
+			# TODO: check Godot 4 standards, I can't find info
+			var prop_name: String = tag.tag_name.to_pascal_case()
 
-	for tag in analysis.get("singles", []):
-		# Ignore unwanted tags
-		if not tag.get("import", true): continue
+			# In case the prop is there, use the one we already have
+			var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
+			if prop == null:
+				prop = _create_prop(
+					prop_name,
+					tag.get("prop_clickable", true),
+					tag.get("prop_visible", true)
+				)
+			else:
+				prop.clickable = tag.get("prop_clickable", true)
+				prop.visible = tag.get("prop_visible", true)
 
-		# Always convert to PascalCase as a standard
-		# TODO: check Godot 4 standards, I can't find info
-		var prop_name: String = tag.tag_name.to_pascal_case()
-
-		# In case the prop is there, use the one we already have
-		var prop: PopochiuProp = props_container.get_node_or_null(prop_name)
-		if prop == null:
-			# Create a new prop if necessary, specifying the interaction flags.
-			prop = _create_prop(
-				prop_name,
-				tag.get("prop_clickable", true),
-				tag.get("prop_visible", true)
-			)
-		else:
-			# Force flags (a bit redundant but they may have been changed
-			# in the Importer interface, for already imported props)
-			prop.clickable = tag.get("prop_clickable", true)
-			prop.visible = tag.get("prop_visible", true)
-
-		prop.set_meta("ANIM_NAME", tag.tag_name)
-		prop.set_meta("ANIM_AUTOPLAY", tag.get("autoplays", false))
-		prop.set_meta("ANIM_GROUP", {})
-		importable_names[tag.tag_name] = true
+			prop.set_meta("ANIM_NAME", tag.tag_name)
+			prop.set_meta("ANIM_AUTOPLAY", tag.get("autoplays", false))
+			prop.set_meta("ANIM_GROUP", {})
+			importable_names[tag.tag_name] = true
 
 	for prop in props_container.get_children():
 		if not prop.has_meta("ANIM_NAME"): continue
@@ -181,18 +191,19 @@ func _on_import_pressed() -> void:
 	_importing = false
 
 	var has_errors := typeof(result) == TYPE_INT and result != RESULT_CODE.SUCCESS
-	var group_errors := _get_group_errors(analysis)
+	var importer_errors: Array = analysis.get("errors", [])
 
 	if has_errors:
 		PopochiuUtils.print_error(RESULT_CODE.get_error_message(result))
 
-	for group_error in group_errors:
-		PopochiuUtils.print_error(group_error)
+	for importer_error in importer_errors:
+		PopochiuUtils.print_error(importer_error)
 
-	for group_warning in analysis.get("warnings", []):
-		PopochiuUtils.print_warning(group_warning)
+	# Validation messages (including the frame-range based ones) are reported at
+	# scan time, where they are actionable. At import only the errors that
+	# caused tags to be skipped are repeated as a confirmation.
 
-	if has_errors or not group_errors.is_empty():
+	if has_errors or not importer_errors.is_empty():
 		_show_message("Some errors occurred. Please check output panel.", "Warning!")
 	else:
 		await get_tree().create_timer(0.1).timeout
@@ -211,25 +222,6 @@ func _get_autoplay_child(children: Array) -> String:
 		if child.get("autoplays", false):
 			return child.get("anim_name", "")
 	return PopochiuEditorHelper.EMPTY_STRING
-
-
-# Builds the actionable error messages for misconfigured groups, so they can be
-# printed to the Output panel.
-func _get_group_errors(analysis: Dictionary) -> Array:
-	var errors := []
-	for group in analysis.get("groups", []):
-		if not group.get("is_valid", true):
-			var message: String = group.get("error", "")
-			if not message.is_empty():
-				errors.push_back("Aseprite importer: Group '%s': %s" % [group.get("name", ""), message])
-
-	if not errors.is_empty():
-		errors.push_back(
-			"Aseprite importer: no prop was created for the misconfigured group(s) above. "
-			+ "Fix the Aseprite file: remove the group tag (its tags will be imported as separate props) "
-			+ "or rename the contained tags so they start with the group name."
-		)
-	return errors
 
 
 func _customize_tag_ui(tag_row: AnimationTagRow) -> void:

--- a/docs/src/the-editor-handbook/importers.md
+++ b/docs/src/the-editor-handbook/importers.md
@@ -95,6 +95,36 @@ For example, to create a walk animation that supports the four main directions, 
 
 If a file contains no tags, it will be imported as a single animation named `default`.
 
+### Group tags (Rooms)
+
+A Room source file can contain **multiple animations for the same prop**. Instead of creating one prop per tag, you can mark a set of tags as a **group** using a small, explicit naming convention. A group tag starts with `@` and its animations start with `:` followed by the group name.
+
+For example, a `Door` that can be opened and closed could be organized like this:
+
+| Tag | Role | Frame range |
+|-----|------|-------------|
+| `@Door` | Group tag | 15-20 |
+| `:DoorClosed` | Animation `closed` | 15-17 |
+| `:DoorOpen` | Animation `open` | 18-20 |
+
+The importer creates a **single prop named `Door`** with **two animations** in its AnimationPlayer: `closed` and `open`. The `@` and `:` markers and the group prefix are stripped from the animation names automatically (converted to `snake_case`).
+
+Rules to keep in mind:
+
+* **Group tags** start with `@` (e.g. `@Door`). The group tag's own frame range is the **group span**: the prop's spritesheet is exported from exactly that range, and every animation of the group must be fully inside it. The group span is the single source of truth for both validation and export.
+* **Group animations** start with `:` followed by the group name (e.g. `:DoorClosed`, `:door_open`). The character right after the group name must be a separator or an uppercase letter: `:DoorClosed` works, `:Doors` does not.
+* **Plain tags** (no marker) are imported as standalone single-animation props, exactly as before.
+* `@` and `:` are reserved: do not use them at the start of a tag for anything else.
+* In the importer interface, a group is shown as a bold header row with its child animations indented below it. The group row carries the prop-level options (Import, Visible, Clickable); each child row carries the animation-level options (Import, Loops, Autoplays). Autoplay is exclusive within a group: only one animation can autoplay at a time, and you can leave all of them off.
+
+If the file is misconfigured, the importer prints an **actionable error in the Output panel as soon as the file is scanned** and skips the offending tag (no prop is created for it):
+
+* An animation tag with no matching group (e.g. `:Foo` with no `@Foo`) is skipped and reported.
+* An animation that is not fully inside its group's span (e.g. `:DoorClosed` on frames 15-16 while `@Door` spans 11-14) is an error: the group tag must fully cover all its animations.
+* Two group tags with the same name (case-insensitive) are reported as ambiguous.
+* A group with no animations is reported as a warning (no prop is created).
+* A plain tag whose name matches a group name **and** falls inside the group's span (e.g. `DoorBroken` on a frame inside `@Door`) triggers a warning: you probably forgot the `:` prefix. Plain tags outside the group's span are legitimate separate props (e.g. a `DoorBell` placed after the group's range).
+
 ### Multiple source files
 
 If you are in need, you may want to separate your character animations over different source files. This is feasible, but keeping everything in a single file is the best option to speed up development by a great amount.  

--- a/project.godot
+++ b/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="popochiu 2.0"
 config/description="Make 2D point n' click games with a smooth workflow (like in Adventure Game Studio or PowerQuest)."
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 config/icon="res://icon.svg"
 config/windows_native_icon="res://popochiu.ico"
 


### PR DESCRIPTION
This adds an automatic, always-enabled logic, that detects tags with sub-tags in a Room-describing Aseprite file.

This allows to group different tags so they are imported as different named animations in a common prop.
